### PR TITLE
Update Windows scripts with Enterprise entry point

### DIFF
--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Get-Java.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Get-Java.ps1
@@ -151,6 +151,7 @@ function Get-Java
     if ($PsCmdlet.ParameterSetName -eq 'ServerInvoke')
     {
       $serverMainClass = ''
+      if ($Neo4jServer.ServerType -eq 'Enterprise') { $serverMainClass = 'org.neo4j.server.enterprise.EnterpriseEntryPoint' }
       if ($Neo4jServer.ServerType -eq 'Community') { $serverMainClass = 'org.neo4j.server.CommunityEntryPoint' }
       if ($Neo4jServer.DatabaseMode.ToUpper() -eq 'ARBITER') { $serverMainClass = 'org.neo4j.server.enterprise.ArbiterEntryPoint' }
 

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Get-Neo4jPrunsrv.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Get-Neo4jPrunsrv.ps1
@@ -168,6 +168,7 @@ function Get-Neo4jPrunsrv
           }
         }
 
+        if ($Neo4jServer.ServerType -eq 'Enterprise') { $serverMainClass = 'org.neo4j.server.enterprise.EnterpriseEntryPoint' }
         if ($Neo4jServer.ServerType -eq 'Community') { $serverMainClass = 'org.neo4j.server.CommunityEntryPoint' }
         if ($Neo4jServer.DatabaseMode.ToUpper() -eq 'ARBITER') { $serverMainClass = 'org.neo4j.server.enterprise.ArbiterEntryPoint' }
         if ($serverMainClass -eq '') { Write-Error "Unable to determine the Server Main Class from the server information"; return $null }


### PR DESCRIPTION
The main class for Neo4j is specified in these two Powershell scripts, yet it was missing for Enterprise. The branch for Enterprise is missing from the public Neo4j repo as well, yet it is present in the Neo4j Enterprise .zip file.

I suspect that these two lines are added by some build step in the private Neo4j repository. A diff between the ONgDB packaging scripts and the Neo4j Enterprise packaging scripts revealed that these two lines were the only difference aside from license changes.

The entry point classname was first renamed in this commit:
https://github.com/neo4j/neo4j/commit/235af36e375bd3a9c7dbf1a5d816bfc9b2f0366a

It was then removed altogether in this commit:
https://github.com/neo4j/neo4j/commit/d6a0ba62e2e8a7123ad18aabe5029a27cc4803c5

This problem prevents starting Neo4j from Windows using those Powershell scripts.