### PR TITLE
3.6 - Sort information changes for `db.indexes()` procedure

### DIFF
--- a/community/community-it/index-it/src/test/java/org/neo4j/kernel/api/impl/fulltext/FulltextSortTest.java
+++ b/community/community-it/index-it/src/test/java/org/neo4j/kernel/api/impl/fulltext/FulltextSortTest.java
@@ -28,6 +28,7 @@ import org.junit.rules.RuleChain;
 import org.junit.rules.Timeout;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -116,7 +117,10 @@ public class FulltextSortTest
             assertEquals( "INDEX ON NODE:Label1(prop1)", row.get( "description" ) );
             assertEquals( asList( "Label1" ), row.get( "tokenNames" ) );
             assertEquals( asList( "prop1" ), row.get( "properties" ) );
-            assertEquals( asList( "sortProp" ), row.get( "sortProperties" ) );
+            assertEquals( new HashMap<String,Object>()
+            {{
+                put( "sortProp", "LONG" );
+            }}, row.get( "sortProperties" ) );
             assertEquals( "sort-index", row.get( "indexName" ) );
             assertEquals( "node_fulltext", row.get( "type" ) );
             assertFalse( result.hasNext() );
@@ -142,7 +146,10 @@ public class FulltextSortTest
             assertEquals( "INDEX ON NODE:Label1(prop1)", row.get( "description" ) );
             assertEquals( "ONLINE", row.get( "state" ) );
             assertEquals( asList( "prop1" ), row.get( "properties" ) );
-            assertEquals( asList( "sortProp" ), row.get( "sortProperties" ) );
+            assertEquals( new HashMap<String,Object>()
+            {{
+                put( "sortProp", "LONG" );
+            }}, row.get( "sortProperties" ) );
             assertFalse( result.hasNext() );
             //noinspection ConstantConditions
             assertFalse( result.hasNext() );
@@ -167,7 +174,11 @@ public class FulltextSortTest
             assertEquals( "INDEX ON RELATIONSHIP:Reltype1(prop1)", row.get( "description" ) );
             assertEquals( asList( "Reltype1" ), row.get( "tokenNames" ) );
             assertEquals( asList( "prop1" ), row.get( "properties" ) );
-            assertEquals( asList( "prop1", "sortProp" ), row.get( "sortProperties" ) );
+            assertEquals( new HashMap<String,Object>()
+            {{
+                put( "prop1", "STRING" );
+                put( "sortProp", "LONG" );
+            }}, row.get( "sortProperties" ) );
             assertEquals( "sort-index", row.get( "indexName" ) );
             assertEquals( "relationship_fulltext", row.get( "type" ) );
             assertFalse( result.hasNext() );
@@ -191,7 +202,11 @@ public class FulltextSortTest
             assertEquals( "INDEX ON RELATIONSHIP:Reltype1(prop1)", row.get( "description" ) );
             assertEquals( "ONLINE", row.get( "state" ) );
             assertEquals( asList( "prop1" ), row.get( "properties" ) );
-            assertEquals( asList( "prop1", "sortProp" ), row.get( "sortProperties" ) );
+            assertEquals( new HashMap<String,Object>()
+            {{
+                put( "prop1", "STRING" );
+                put( "sortProp", "LONG" );
+            }}, row.get( "sortProperties" ) );
             assertFalse( result.hasNext() );
             //noinspection ConstantConditions
             assertFalse( result.hasNext() );

--- a/community/community-it/kernel-it/src/test/java/org/neo4j/kernel/impl/api/integrationtest/BuiltInProceduresIT.java
+++ b/community/community-it/kernel-it/src/test/java/org/neo4j/kernel/impl/api/integrationtest/BuiltInProceduresIT.java
@@ -196,7 +196,7 @@ public class BuiltInProceduresIT extends KernelIntegrationTest
                       "List the currently active config of Neo4j.", "DBMS" ),
                 proc( "db.constraints", "() :: (description :: STRING?)", "List all constraints in the database.", "READ" ),
                 proc( "db.indexes", "() :: (description :: STRING?, indexName :: STRING?, tokenNames :: LIST? OF STRING?, properties :: " +
-                                    "LIST? OF STRING?, sortProperties :: LIST? OF STRING?, state :: STRING?, type :: STRING?, progress :: FLOAT?, " +
+                                    "LIST? OF STRING?, sortProperties :: MAP?, state :: STRING?, type :: STRING?, progress :: FLOAT?, " +
                                     "provider :: MAP?, id :: INTEGER?, failureMessage :: STRING?)",
                       "List all indexes in the database.", "READ" ),
                 proc( "db.awaitIndex", "(index :: STRING?, timeOutSeconds = 300 :: INTEGER?) :: VOID",
@@ -425,13 +425,13 @@ public class BuiltInProceduresIT extends KernelIntegrationTest
                                                     "key", provider.getProviderDescriptor().getKey(), "version",
                                                     provider.getProviderDescriptor().getVersion() );
         assertThat( result, containsInAnyOrder(
-                new Object[]{"INDEX ON :Age(foo)", "index_1", singletonList( "Age" ), singletonList( "foo" ), Collections.emptyList(), "ONLINE",
+                new Object[]{"INDEX ON :Age(foo)", "index_1", singletonList( "Age" ), singletonList( "foo" ), Collections.emptyMap(), "ONLINE",
                              "node_unique_property", 100D, pdm, indexingService.getIndexId( ageFooDescriptor ), ""},
                 new Object[]{"INDEX ON :Person(foo)", "Unnamed index", singletonList( "Person" ),
-                             singletonList( "foo" ), Collections.emptyList(), "ONLINE", "node_label_property", 100D, pdm,
+                             singletonList( "foo" ), Collections.emptyMap(), "ONLINE", "node_label_property", 100D, pdm,
                              indexingService.getIndexId( personFooDescriptor ), ""},
                 new Object[]{"INDEX ON :Person(foo, bar)", "Unnamed index", singletonList( "Person" ),
-                             Arrays.asList( "foo", "bar" ), Collections.emptyList(), "ONLINE", "node_label_property", 100D, pdm,
+                             Arrays.asList( "foo", "bar" ), Collections.emptyMap(), "ONLINE", "node_label_property", 100D, pdm,
                              indexingService.getIndexId( personFooBarDescriptor ), ""}
         ) );
         commit();
@@ -505,16 +505,16 @@ public class BuiltInProceduresIT extends KernelIntegrationTest
                                                         "key", provider.getProviderDescriptor().getKey(), "version",
                                                         provider.getProviderDescriptor().getVersion() );
             assertThat( result, containsInAnyOrder(
-                    new Object[]{"INDEX ON :Age(foo)", "index_1", singletonList( "Age" ), singletonList( "foo" ), Collections.emptyList(), "ONLINE",
+                    new Object[]{"INDEX ON :Age(foo)", "index_1", singletonList( "Age" ), singletonList( "foo" ), Collections.emptyMap(), "ONLINE",
                                  "node_unique_property", 100D, pdm, indexing.getIndexId( ageFooDescriptor ), ""},
                     new Object[]{"INDEX ON :Person(foo)", "Unnamed index", singletonList( "Person" ),
-                                 singletonList( "foo" ), Collections.emptyList(), "ONLINE", "node_label_property", 100D, pdm,
+                                 singletonList( "foo" ), Collections.emptyMap(), "ONLINE", "node_label_property", 100D, pdm,
                                  indexing.getIndexId( personFooDescriptor ), ""},
                     new Object[]{"INDEX ON :Person(foo, bar)", "Unnamed index", singletonList( "Person" ),
-                                 Arrays.asList( "foo", "bar" ), Collections.emptyList(), "ONLINE", "node_label_property", 100D, pdm,
+                                 Arrays.asList( "foo", "bar" ), Collections.emptyMap(), "ONLINE", "node_label_property", 100D, pdm,
                                  indexing.getIndexId( personFooBarDescriptor ), ""},
                     new Object[]{"INDEX ON :Person(baz)", "Unnamed index", singletonList( "Person" ),
-                                 singletonList( "baz" ), Collections.emptyList(), "POPULATING", "node_unique_property", 100D, pdm,
+                                 singletonList( "baz" ), Collections.emptyMap(), "POPULATING", "node_unique_property", 100D, pdm,
                                  indexing.getIndexId( personBazDescriptor ), ""}
             ) );
             commit();

--- a/community/community-it/kernel-it/src/test/java/org/neo4j/kernel/impl/api/integrationtest/DbIndexesFailureMessageIT.java
+++ b/community/community-it/kernel-it/src/test/java/org/neo4j/kernel/impl/api/integrationtest/DbIndexesFailureMessageIT.java
@@ -91,7 +91,7 @@ public class DbIndexesFailureMessageIT extends KernelIntegrationTest
         assertEquals( "Unnamed index", result[1] );
         assertEquals( Collections.singletonList( "Fail" ), result[2] );
         assertEquals( Collections.singletonList( "foo" ), result[3] );
-        assertEquals( Collections.emptyList(), result[4] );
+        assertEquals( Collections.emptyMap(), result[4] );
         assertEquals( "FAILED", result[5] );
         assertEquals( "node_label_property", result[6] );
         assertEquals( 0.0, result[7] );

--- a/community/fulltext-index/src/main/java/org/neo4j/kernel/api/impl/fulltext/FulltextIndexProvider.java
+++ b/community/fulltext-index/src/main/java/org/neo4j/kernel/api/impl/fulltext/FulltextIndexProvider.java
@@ -68,6 +68,7 @@ import org.neo4j.kernel.impl.index.schema.ByteBufferFactory;
 import org.neo4j.kernel.impl.newapi.AllStoreHolder;
 import org.neo4j.kernel.impl.storemigration.StoreMigrationParticipant;
 import org.neo4j.kernel.impl.storemigration.participant.SchemaIndexMigrator;
+import org.neo4j.kernel.impl.util.FulltextSortType;
 import org.neo4j.logging.Log;
 import org.neo4j.scheduler.JobScheduler;
 import org.neo4j.storageengine.api.EntityType;
@@ -476,7 +477,7 @@ class FulltextIndexProvider extends IndexProvider implements FulltextAdapter, Au
         {
             if ( sortMap.containsKey( sortProperty ) )
             {
-                sortTypesArray[i] = FulltextSortType.valueOfIgnoreCase( sortMap.get( sortProperty ) ).neoStoreByte;
+                sortTypesArray[i] = FulltextSortType.valueOfIgnoreCase( sortMap.get( sortProperty ) ).getNeoStoreByte();
                 i++;
             }
             else

--- a/community/fulltext-index/src/main/java/org/neo4j/kernel/api/impl/fulltext/FulltextIndexSettings.java
+++ b/community/fulltext-index/src/main/java/org/neo4j/kernel/api/impl/fulltext/FulltextIndexSettings.java
@@ -47,6 +47,7 @@ import org.neo4j.io.fs.StoreChannel;
 import org.neo4j.kernel.impl.core.TokenHolder;
 import org.neo4j.kernel.impl.core.TokenNotFoundException;
 import org.neo4j.kernel.impl.core.UnknownSortTypeException;
+import org.neo4j.kernel.impl.util.FulltextSortType;
 import org.neo4j.storageengine.api.schema.StoreIndexDescriptor;
 
 public class FulltextIndexSettings

--- a/community/fulltext-index/src/main/java/org/neo4j/kernel/api/impl/fulltext/LuceneFulltextDocumentStructure.java
+++ b/community/fulltext-index/src/main/java/org/neo4j/kernel/api/impl/fulltext/LuceneFulltextDocumentStructure.java
@@ -44,6 +44,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
 
+import org.neo4j.kernel.impl.util.FulltextSortType;
 import org.neo4j.values.storable.TextValue;
 import org.neo4j.values.storable.Value;
 import org.neo4j.values.storable.ValueGroup;

--- a/community/fulltext-index/src/main/java/org/neo4j/kernel/api/impl/fulltext/SimpleFulltextIndexReader.java
+++ b/community/fulltext-index/src/main/java/org/neo4j/kernel/api/impl/fulltext/SimpleFulltextIndexReader.java
@@ -40,6 +40,7 @@ import org.neo4j.kernel.api.impl.index.collector.DocValuesCollector;
 import org.neo4j.kernel.api.impl.index.collector.ValuesIterator;
 import org.neo4j.kernel.api.impl.schema.reader.IndexReaderCloseException;
 import org.neo4j.kernel.impl.core.TokenHolder;
+import org.neo4j.kernel.impl.util.FulltextSortType;
 import org.neo4j.values.storable.Value;
 
 /**

--- a/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/BuiltInProcedures.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/BuiltInProcedures.java
@@ -63,6 +63,7 @@ import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.impl.api.TokenAccess;
 import org.neo4j.kernel.impl.api.index.IndexingService;
+import org.neo4j.kernel.impl.util.FulltextSortType;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Description;
@@ -1091,38 +1092,6 @@ public class BuiltInProcedures
         public String typeName()
         {
             return typeName;
-        }
-    }
-
-    /**
-     * Local version of class from {@link org.neo4j.kernel.api.impl.fulltext}
-     */
-    private enum FulltextSortType
-    {
-        LONG( 0 ),
-        DOUBLE( 1 ),
-        STRING( 2 );
-
-        int neoStoreByte;
-
-        FulltextSortType( final Integer neoStoreByte )
-        {
-            this.neoStoreByte = neoStoreByte;
-        }
-
-        public static String intToType( int i )
-        {
-            switch ( i )
-            {
-            case 0:
-                return LONG.name();
-            case 1:
-                return DOUBLE.name();
-            case 2:
-                return STRING.name();
-            default:
-                return null;
-            }
         }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/FulltextSortType.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/FulltextSortType.java
@@ -16,7 +16,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.kernel.api.impl.fulltext;
+package org.neo4j.kernel.impl.util;
 
 public enum FulltextSortType
 {
@@ -56,5 +56,10 @@ public enum FulltextSortType
         default:
             return null;
         }
+    }
+
+    public int getNeoStoreByte()
+    {
+        return neoStoreByte;
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/BuiltInProceduresTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/BuiltInProceduresTest.java
@@ -180,7 +180,7 @@ public class BuiltInProceduresTest
 
         // When/Then
         assertThat( call( "db.indexes" ), contains( record(
-                "INDEX ON :User(name)", "Unnamed index", singletonList( "User" ), singletonList( "name" ), Collections.emptyList(), "ONLINE",
+                "INDEX ON :User(name)", "Unnamed index", singletonList( "User" ), singletonList( "name" ), Collections.emptyMap(), "ONLINE",
                 "node_label_property", 100D,
                 getIndexProviderDescriptorMap( EMPTY.getProviderDescriptor() ), 42L, "" ) ) );
     }
@@ -193,7 +193,7 @@ public class BuiltInProceduresTest
 
         // When/Then
         assertThat( call( "db.indexes" ), contains( record(
-                "INDEX ON :User(name)", "Unnamed index", singletonList( "User" ), singletonList( "name" ), Collections.emptyList(), "ONLINE",
+                "INDEX ON :User(name)", "Unnamed index", singletonList( "User" ), singletonList( "name" ), Collections.emptyMap(), "ONLINE",
                 "node_unique_property", 100D,
                 getIndexProviderDescriptorMap( EMPTY.getProviderDescriptor() ), 42L, "" ) ) );
     }
@@ -207,7 +207,7 @@ public class BuiltInProceduresTest
 
         // When/Then
         assertThat( call( "db.indexes" ), contains( record(
-                "INDEX ON :User(name)", "Unnamed index", singletonList( "User" ), singletonList( "name" ), Collections.emptyList(), "NOT FOUND",
+                "INDEX ON :User(name)", "Unnamed index", singletonList( "User" ), singletonList( "name" ), Collections.emptyMap(), "NOT FOUND",
                 "node_label_property", 0D,
                 getIndexProviderDescriptorMap( EMPTY.getProviderDescriptor() ), 42L, "Index not found. It might have been concurrently dropped." ) ) );
     }
@@ -297,7 +297,7 @@ public class BuiltInProceduresTest
                 record( "db.constraints", "db.constraints() :: (description :: STRING?)",
                         "List all constraints in the database.", "READ" ),
                 record( "db.indexes", "db.indexes() :: (description :: STRING?, indexName :: STRING?, " +
-                                "tokenNames :: LIST? OF STRING?, properties :: LIST? OF STRING?, sortProperties :: LIST? OF STRING?, state :: STRING?, " +
+                                "tokenNames :: LIST? OF STRING?, properties :: LIST? OF STRING?, sortProperties :: MAP?, state :: STRING?, " +
                                 "type :: STRING?, progress :: FLOAT?, provider :: MAP?, id :: INTEGER?, failureMessage :: STRING?)",
                         "List all indexes in the database.", "READ" ),
                 record( "db.labels", "db.labels() :: (label :: STRING?)", "List all labels in the database.", "READ" ),

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/SortStoreFormatTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/SortStoreFormatTest.java
@@ -28,7 +28,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -114,7 +113,7 @@ public class SortStoreFormatTest
         indexesResult = database.execute( DB_INDEXES );
         Map<String,Object> testIndexMap = indexesResult.stream().filter( m -> m.get( "indexName" ).equals( "testIndex" ) ).findFirst().get();
         Assert.assertTrue( "The fulltext 'testIndex' is missing 'sortProperties' after migration", testIndexMap.containsKey( "sortProperties" ));
-        Assert.assertTrue( ((List<String>) testIndexMap.get( "sortProperties" )).isEmpty() );
+        Assert.assertTrue( ((Map<String,Object>) testIndexMap.get( "sortProperties" )).isEmpty() );
 
         // Try dropping a fulltext index
         database.execute( "CALL db.index.fulltext.drop(\"testIndex\")" );
@@ -127,7 +126,7 @@ public class SortStoreFormatTest
 
         indexesResult = database.execute( DB_INDEXES );
         Map<String,Object> sortIndex = indexesResult.stream().filter( m -> m.get( "indexName" ).equals( "sortIndex" ) ).findFirst().get();
-        Assert.assertTrue( ((List<String>) sortIndex.get( "sortProperties" )).contains( "name" ) );
+        Assert.assertTrue( ((Map<String,Object>) sortIndex.get( "sortProperties" )).keySet().contains( "name" ) );
 
         indexesResult.close();
         database.shutdown();


### PR DESCRIPTION
**Commits:**
- Updates db.indexes() procedure to return map of sort information.
- Test fixes for db.indexes() sortInformation change.

**Feature Added:**
Provides a map of the sort information including the sort property name, and sort property type. Example image below: 
<img width="1293" alt="Screen Shot 2020-05-07 at 2 08 44 PM" src="https://user-images.githubusercontent.com/32267391/81728968-417e0700-9459-11ea-986c-e7be8f653f5c.png">