### PR TITLE
3.6 - Fulltext - Pagination

### DIFF
--- a/community/community-it/index-it/src/test/java/org/neo4j/kernel/api/impl/fulltext/FulltextPaginationTest.java
+++ b/community/community-it/index-it/src/test/java/org/neo4j/kernel/api/impl/fulltext/FulltextPaginationTest.java
@@ -1,0 +1,363 @@
+package org.neo4j.kernel.api.impl.fulltext;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.RuleChain;
+import org.junit.rules.Timeout;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.graphdb.Result;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
+import org.neo4j.graphdb.factory.GraphDatabaseFactory;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.kernel.internal.GraphDatabaseAPI;
+import org.neo4j.test.rule.CleanupRule;
+import org.neo4j.test.rule.TestDirectory;
+import org.neo4j.test.rule.VerboseTimeout;
+import org.neo4j.test.rule.fs.DefaultFileSystemRule;
+
+import static java.lang.String.format;
+import static org.junit.Assert.assertEquals;
+
+public class FulltextPaginationTest
+{
+    static final String SEARCH_NODES = "CALL db.index.fulltext.searchNodes(\"%s\", \"%s\", %s)";
+    static final String SEARCH_RELATIONSHIPS = "CALL db.index.fulltext.searchRelationships(\"%s\", \"%s\", %s)";
+    static final String NODE_CREATE_SORT = "CALL db.index.fulltext.createNodeIndex(\"%s\", %s, %s, %s, %s )";
+    static final String RELATIONSHIP_CREATE_SORT = "CALL db.index.fulltext.createRelationshipIndex(\"%s\", %s, %s, %s, %s)";
+
+    private final Timeout timeout = VerboseTimeout.builder().withTimeout( 1, TimeUnit.HOURS ).build();
+    private final DefaultFileSystemRule fs = new DefaultFileSystemRule();
+    private final TestDirectory testDirectory = TestDirectory.testDirectory();
+    private final ExpectedException expectedException = ExpectedException.none();
+    private final CleanupRule cleanup = new CleanupRule();
+
+    @Rule
+    public final RuleChain rules = RuleChain.outerRule( timeout ).around( fs ).around( testDirectory ).around( expectedException ).around( cleanup );
+
+    private GraphDatabaseAPI db;
+    private GraphDatabaseBuilder builder;
+
+    @Before
+    public void before()
+    {
+        GraphDatabaseFactory factory = new GraphDatabaseFactory();
+        builder = factory.newEmbeddedDatabaseBuilder( testDirectory.databaseDir() );
+        builder.setConfig( GraphDatabaseSettings.store_internal_log_level, "DEBUG" );
+    }
+
+    @After
+    public void tearDown()
+    {
+        if ( db != null )
+        {
+            db.shutdown();
+        }
+    }
+
+    @Test
+    public void pagedSearchNodesIndexReturnsPagedResults()
+    {
+        final Label PERSON = Label.label( "Person" );
+
+        db = createDatabase();
+
+        // Create Fulltext index w/o sort
+        db.execute( format( NODE_CREATE_SORT, "fulltext-index", array( "Person" ), array( "name" ), "{}", "{}" ) ).close();
+
+        // Populate Graph
+        int entityCount = 100;
+        long bornValue = 1900;
+        try ( Transaction tx = db.beginTx() )
+        {
+            for ( int i = 0; i < entityCount; i++ )
+            {
+                Node node = db.createNode( PERSON );
+                node.setProperty( "name", "Bob" + bornValue );
+                bornValue++;
+            }
+            tx.success();
+        }
+
+        Result result;
+        try ( Transaction tx = db.beginTx() )
+        {
+            // Search with Paging
+            result = db.execute( format( SEARCH_NODES, "fulltext-index", "*", "{pageSize: 10, page:0}" ) );
+
+            // Loop through results
+            long numResults = 0;
+            while ( result.hasNext() )
+            {
+                result.next();
+                numResults++;
+            }
+            // Verify results were paged
+            assertEquals( 10, numResults );
+            result.close();
+            tx.success();
+        }
+    }
+
+    @Test
+    public void pagedSearchRelationshipsIndexReturnsPagedResults()
+    {
+        final Label MOVIE = Label.label( "Movie" );
+        final Label PERSON = Label.label( "Person" );
+        final RelationshipType REVIEWED = RelationshipType.withName( "REVIEWED" );
+
+        db = createDatabase();
+
+        // Create Fulltext index
+        db.execute( format( RELATIONSHIP_CREATE_SORT, "fulltext-index", array( "REVIEWED" ), array( "summary" ), "{}", "{}" ) ).close();
+
+        // Populate Graph
+        int entityCount = 100;
+        long ratingValue = 0;
+        try ( Transaction tx = db.beginTx() )
+        {
+            for ( int i = 0; i < entityCount; i++ )
+            {
+                Node person = db.createNode( PERSON );
+                Node movie = db.createNode( MOVIE );
+
+                Relationship relationshipTo = person.createRelationshipTo( movie, REVIEWED );
+                relationshipTo.setProperty( "summary", "I give this movie " + ratingValue + " out of 100." );
+
+                ratingValue++;
+            }
+            tx.success();
+        }
+
+        // Query and Assert
+        Result result;
+        try ( Transaction tx = db.beginTx() )
+        {
+            // Search with paging
+            result = db.execute( format( SEARCH_RELATIONSHIPS, "fulltext-index", "*", "{pageSize: 10, page:0}" ) );
+
+            // Loop through results
+            long numResults = 0;
+            while ( result.hasNext() )
+            {
+                result.next();
+                numResults++;
+            }
+            // Verify results were returned
+            assertEquals( 10, numResults );
+            result.close();
+            tx.success();
+        }
+    }
+
+    /**
+     * Asserts that paging and sorted queries returns sorted and paged results
+     */
+    @Test
+    public void pagedSearchNodesSortIndexReturnsSortedPagedResults()
+    {
+        final Label PERSON = Label.label( "Person" );
+        final String BORN = "born";
+
+        db = createDatabase();
+
+        // Create Fulltext Sort index
+        String sortMap = "{born: \"LONG\"}";
+        db.execute( format( NODE_CREATE_SORT, "sort-index", array( "Person" ), array( "name" ), "{}", sortMap ) ).close();
+
+        // Populate Graph
+        int entityCount = 100;
+        long bornValue = 1900;
+        try ( Transaction tx = db.beginTx() )
+        {
+            for ( int i = 0; i < entityCount; i++ )
+            {
+                Node node = db.createNode( PERSON );
+                node.setProperty( "name", "Bob" + bornValue );
+                node.setProperty( BORN, bornValue );
+                bornValue++;
+            }
+            tx.success();
+        }
+
+        // Query and Assert
+        Result result;
+        Map<String,Object> row;
+        // Try without sorting
+        try ( Transaction tx = db.beginTx() )
+        {
+            // Search with Paging
+            result = db.execute( format( SEARCH_NODES, "sort-index", "*", "{pageSize: 10, page:0}" ) );
+
+            // Loop through results
+            long numResults = 0;
+            while ( result.hasNext() )
+            {
+                result.next();
+                numResults++;
+            }
+            // Verify results were paged
+            assertEquals( 10, numResults );
+            result.close();
+            tx.success();
+        }
+
+        // Try with sort
+        try ( Transaction tx = db.beginTx() )
+        {
+            // Search with sort and paging
+            result = db.execute( format( SEARCH_NODES, "sort-index", "*", "{pageSize: 10, page:1, sortProperty: 'born', sortDirection: 'ASC'}" ) );
+
+            // Loop through results, verify they are in order.
+            long lastBorn = 1910;
+            while ( result.hasNext() )
+            {
+                row = result.next();
+                assertEquals( lastBorn, ((Node) row.get( "node" )).getProperty( "born" ) );
+                lastBorn++;
+            }
+            // Verify results were paged
+            assertEquals( 1920, lastBorn );
+            result.close();
+            tx.success();
+        }
+
+        // Try with reversed order
+        try ( Transaction tx = db.beginTx() )
+        {
+            // Query with Sort
+            result = db.execute( format( SEARCH_NODES, "sort-index", "*", "{pageSize: 10, page:1, sortProperty: 'born', sortDirection: 'DESC'}" ) );
+
+            // Loop through results, verify they are in order.
+            long lastBorn = 1989;
+            while ( result.hasNext() )
+            {
+                row = result.next();
+                assertEquals( lastBorn, ((Node) row.get( "node" )).getProperty( "born" ) );
+                lastBorn--;
+            }
+            // Verify results were returned
+            assertEquals( 1979, lastBorn );
+            result.close();
+            tx.success();
+        }
+        db.shutdown();
+    }
+
+    @Test
+    public void pagedSearchRelationshipSortIndexReturnsSortedPagedResults()
+    {
+        final Label MOVIE = Label.label( "Movie" );
+        final Label PERSON = Label.label( "Person" );
+        final RelationshipType REVIEWED = RelationshipType.withName( "REVIEWED" );
+        final String RATING = "rating";
+
+        db = createDatabase();
+
+        // Create Fulltext Sort index
+        String sortMap = "{rating: \"LONG\"}";
+        db.execute( format( RELATIONSHIP_CREATE_SORT, "sort-index", array( "REVIEWED" ), array( "summary" ), "{}", sortMap ) ).close();
+
+        // Populate Graph
+        int entityCount = 100;
+        long ratingValue = 0;
+        try ( Transaction tx = db.beginTx() )
+        {
+            for ( int i = 0; i < entityCount; i++ )
+            {
+                Node person = db.createNode( PERSON );
+                Node movie = db.createNode( MOVIE );
+
+                Relationship relationshipTo = person.createRelationshipTo( movie, REVIEWED );
+                relationshipTo.setProperty( "summary", "I give this movie " + ratingValue + " out of 100." );
+                relationshipTo.setProperty( RATING, ratingValue );
+
+                ratingValue++;
+            }
+            tx.success();
+        }
+
+        // Query and Assert
+        Result result;
+        Map<String,Object> row;
+        try ( Transaction tx = db.beginTx() )
+        {
+            // Search with paging
+            result = db.execute( format( SEARCH_RELATIONSHIPS, "sort-index", "*", "{pageSize: 10, page:0}" ) );
+
+            // Loop through results, verify they are in order.
+            long numResults = 0;
+            while ( result.hasNext() )
+            {
+                row = result.next();
+                numResults++;
+            }
+            // Verify results were returned
+            assertEquals( 10, numResults );
+            result.close();
+            tx.success();
+        }
+
+        try ( Transaction tx = db.beginTx() )
+        {
+            // Search with sort and paging
+            result = db.execute( format( SEARCH_RELATIONSHIPS, "sort-index", "*", "{pageSize: 10, page:1, sortProperty: 'rating', sortDirection: 'ASC'}" ) );
+
+            // Loop through results, verify they are in order.
+            long lastRating = 10;
+            while ( result.hasNext() )
+            {
+                row = result.next();
+                assertEquals( lastRating, ((Relationship) row.get( "relationship" )).getProperty( "rating" ) );
+                lastRating++;
+            }
+            // Verify results were returned
+            assertEquals( lastRating, 20 );
+            result.close();
+            tx.success();
+        }
+
+        // Try with reversed order
+        try ( Transaction tx = db.beginTx() )
+        {
+            // Query with Sort
+            result = db.execute( format( SEARCH_RELATIONSHIPS, "sort-index", "*", "{pageSize: 10, page:1, sortProperty: 'rating', sortDirection: 'DESC'}" ) );
+
+            // Loop through results, verify they are in order.
+            long lastRating = 89;
+            while ( result.hasNext() )
+            {
+                row = result.next();
+                assertEquals( lastRating, ((Relationship) row.get( "relationship" )).getProperty( "rating" ) );
+                lastRating--;
+            }
+            // Verify results were returned
+            assertEquals( 79, lastRating );
+            result.close();
+            tx.success();
+        }
+        db.shutdown();
+    }
+
+    private GraphDatabaseAPI createDatabase()
+    {
+        return (GraphDatabaseAPI) cleanup.add( builder.newGraphDatabase() );
+    }
+
+    static String array( String... args )
+    {
+        return Arrays.stream( args ).map( s -> "\"" + s + "\"" ).collect( Collectors.joining( ", ", "[", "]" ) );
+    }
+}

--- a/community/community-it/kernel-it/src/test/java/org/neo4j/kernel/impl/api/integrationtest/BuiltInProceduresIT.java
+++ b/community/community-it/kernel-it/src/test/java/org/neo4j/kernel/impl/api/integrationtest/BuiltInProceduresIT.java
@@ -310,12 +310,21 @@ public class BuiltInProceduresIT extends KernelIntegrationTest
                 proc( "db.index.fulltext.queryNodes",
                       "(indexName :: STRING?, queryString :: STRING?, sortProperty =  :: STRING?, sortDirection = ASC :: STRING?) :: " +
                       "(node :: NODE?, score :: FLOAT?)",
-                      "Query the given fulltext index. Returns the matching nodes and their lucene query score, ordered by score.", "READ" ),
+                      "Query the given fulltext index. Returns the matching nodes and their lucene query score, ordered by " +
+                      "score. Deprecated use 'db.index.fulltext.searchNodes'.", "READ" ),
                 proc( "db.index.fulltext.queryRelationships",
                       "(indexName :: STRING?, queryString :: STRING?, sortProperty =  :: STRING?, sortDirection = ASC :: STRING?) :: " +
                       "(relationship :: RELATIONSHIP?, score :: FLOAT?)",
                       "Query the given fulltext index. Returns the matching relationships and their lucene query score, ordered by " +
-                      "score.", "READ" ),
+                      "score. Deprecated use 'db.index.fulltext.searchRelationships'.", "READ" ),
+                proc( "db.index.fulltext.searchNodes",
+                      "(indexName :: STRING?, queryString :: STRING?, config = {} :: MAP?) :: " +
+                      "(node :: NODE?, score :: FLOAT?)",
+                      "Query the given fulltext index. Returns the matching nodes and their lucene query score, ordered by score.", "READ" ),
+                proc( "db.index.fulltext.searchRelationships",
+                      "(indexName :: STRING?, queryString :: STRING?, config = {} :: MAP?) :: " +
+                      "(relationship :: RELATIONSHIP?, score :: FLOAT?)",
+                      "Query the given fulltext index. Returns the matching relationships and their lucene query score, ordered by score.", "READ" ),
                 proc( "db.index.fulltext.countNodes", "(indexName :: STRING?, queryString :: STRING?) :: (count :: INTEGER?)",
                       "Query the given fulltext index. Returns the count of matching nodes.", "READ" ),
                 proc( "db.index.fulltext.countRelationships", "(indexName :: STRING?, queryString :: STRING?) :: (count :: INTEGER?)",

--- a/community/fulltext-index/src/main/java/org/neo4j/kernel/api/impl/fulltext/FulltextAdapter.java
+++ b/community/fulltext-index/src/main/java/org/neo4j/kernel/api/impl/fulltext/FulltextAdapter.java
@@ -44,8 +44,8 @@ public interface FulltextAdapter
 
     ScoreEntityIterator query( KernelTransaction tx, String indexName, String queryString ) throws IOException, IndexNotFoundKernelException, ParseException;
 
-    ScoreEntityIterator queryWithSort( KernelTransaction ktx, String indexName, String queryString, String sortProperty, String sortDirection )
-            throws IndexNotFoundKernelException, ParseException;
+    ScoreEntityIterator query( KernelTransaction tx, String indexName, String queryString, FulltextQueryConfig queryConfig )
+            throws IOException, IndexNotFoundKernelException, ParseException;
 
     CountResult queryForCount( KernelTransaction ktx, String indexName, String queryString )
             throws IndexNotFoundKernelException, ParseException;

--- a/community/fulltext-index/src/main/java/org/neo4j/kernel/api/impl/fulltext/FulltextIndexProvider.java
+++ b/community/fulltext-index/src/main/java/org/neo4j/kernel/api/impl/fulltext/FulltextIndexProvider.java
@@ -406,7 +406,7 @@ class FulltextIndexProvider extends IndexProvider implements FulltextAdapter, Au
     }
 
     @Override
-    public ScoreEntityIterator queryWithSort( KernelTransaction ktx, String indexName, String queryString, String sortProperty, String sortDirection )
+    public ScoreEntityIterator query( KernelTransaction ktx, String indexName, String queryString, FulltextQueryConfig queryConfig )
             throws IndexNotFoundKernelException, ParseException
     {
         KernelTransactionImplementation kti = (KernelTransactionImplementation) ktx;
@@ -423,7 +423,7 @@ class FulltextIndexProvider extends IndexProvider implements FulltextAdapter, Au
             IndexReader indexReader = allStoreHolder.indexReader( indexReference, false );
             fulltextIndexReader = (FulltextIndexReader) indexReader;
         }
-        return fulltextIndexReader.queryWithSort( queryString, sortProperty, sortDirection );
+        return fulltextIndexReader.query( queryString, queryConfig );
     }
 
     @Override

--- a/community/fulltext-index/src/main/java/org/neo4j/kernel/api/impl/fulltext/FulltextIndexReader.java
+++ b/community/fulltext-index/src/main/java/org/neo4j/kernel/api/impl/fulltext/FulltextIndexReader.java
@@ -43,7 +43,7 @@ public abstract class FulltextIndexReader implements IndexReader
      */
     public abstract ScoreEntityIterator query( String query ) throws ParseException;
 
-    public abstract ScoreEntityIterator queryWithSort( String query, String sortProp, String sortDirection ) throws ParseException;
+    public abstract ScoreEntityIterator query( String query, FulltextQueryConfig fulltextQueryConfig ) throws ParseException;
 
     public abstract CountResult queryForCount( String query ) throws ParseException;
 

--- a/community/fulltext-index/src/main/java/org/neo4j/kernel/api/impl/fulltext/FulltextQueryConfig.java
+++ b/community/fulltext-index/src/main/java/org/neo4j/kernel/api/impl/fulltext/FulltextQueryConfig.java
@@ -1,0 +1,89 @@
+package org.neo4j.kernel.api.impl.fulltext;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class FulltextQueryConfig
+{
+    private final String sortProperty;
+    private final String sortDirection;
+
+    private final Integer pageSize;
+    private final Integer page;
+
+    private FulltextQueryConfig( String sortProperty, String sortDirection, Integer pageSize, Integer page )
+    {
+        this.sortProperty = sortProperty;
+        this.sortDirection = sortDirection;
+        this.pageSize = pageSize;
+        this.page = page;
+    }
+
+    public static FulltextQueryConfig defaultConfig()
+    {
+        return new FulltextQueryConfig( "", "ASC", Integer.MAX_VALUE, 0 );
+    }
+
+    public static FulltextQueryConfig parseConfig( Map<String,Object> config )
+    {
+        try
+        {
+            String sortProperty = (String) config.getOrDefault( "sortProperty", "" );
+            String sortDirection = (String) config.getOrDefault( "sortDirection", "ASC" );
+
+            Integer maxIntValue = Integer.MAX_VALUE;
+            Long pageSizeLong = (Long) config.getOrDefault( "pageSize", maxIntValue.longValue() );
+            Long pageLong = (Long) config.getOrDefault( "page", 0L );
+
+            Integer pageSize = pageSizeLong.intValue();
+            Integer page = pageLong.intValue();
+
+            return new FulltextQueryConfig( sortProperty, sortDirection, pageSize, page );
+        }
+        catch ( Exception e )
+        {
+            throw new RuntimeException( "Unable to parse procedure configuration.", e );
+        }
+    }
+
+    public static FulltextQueryConfig sortConfig( String sortProperty, String sortDirection )
+    {
+        Map<String,Object> configMap = new HashMap<String,Object>()
+        {{
+            put( "sortProperty", sortProperty );
+            put( "sortDirection", sortDirection );
+        }};
+
+        return parseConfig( configMap );
+    }
+
+    public boolean isSortQuery()
+    {
+        return sortProperty != null && !sortProperty.isEmpty();
+    }
+
+    public boolean isPaged()
+    {
+        return this.pageSize != null && pageSize != Integer.MAX_VALUE;
+    }
+
+    public String getSortProperty()
+    {
+        return sortProperty;
+    }
+
+    public String getSortDirection()
+    {
+        return sortDirection;
+    }
+
+    public Integer getPageSize()
+    {
+        return pageSize;
+    }
+
+    public Integer getPage()
+    {
+        return page;
+    }
+}

--- a/community/fulltext-index/src/main/java/org/neo4j/kernel/api/impl/fulltext/PartitionedFulltextIndexReader.java
+++ b/community/fulltext-index/src/main/java/org/neo4j/kernel/api/impl/fulltext/PartitionedFulltextIndexReader.java
@@ -70,9 +70,9 @@ class PartitionedFulltextIndexReader extends FulltextIndexReader
     }
 
     @Override
-    public ScoreEntityIterator queryWithSort( String query, String sortField, String sortDirection ) throws ParseException
+    public ScoreEntityIterator query( String query, FulltextQueryConfig queryConfig ) throws ParseException
     {
-        return partitionedQuery( query, sortField, sortDirection );
+        return partitionedQuery( query, queryConfig );
     }
 
     @Override
@@ -98,12 +98,12 @@ class PartitionedFulltextIndexReader extends FulltextIndexReader
         return ScoreEntityIterator.mergeIterators( results );
     }
 
-    private ScoreEntityIterator partitionedQuery( String query, String sortFieldString, String sortDirection ) throws ParseException
+    private ScoreEntityIterator partitionedQuery( String query, FulltextQueryConfig queryConfig ) throws ParseException
     {
         List<ScoreEntityIterator> results = new ArrayList<>();
         for ( FulltextIndexReader indexReader : indexReaders )
         {
-            results.add( indexReader.queryWithSort( query, sortFieldString, sortDirection ) );
+            results.add( indexReader.query( query, queryConfig ) );
         }
         return ScoreEntityIterator.mergeIterators( results );
     }

--- a/community/fulltext-index/src/main/java/org/neo4j/kernel/api/impl/fulltext/TransactionStateFulltextIndexReader.java
+++ b/community/fulltext-index/src/main/java/org/neo4j/kernel/api/impl/fulltext/TransactionStateFulltextIndexReader.java
@@ -55,11 +55,11 @@ class TransactionStateFulltextIndexReader extends FulltextIndexReader
     }
 
     @Override
-    public ScoreEntityIterator queryWithSort( String query, String sortField, String sortDirection ) throws ParseException
+    public ScoreEntityIterator query( String query, FulltextQueryConfig queryConfig ) throws ParseException
     {
-        ScoreEntityIterator iterator = baseReader.queryWithSort( query, sortField, sortDirection );
+        ScoreEntityIterator iterator = baseReader.query( query, queryConfig );
         iterator = iterator.filter( entry -> !modifiedEntityIdsInThisTransaction.contains( entry.entityId() ) );
-        iterator = mergeIterators( asList( iterator, nearRealTimeReader.queryWithSort( query, sortField, sortDirection ) ) );
+        iterator = mergeIterators( asList( iterator, nearRealTimeReader.query( query, queryConfig ) ) );
         return iterator;
     }
 

--- a/enterprise/neo4j-enterprise/src/test/java/org/neo4j/kernel/builtinprocs/ProcedureResourcesIT.java
+++ b/enterprise/neo4j-enterprise/src/test/java/org/neo4j/kernel/builtinprocs/ProcedureResourcesIT.java
@@ -400,6 +400,14 @@ public class ProcedureResourcesIT
             proc.withParam( ftsRelsIndex );
             proc.withParam( "'value'" );
             break;
+        case "db.index.fulltext.searchNodes":
+            proc.withParam( ftsNodesIndex );
+            proc.withParam( "'value'" );
+            break;
+        case "db.index.fulltext.searchRelationships":
+            proc.withParam( ftsRelsIndex );
+            proc.withParam( "'value'" );
+            break;
         case "db.index.fulltext.countNodes":
             proc.withParam( ftsNodesIndex );
             proc.withParam( "'value'" );


### PR DESCRIPTION
Adds in paging feature to Fulltext queries. 

Depreciates 'queryNodes/queryRelationships' in favor of 'searchNodes'/'searchRelationships'. 

Adds 'FulltextPaginationTest'. 

Internally removes 'queryWithSort' and instead overloads 'query' method.