### PR TITLE
3.6 - Fulltext - MultiSort

### DIFF
--- a/community/community-it/index-it/src/test/java/org/neo4j/kernel/api/impl/fulltext/FulltextPaginationTest.java
+++ b/community/community-it/index-it/src/test/java/org/neo4j/kernel/api/impl/fulltext/FulltextPaginationTest.java
@@ -218,7 +218,7 @@ public class FulltextPaginationTest
         try ( Transaction tx = db.beginTx() )
         {
             // Search with sort and paging
-            result = db.execute( format( SEARCH_NODES, "sort-index", "*", "{pageSize: 10, page:1, sortProperty: 'born', sortDirection: 'ASC'}" ) );
+            result = db.execute( format( SEARCH_NODES, "sort-index", "*", "{pageSize: 10, page:1, sortBy: [{property: 'born'}]}" ) );
 
             // Loop through results, verify they are in order.
             long lastBorn = 1910;
@@ -238,7 +238,7 @@ public class FulltextPaginationTest
         try ( Transaction tx = db.beginTx() )
         {
             // Query with Sort
-            result = db.execute( format( SEARCH_NODES, "sort-index", "*", "{pageSize: 10, page:1, sortProperty: 'born', sortDirection: 'DESC'}" ) );
+            result = db.execute( format( SEARCH_NODES, "sort-index", "*", "{pageSize: 10, page:1, sortBy: [{property: 'born', direction: 'DESC'}]}" ) );
 
             // Loop through results, verify they are in order.
             long lastBorn = 1989;
@@ -313,7 +313,7 @@ public class FulltextPaginationTest
         try ( Transaction tx = db.beginTx() )
         {
             // Search with sort and paging
-            result = db.execute( format( SEARCH_RELATIONSHIPS, "sort-index", "*", "{pageSize: 10, page:1, sortProperty: 'rating', sortDirection: 'ASC'}" ) );
+            result = db.execute( format( SEARCH_RELATIONSHIPS, "sort-index", "*", "{pageSize: 10, page:1, sortBy: [{property: 'rating'}]}" ) );
 
             // Loop through results, verify they are in order.
             long lastRating = 10;
@@ -333,7 +333,8 @@ public class FulltextPaginationTest
         try ( Transaction tx = db.beginTx() )
         {
             // Query with Sort
-            result = db.execute( format( SEARCH_RELATIONSHIPS, "sort-index", "*", "{pageSize: 10, page:1, sortProperty: 'rating', sortDirection: 'DESC'}" ) );
+            result = db.execute(
+                    format( SEARCH_RELATIONSHIPS, "sort-index", "*", "{pageSize: 10, page:1, sortBy: [{property: 'rating', direction: 'DESC'}]}" ) );
 
             // Loop through results, verify they are in order.
             long lastRating = 89;

--- a/community/community-it/index-it/src/test/java/org/neo4j/kernel/api/impl/fulltext/FulltextSortTest.java
+++ b/community/community-it/index-it/src/test/java/org/neo4j/kernel/api/impl/fulltext/FulltextSortTest.java
@@ -378,21 +378,20 @@ public class FulltextSortTest
         // Assertions to ensure sorting is working as expected
         try ( Transaction tx = db.beginTx() )
         {
-            // probably wanna make it more clear where "sorts" comes from.
-            String sortConfig = "{sorts: " +
+            String sortConfig = "{sortBy: " +
                                 "[" +
-                                "{sortProperty: \"born\"}," +
-                                "{sortProperty: \"name\", sortDirection: \"DESC\"}" +
+                                "{property: \"born\"}," +
+                                "{property: \"name\", direction: \"DESC\"}" +
                                 "]}";
             Integer[] expectedOrder = new Integer[]{2, 1, 4, 3};
             // Search with Sorts : BORN (1) then NAME-DESC (2)
             result = db.execute( format( SEARCH_NODES_SORT, "sort-index", "*", sortConfig ) );
             sortOrderAssertionHelper( result, expectedOrder );
 
-            sortConfig = "{sorts: " +
+            sortConfig = "{sortBy: " +
                          "[" +
-                         "{sortProperty: \"born\"}," +
-                         "{sortProperty: \"name\"}" +
+                         "{property: \"born\"}," +
+                         "{property: \"name\"}" +
                          "]}";
             expectedOrder = new Integer[]{1, 2, 4, 3};
             // Search with Sorts : BORN (1) then NAME (2)

--- a/community/community-it/index-it/src/test/java/org/neo4j/kernel/api/impl/fulltext/FulltextSortTest.java
+++ b/community/community-it/index-it/src/test/java/org/neo4j/kernel/api/impl/fulltext/FulltextSortTest.java
@@ -65,6 +65,9 @@ public class FulltextSortTest
     static final String NODE_CREATE_SORT = "CALL db.index.fulltext.createNodeIndex(\"%s\", %s, %s, %s, %s )";
     static final String RELATIONSHIP_CREATE_SORT = "CALL db.index.fulltext.createRelationshipIndex(\"%s\", %s, %s, %s, %s)";
 
+    static final String SEARCH_NODES_SORT = "CALL db.index.fulltext.searchNodes(\"%s\", \"%s\", %s)";
+    static final String SEARCH_RELS_SORT = "CALL db.index.fulltext.searchRelationships(\"%s\", \"%s\", \"%s\", \"%s\")";
+
     static final String NAME = "name";
     static final String BORN = "born";
     static final String COLOR = "color";
@@ -364,6 +367,45 @@ public class FulltextSortTest
     }
 
     @Test
+    public void searchNodesMultiSort()
+    {
+        db = createDatabase();
+
+        // Create the Fulltext index and sortable nodes
+        populateGraphWithMultiSortableEntities( db );
+
+        Result result;
+        // Assertions to ensure sorting is working as expected
+        try ( Transaction tx = db.beginTx() )
+        {
+            // probably wanna make it more clear where "sorts" comes from.
+            String sortConfig = "{sorts: " +
+                                "[" +
+                                "{sortProperty: \"born\"}," +
+                                "{sortProperty: \"name\", sortDirection: \"DESC\"}" +
+                                "]}";
+            Integer[] expectedOrder = new Integer[]{2, 1, 4, 3};
+            // Search with Sorts : BORN (1) then NAME-DESC (2)
+            result = db.execute( format( SEARCH_NODES_SORT, "sort-index", "*", sortConfig ) );
+            sortOrderAssertionHelper( result, expectedOrder );
+
+            sortConfig = "{sorts: " +
+                         "[" +
+                         "{sortProperty: \"born\"}," +
+                         "{sortProperty: \"name\"}" +
+                         "]}";
+            expectedOrder = new Integer[]{1, 2, 4, 3};
+            // Search with Sorts : BORN (1) then NAME (2)
+            result = db.execute( format( SEARCH_NODES_SORT, "sort-index", "*", sortConfig ) );
+            sortOrderAssertionHelper( result, expectedOrder );
+
+            result.close();
+            tx.success();
+        }
+        db.shutdown();
+    }
+
+    @Test
     public void badSortTypeResultsInError()
     {
         db = createDatabase();
@@ -479,6 +521,39 @@ public class FulltextSortTest
             p4.setProperty( UID, 4 );
             tx.success();
 
+        }
+    }
+
+    private static void populateGraphWithMultiSortableEntities( GraphDatabaseAPI db )
+    {
+        final Label PERSON = Label.label( "Person" );
+
+        String sortMap = "{" + BORN + ": \"LONG\"," + NAME + ": \"STRING\"}";
+        db.execute( format( NODE_CREATE_SORT, "sort-index", array( "Person" ), array( NAME ), "{}", sortMap ) ).close();
+
+        try ( Transaction tx = db.beginTx() )
+        {
+
+            Node p1 = db.createNode( PERSON );
+            p1.setProperty( NAME, "Alex" );
+            p1.setProperty( BORN, 1990L );
+            p1.setProperty( UID, 1 );
+
+            Node p2 = db.createNode( PERSON );
+            p2.setProperty( NAME, "Bob" );
+            p2.setProperty( BORN, 1990L );
+            p2.setProperty( UID, 2 );
+
+            Node p3 = db.createNode( PERSON );
+            p3.setProperty( NAME, "Chris" );
+            p3.setProperty( BORN, 1992L );
+            p3.setProperty( UID, 3 );
+
+            Node p4 = db.createNode( PERSON );
+            p4.setProperty( NAME, "Dave" );
+            p4.setProperty( BORN, 1991L );
+            p4.setProperty( UID, 4 );
+            tx.success();
         }
     }
 

--- a/community/fulltext-index/src/main/java/org/neo4j/kernel/api/impl/fulltext/FulltextProcedures.java
+++ b/community/fulltext-index/src/main/java/org/neo4j/kernel/api/impl/fulltext/FulltextProcedures.java
@@ -197,18 +197,7 @@ public class FulltextProcedures
             throws ParseException, IndexNotFoundKernelException, IOException
     {
 
-        return searchFulltextForNodes( name, query, new HashMap<String,Object>()
-        {{
-            put( "sorts", Collections.singletonList( new HashMap()
-            {
-                {
-                    {
-                        put( "sortProperty", sortProperty );
-                        put( "sortDirection", sortDirection );
-                    }
-                }
-            } ) );
-        }} );
+        return searchFulltextForNodes( name, query, FulltextQueryConfig.singleSortMap( sortProperty, sortDirection ) );
     }
 
     @Deprecated
@@ -221,18 +210,7 @@ public class FulltextProcedures
             throws ParseException, IndexNotFoundKernelException, IOException
     {
 
-        return searchFulltextForRelationships( name, query, new HashMap<String,Object>()
-        {{
-            put( "sorts", Collections.singletonList( new HashMap()
-            {
-                {
-                    {
-                        put( "sortProperty", sortProperty );
-                        put( "sortDirection", sortDirection );
-                    }
-                }
-            } ) );
-        }} );
+        return searchFulltextForRelationships( name, query, FulltextQueryConfig.singleSortMap( sortProperty, sortDirection ) );
     }
 
     @Description( "Query the given fulltext index. Returns the matching nodes and their lucene query score, ordered by score." )

--- a/community/fulltext-index/src/main/java/org/neo4j/kernel/api/impl/fulltext/FulltextProcedures.java
+++ b/community/fulltext-index/src/main/java/org/neo4j/kernel/api/impl/fulltext/FulltextProcedures.java
@@ -27,6 +27,7 @@ import org.apache.lucene.queryparser.classic.ParseException;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -195,10 +196,18 @@ public class FulltextProcedures
                                                      @Name( value = "sortDirection", defaultValue = "ASC" ) String sortDirection )
             throws ParseException, IndexNotFoundKernelException, IOException
     {
+
         return searchFulltextForNodes( name, query, new HashMap<String,Object>()
         {{
-            put( "sortProperty", sortProperty );
-            put( "sortDirection", sortDirection );
+            put( "sorts", Collections.singletonList( new HashMap()
+            {
+                {
+                    {
+                        put( "sortProperty", sortProperty );
+                        put( "sortDirection", sortDirection );
+                    }
+                }
+            } ) );
         }} );
     }
 
@@ -211,10 +220,18 @@ public class FulltextProcedures
                                                                      @Name( value = "sortDirection", defaultValue = "ASC" ) String sortDirection )
             throws ParseException, IndexNotFoundKernelException, IOException
     {
+
         return searchFulltextForRelationships( name, query, new HashMap<String,Object>()
         {{
-            put( "sortProperty", sortProperty );
-            put( "sortDirection", sortDirection );
+            put( "sorts", Collections.singletonList( new HashMap()
+            {
+                {
+                    {
+                        put( "sortProperty", sortProperty );
+                        put( "sortDirection", sortDirection );
+                    }
+                }
+            } ) );
         }} );
     }
 

--- a/community/fulltext-index/src/main/java/org/neo4j/kernel/api/impl/fulltext/FulltextQueryConfig.java
+++ b/community/fulltext-index/src/main/java/org/neo4j/kernel/api/impl/fulltext/FulltextQueryConfig.java
@@ -29,7 +29,7 @@ public class FulltextQueryConfig
     {
         try
         {
-            List<HashMap<String,Object>> sortsList = (List<HashMap<String,Object>>) config.getOrDefault( "sortBy", "[]" );
+            List<HashMap<String,Object>> sortsList = (List<HashMap<String,Object>>) config.getOrDefault( "sortBy", new ArrayList<>() );
             List<SortParameter> sorts = new ArrayList<>();
 
             // Determine SortParameter

--- a/community/fulltext-index/src/main/java/org/neo4j/kernel/api/impl/fulltext/FulltextQueryConfig.java
+++ b/community/fulltext-index/src/main/java/org/neo4j/kernel/api/impl/fulltext/FulltextQueryConfig.java
@@ -66,18 +66,25 @@ public class FulltextQueryConfig
 
     public static Map<String,Object> singleSortMap( String sortProperty, String sortDirection )
     {
-        return new HashMap<String,Object>()
-        {{
-            put( "sortBy", Collections.singletonList( new HashMap()
-            {
+        if ( sortProperty == null || sortProperty.isEmpty() )
+        {
+            return new HashMap<>();
+        }
+        else
+        {
+            return new HashMap<String,Object>()
+            {{
+                put( "sortBy", Collections.singletonList( new HashMap()
                 {
                     {
-                        put( "property", sortProperty );
-                        put( "direction", sortDirection );
+                        {
+                            put( "property", sortProperty );
+                            put( "direction", sortDirection );
+                        }
                     }
-                }
-            } ) );
-        }};
+                } ) );
+            }};
+        }
     }
 
     public boolean isSortQuery()

--- a/community/fulltext-index/src/main/java/org/neo4j/kernel/api/impl/fulltext/SimpleFulltextIndexReader.java
+++ b/community/fulltext-index/src/main/java/org/neo4j/kernel/api/impl/fulltext/SimpleFulltextIndexReader.java
@@ -145,7 +145,7 @@ class SimpleFulltextIndexReader extends FulltextIndexReader
 
     private ScoreEntityIterator indexQueryWithSort( Query query, FulltextQueryConfig queryConfig )
     {
-        List<FulltextQueryConfig.SortParameter> sortParameters = queryConfig.getSorts();
+        List<FulltextQueryConfig.SortParameter> sortParameters = queryConfig.getSortBy();
         try
         {
 
@@ -179,8 +179,8 @@ class SimpleFulltextIndexReader extends FulltextIndexReader
         List<SortField> sortFields = new ArrayList<>();
         for ( FulltextQueryConfig.SortParameter sortParameter : sortParameters )
         {
-            String sortFieldString = sortParameter.getSortProperty();
-            boolean reverseSortOrder = reverseSortDirection( sortParameter.getSortDirection() );
+            String sortFieldString = sortParameter.getProperty();
+            boolean reverseSortOrder = isSortDirectionReversed( sortParameter.getDirection() );
 
             if ( !Arrays.asList( sortProperties ).contains( sortFieldString ) )
             {
@@ -283,7 +283,7 @@ class SimpleFulltextIndexReader extends FulltextIndexReader
     }
 
     // Returns boolean that is used by SortField. If true then it reverses sort direction
-    private boolean reverseSortDirection( String sortDirection ) throws IOException
+    private boolean isSortDirectionReversed( String sortDirection ) throws IOException
     {
         FulltextSortDirection fulltextSortDirection = FulltextSortDirection.valueOfIgnoreCase( sortDirection );
 

--- a/community/fulltext-index/src/main/java/org/neo4j/kernel/api/impl/fulltext/SimpleFulltextIndexReader.java
+++ b/community/fulltext-index/src/main/java/org/neo4j/kernel/api/impl/fulltext/SimpleFulltextIndexReader.java
@@ -33,7 +33,9 @@ import org.apache.lucene.search.SortedNumericSortField;
 import org.apache.lucene.search.TotalHitCountCollector;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 
 import org.neo4j.kernel.api.impl.index.collector.DocValuesCollector;
@@ -143,21 +145,11 @@ class SimpleFulltextIndexReader extends FulltextIndexReader
 
     private ScoreEntityIterator indexQueryWithSort( Query query, FulltextQueryConfig queryConfig )
     {
-        String sortFieldString = queryConfig.getSortProperty();
-        String sortDirection = queryConfig.getSortDirection();
+        List<FulltextQueryConfig.SortParameter> sortParameters = queryConfig.getSorts();
         try
         {
-            boolean reverseSortOrder = determineSortDirection( sortDirection );
 
-            Sort sort;
-            if ( Arrays.asList( sortProperties ).contains( sortFieldString ) )
-            {
-                sort = buildSort( sortFieldString, reverseSortOrder );
-            }
-            else
-            {
-                throw new IOException( "Sort Field '" + sortFieldString + "' is not an indexed property." );
-            }
+            Sort sort = buildSort( sortParameters );
 
             DocValuesCollector docValuesCollector = new DocValuesCollector( true );
             getIndexSearcher().search( query, docValuesCollector );
@@ -180,6 +172,67 @@ class SimpleFulltextIndexReader extends FulltextIndexReader
         {
             throw new RuntimeException( e );
         }
+    }
+
+    private Sort buildSort( List<FulltextQueryConfig.SortParameter> sortParameters ) throws IOException
+    {
+        List<SortField> sortFields = new ArrayList<>();
+        for ( FulltextQueryConfig.SortParameter sortParameter : sortParameters )
+        {
+            String sortFieldString = sortParameter.getSortProperty();
+            boolean reverseSortOrder = reverseSortDirection( sortParameter.getSortDirection() );
+
+            if ( !Arrays.asList( sortProperties ).contains( sortFieldString ) )
+            {
+                throw new IOException( "Sort Field '" + sortFieldString + "' is not an indexed property." );
+            }
+
+            if ( sortTypes != null && sortTypes.containsKey( sortFieldString ) )
+            {
+                SortField sortField;
+                String sortType = sortTypes.get( sortFieldString );
+
+                FulltextSortType sortTypeEnum = FulltextSortType.valueOfIgnoreCase( sortType );
+
+                if ( sortTypeEnum == null )
+                {
+                    throw new RuntimeException( "Unable to determine sortField type '" + sortType + "'." );
+                }
+
+                switch ( sortTypeEnum )
+                {
+                case LONG:
+                    sortField = new SortedNumericSortField( sortFieldString, SortField.Type.LONG, reverseSortOrder );
+                    if ( !reverseSortOrder )
+                    {
+                        sortField.setMissingValue( Long.MAX_VALUE );
+                    }
+                    break;
+                case DOUBLE:
+                    sortField = new SortedNumericSortField( sortFieldString, SortField.Type.DOUBLE, reverseSortOrder );
+                    if ( !reverseSortOrder )
+                    {
+                        sortField.setMissingValue( Double.MAX_VALUE );
+                    }
+                    break;
+                case STRING:
+                    sortField = new SortField( sortFieldString, SortField.Type.STRING, reverseSortOrder );
+                    if ( !reverseSortOrder )
+                    {
+                        sortField.setMissingValue( SortField.STRING_LAST );
+                    }
+                    break;
+                default:
+                    throw new IOException( "Unable to determine sortField type '" + sortType + "'." );
+                }
+                sortFields.add( sortField );
+            }
+            else
+            {
+                throw new IOException( "Either sortTypes map is null or sortField '" + sortFieldString + "' is not in sortTypes." );
+            }
+        }
+        return new Sort( sortFields.toArray( new SortField[]{} ) );
     }
 
     private Sort buildSort( String sortFieldString, boolean reverseSortOrder ) throws IOException
@@ -230,7 +283,7 @@ class SimpleFulltextIndexReader extends FulltextIndexReader
     }
 
     // Returns boolean that is used by SortField. If true then it reverses sort direction
-    private boolean determineSortDirection( String sortDirection ) throws IOException
+    private boolean reverseSortDirection( String sortDirection ) throws IOException
     {
         FulltextSortDirection fulltextSortDirection = FulltextSortDirection.valueOfIgnoreCase( sortDirection );
 


### PR DESCRIPTION
- Adds multisort support for fulltext indexes. Functions through continuous tie-breakers. 
- Updates 'searchNodes/searchRelationships' procedures.
- Adds multisort test.


On top of the pagination PR.

Fulltext indexes with sort are created in their usual way. The `searchNodes/searchRelationships` procedures have been updated to use a `sortBy` list of sorts to apply to the query: 

```
CALL db.index.fulltext.searchNodes("personIndex", "*", 
{sortBy: 
	[
		{property: "born", direction: "ASC"},
		{property: "name", direction: "DESC"}
	]
}) YIELD node, score RETURN *
```