### PR TITLE
3.6 - Fulltext Paging skip-limit changes

### DIFF
--- a/community/community-it/index-it/src/test/java/org/neo4j/kernel/api/impl/fulltext/FulltextPaginationTest.java
+++ b/community/community-it/index-it/src/test/java/org/neo4j/kernel/api/impl/fulltext/FulltextPaginationTest.java
@@ -95,7 +95,7 @@ public class FulltextPaginationTest
         try ( Transaction tx = db.beginTx() )
         {
             // Search with Paging
-            result = db.execute( format( SEARCH_NODES, "fulltext-index", "*", "{pageSize: 10, page:0}" ) );
+            result = db.execute( format( SEARCH_NODES, "fulltext-index", "*", "{limit:10}" ) );
 
             // Loop through results
             long numResults = 0;
@@ -146,7 +146,7 @@ public class FulltextPaginationTest
         try ( Transaction tx = db.beginTx() )
         {
             // Search with paging
-            result = db.execute( format( SEARCH_RELATIONSHIPS, "fulltext-index", "*", "{pageSize: 10, page:0}" ) );
+            result = db.execute( format( SEARCH_RELATIONSHIPS, "fulltext-index", "*", "{limit: 10}" ) );
 
             // Loop through results
             long numResults = 0;
@@ -199,7 +199,7 @@ public class FulltextPaginationTest
         try ( Transaction tx = db.beginTx() )
         {
             // Search with Paging
-            result = db.execute( format( SEARCH_NODES, "sort-index", "*", "{pageSize: 10, page:0}" ) );
+            result = db.execute( format( SEARCH_NODES, "sort-index", "*", "{limit: 10}" ) );
 
             // Loop through results
             long numResults = 0;
@@ -218,7 +218,7 @@ public class FulltextPaginationTest
         try ( Transaction tx = db.beginTx() )
         {
             // Search with sort and paging
-            result = db.execute( format( SEARCH_NODES, "sort-index", "*", "{pageSize: 10, page:1, sortBy: [{property: 'born'}]}" ) );
+            result = db.execute( format( SEARCH_NODES, "sort-index", "*", "{skip: 10, limit: 10, sortBy: [{property: 'born'}]}" ) );
 
             // Loop through results, verify they are in order.
             long lastBorn = 1910;
@@ -238,7 +238,7 @@ public class FulltextPaginationTest
         try ( Transaction tx = db.beginTx() )
         {
             // Query with Sort
-            result = db.execute( format( SEARCH_NODES, "sort-index", "*", "{pageSize: 10, page:1, sortBy: [{property: 'born', direction: 'DESC'}]}" ) );
+            result = db.execute( format( SEARCH_NODES, "sort-index", "*", "{skip: 10, limit: 10, sortBy: [{property: 'born', direction: 'DESC'}]}" ) );
 
             // Loop through results, verify they are in order.
             long lastBorn = 1989;
@@ -295,7 +295,7 @@ public class FulltextPaginationTest
         try ( Transaction tx = db.beginTx() )
         {
             // Search with paging
-            result = db.execute( format( SEARCH_RELATIONSHIPS, "sort-index", "*", "{pageSize: 10, page:0}" ) );
+            result = db.execute( format( SEARCH_RELATIONSHIPS, "sort-index", "*", "{limit: 10}" ) );
 
             // Loop through results, verify they are in order.
             long numResults = 0;
@@ -313,7 +313,7 @@ public class FulltextPaginationTest
         try ( Transaction tx = db.beginTx() )
         {
             // Search with sort and paging
-            result = db.execute( format( SEARCH_RELATIONSHIPS, "sort-index", "*", "{pageSize: 10, page:1, sortBy: [{property: 'rating'}]}" ) );
+            result = db.execute( format( SEARCH_RELATIONSHIPS, "sort-index", "*", "{skip: 10, limit: 10, sortBy: [{property: 'rating'}]}" ) );
 
             // Loop through results, verify they are in order.
             long lastRating = 10;
@@ -334,7 +334,7 @@ public class FulltextPaginationTest
         {
             // Query with Sort
             result = db.execute(
-                    format( SEARCH_RELATIONSHIPS, "sort-index", "*", "{pageSize: 10, page:1, sortBy: [{property: 'rating', direction: 'DESC'}]}" ) );
+                    format( SEARCH_RELATIONSHIPS, "sort-index", "*", "{skip: 10, limit:10, sortBy: [{property: 'rating', direction: 'DESC'}]}" ) );
 
             // Loop through results, verify they are in order.
             long lastRating = 89;

--- a/community/fulltext-index/src/main/java/org/neo4j/kernel/api/impl/fulltext/FulltextQueryConfig.java
+++ b/community/fulltext-index/src/main/java/org/neo4j/kernel/api/impl/fulltext/FulltextQueryConfig.java
@@ -10,19 +10,19 @@ public class FulltextQueryConfig
 {
     private final List<SortParameter> sortBy;
 
-    private final Integer pageSize;
-    private final Integer page;
+    private final Integer skip;
+    private final Integer limit;
 
-    public FulltextQueryConfig( List<SortParameter> sortBy, Integer pageSize, Integer page )
+    public FulltextQueryConfig( List<SortParameter> sortBy, Integer skip, Integer limit )
     {
         this.sortBy = sortBy;
-        this.pageSize = pageSize;
-        this.page = page;
+        this.skip = skip;
+        this.limit = limit;
     }
 
     public static FulltextQueryConfig defaultConfig()
     {
-        return new FulltextQueryConfig( new ArrayList<>(), Integer.MAX_VALUE, 0 );
+        return new FulltextQueryConfig( new ArrayList<>(), 0, Integer.MAX_VALUE );
     }
 
     public static FulltextQueryConfig parseConfig( Map<String,Object> config )
@@ -39,13 +39,13 @@ public class FulltextQueryConfig
             }
 
             Integer maxIntValue = Integer.MAX_VALUE;
-            Long pageSizeLong = (Long) config.getOrDefault( "pageSize", maxIntValue.longValue() );
-            Long pageLong = (Long) config.getOrDefault( "page", 0L );
+            Long skipLong = (Long) config.getOrDefault( "skip", 0L );
+            Long limitLong = (Long) config.getOrDefault( "limit", maxIntValue.longValue() );
 
-            Integer pageSize = pageSizeLong.intValue();
-            Integer page = pageLong.intValue();
+            Integer skip = skipLong.intValue();
+            Integer limit = limitLong.intValue();
 
-            return new FulltextQueryConfig( sorts, pageSize, page );
+            return new FulltextQueryConfig( sorts, skip, limit );
         }
         catch ( Exception e )
         {
@@ -94,7 +94,7 @@ public class FulltextQueryConfig
 
     public boolean isPaged()
     {
-        return this.pageSize != null && pageSize != Integer.MAX_VALUE;
+        return (this.skip != 0) || (this.limit != Integer.MAX_VALUE);
     }
 
     public List<SortParameter> getSortBy()
@@ -102,14 +102,14 @@ public class FulltextQueryConfig
         return sortBy;
     }
 
-    public Integer getPageSize()
+    public Integer getSkip()
     {
-        return pageSize;
+        return skip;
     }
 
-    public Integer getPage()
+    public Integer getLimit()
     {
-        return page;
+        return limit;
     }
 
     public static class SortParameter

--- a/community/fulltext-index/src/main/java/org/neo4j/kernel/api/impl/fulltext/SimpleFulltextIndexReader.java
+++ b/community/fulltext-index/src/main/java/org/neo4j/kernel/api/impl/fulltext/SimpleFulltextIndexReader.java
@@ -126,8 +126,8 @@ class SimpleFulltextIndexReader extends FulltextIndexReader
             {
                 ValuesIterator sortedValuesIterator =
                         docValuesCollector
-                                .getPagedSortedValuesIterator( LuceneFulltextDocumentStructure.FIELD_ENTITY_ID, Sort.RELEVANCE, queryConfig.getPageSize(),
-                                                               queryConfig.getPage() );
+                                .getPagedSortedValuesIterator( LuceneFulltextDocumentStructure.FIELD_ENTITY_ID, Sort.RELEVANCE, queryConfig.getSkip(),
+                                                               queryConfig.getLimit() );
                 return new ScoreEntityIterator( sortedValuesIterator );
             }
             else
@@ -157,8 +157,8 @@ class SimpleFulltextIndexReader extends FulltextIndexReader
             if ( queryConfig.isPaged() )
             {
                 ValuesIterator sortedValuesIterator =
-                        docValuesCollector.getPagedSortedValuesIterator( LuceneFulltextDocumentStructure.FIELD_ENTITY_ID, sort, queryConfig.getPageSize(),
-                                                                         queryConfig.getPage() );
+                        docValuesCollector.getPagedSortedValuesIterator( LuceneFulltextDocumentStructure.FIELD_ENTITY_ID, sort, queryConfig.getSkip(),
+                                                                         queryConfig.getLimit() );
                 return new ScoreEntityIterator( sortedValuesIterator );
             }
             else

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/collector/DocValuesCollector.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/collector/DocValuesCollector.java
@@ -135,7 +135,7 @@ public class DocValuesCollector extends SimpleCollector
         return new TopDocsValuesIterator( topDocs, contexts, field );
     }
 
-    public ValuesIterator getPagedSortedValuesIterator( String field, Sort sort, int pageSize, int page ) throws IOException
+    public ValuesIterator getPagedSortedValuesIterator( String field, Sort sort, int skip, int limit ) throws IOException
     {
         if ( sort == null || sort == Sort.INDEXORDER )
         {
@@ -147,7 +147,7 @@ public class DocValuesCollector extends SimpleCollector
         {
             return ValuesIterator.EMPTY;
         }
-        TopDocs topDocsPaged = getTopDocsPaged( sort, size, pageSize, page );
+        TopDocs topDocsPaged = getTopDocsPaged( sort, size, skip, limit );
         LeafReaderContext[] contexts = getLeafReaderContexts( getMatchingDocs() );
         return new TopDocsValuesIterator( topDocsPaged, contexts, field );
     }
@@ -304,20 +304,20 @@ public class DocValuesCollector extends SimpleCollector
         return topDocs;
     }
 
-    private TopDocs getTopDocsPaged( Sort sort, int totalHits, int pageSize, int page ) throws IOException
+    private TopDocs getTopDocsPaged( Sort sort, int totalHits, int skip, int limit ) throws IOException
     {
         TopDocs topDocs;
         if ( sort == Sort.RELEVANCE )
         {
             TopScoreDocCollector collector = TopScoreDocCollector.create( totalHits );
             replayTo( collector );
-            topDocs = collector.topDocs( page * pageSize, pageSize );
+            topDocs = collector.topDocs( skip, limit );
         }
         else
         {
             TopFieldCollector collector = TopFieldCollector.create( sort, totalHits, false, true, false );
             replayTo( collector );
-            topDocs = collector.topDocs( page * pageSize, pageSize );
+            topDocs = collector.topDocs( skip, limit );
         }
         return topDocs;
     }


### PR DESCRIPTION
For the `searchNodes`/`searchRelationships`  procedures this PR changes `page/pageSize` config parameters into `skip/limit` for cypher compatibility. 
