### PR TITLE
Make TLS tests conditional on Java Versions

### DIFF
--- a/integrationtests/src/test/java/org/neo4j/bolt/BoltTlsIT.java
+++ b/integrationtests/src/test/java/org/neo4j/bolt/BoltTlsIT.java
@@ -55,6 +55,7 @@ import org.neo4j.ssl.SslContextFactory;
 import org.neo4j.ssl.SslResource;
 import org.neo4j.test.TestGraphDatabaseFactory;
 import org.neo4j.test.rule.TestDirectory;
+import org.neo4j.ssl.SupportsTls;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.junit.Assert.assertNotNull;
@@ -119,9 +120,9 @@ public class BoltTlsIT
                 new TestSetup( "TLSv1", "TLSv1.1", false ),
                 new TestSetup( "TLSv1.1", "TLSv1.2", false ),
 
-                new TestSetup( "TLSv1", "TLSv1", false ),
-                new TestSetup( "TLSv1.1", "TLSv1.1", false ),
-                new TestSetup( "TLSv1.2", "TLSv1.2", true ),
+                new TestSetup( "TLSv1", "TLSv1", SupportsTls.supportsTls_1_0() ),
+                new TestSetup( "TLSv1.1", "TLSv1.1", SupportsTls.supportsTls_1_1() ),
+                new TestSetup( "TLSv1.2", "TLSv1.2", SupportsTls.supportsTls_1_2() ),
 
                 new TestSetup( "SSLv3,TLSv1", "TLSv1.1,TLSv1.2", false ),
                 new TestSetup( "TLSv1.1,TLSv1.2", "TLSv1.1,TLSv1.2", true ),

--- a/integrationtests/src/test/java/org/neo4j/ssl/SslNegotiationTest.java
+++ b/integrationtests/src/test/java/org/neo4j/ssl/SslNegotiationTest.java
@@ -98,7 +98,7 @@ public class SslNegotiationTest
                 new TestSetup(
                         protocols( TLSv10 ).ciphers( NEW_CIPHER_A ),
                         protocols( TLSv10 ).ciphers( NEW_CIPHER_A ),
-                        false, TLSv10, NEW_CIPHER_A ),
+                        SupportsTls.supportsTls_1_0(), TLSv10, NEW_CIPHER_A ),
                 new TestSetup(
                         protocols( TLSv11 ).ciphers( OLD_CIPHER_A ),
                         protocols( TLSv11 ).ciphers( OLD_CIPHER_A ),
@@ -106,7 +106,7 @@ public class SslNegotiationTest
                 new TestSetup(
                         protocols( TLSv11 ).ciphers( NEW_CIPHER_A ),
                         protocols( TLSv11 ).ciphers( NEW_CIPHER_A ),
-                        false, TLSv11, NEW_CIPHER_A ),
+                        SupportsTls.supportsTls_1_1(), TLSv11, NEW_CIPHER_A ),
                 new TestSetup(
                         protocols( TLSv12 ).ciphers( NEW_CIPHER_A ),
                         protocols( TLSv12 ).ciphers( NEW_CIPHER_A ),
@@ -164,7 +164,7 @@ public class SslNegotiationTest
                 new TestSetup(
                         protocols( TLSv11 ).ciphers( NEW_CIPHER_B, NEW_CIPHER_A ),
                         protocols( TLSv11 ).ciphers( NEW_CIPHER_C, NEW_CIPHER_A ),
-                        false, TLSv11, NEW_CIPHER_A ),
+                        SupportsTls.supportsTls_1_1(), TLSv11, NEW_CIPHER_A ),
                 new TestSetup(
                         protocols( TLSv12 ).ciphers( NEW_CIPHER_B, NEW_CIPHER_A ),
                         protocols( TLSv12 ).ciphers( NEW_CIPHER_C, NEW_CIPHER_A ),

--- a/integrationtests/src/test/java/org/neo4j/ssl/SupportsTls.java
+++ b/integrationtests/src/test/java/org/neo4j/ssl/SupportsTls.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Graph Foundation, Inc. [https://graphfoundation.org]
+ *
+ * This file is part of ONgDB Enterprise Edition. The included source
+ * code can be redistributed and/or modified under the terms of the
+ * GNU AFFERO GENERAL PUBLIC LICENSE Version 3
+ * (http://www.fsf.org/licensing/licenses/agpl-3.0.html) as found
+ * in the associated LICENSE.txt file.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ */
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.ssl;
+
+public class SupportsTls
+{
+    private static final String version = System.getProperty("java.version");
+    private static final boolean supportsLegacyTls =  "11.0.11".compareTo(version) > 0;
+    private static final boolean supportsTls_1_3 = "1.8.0_263".compareTo(version) <= 0;
+
+    public static boolean supportsTls_1_0()
+    {
+        return supportsLegacyTls;
+    }
+
+    public static boolean supportsTls_1_1()
+    {
+        return supportsLegacyTls;
+    }
+
+    public static boolean supportsTls_1_2()
+    {
+        return true;
+    }
+
+    public static boolean supportsTls_1_3()
+    {
+        return supportsTls_1_3;
+    }
+}


### PR DESCRIPTION
Ran into some failing tests when I was running locally, this should help tests pass regardless of Java version (To a limited degree)
- TLS 1.0/1.1 https://community.axonivy.com/d/140-tls-10-and-tls-11-disabled-by-default-with-java-11011
- TLS 1.3 https://stackoverflow.com/a/62956195
