### PR TITLE
ci: add audited release workflows to 1.1 release line

### DIFF
--- a/.github/BRANCHING.md
+++ b/.github/BRANCHING.md
@@ -1,0 +1,90 @@
+# ONgDB 1.1 branch model and audited releases
+
+Public repository: [`graphfoundation/ongdb`](https://github.com/graphfoundation/ongdb).
+
+| Ref | Purpose | Produces release? |
+|-----|---------|-------------------|
+| `1.1-dev` (and feature branches) | Integration + free CI | **No** |
+| `1.1` | Audited release line (PR-only) | Source of release tags only |
+| Tags `1.1.*` | Immutable release pointer from `1.1` | Triggers `release.yml` after environment approval |
+
+## Flow
+
+1. Optional: push WIP to private remote `dev` (`graphfoundation/ongdb-dev`).
+2. Push or open a PR to public **`1.1-dev`** → free Actions CI (`pr.yml` / `nightly.yml`).
+3. When ready to ship: open an **audit PR** `1.1-dev` → **`1.1`**.
+4. Required review + green `pr.yml` checks → merge to `1.1`.
+5. Create tag `1.1.x` from that commit on `1.1`.
+6. Approve the GitHub Environment **`release`** → artifacts build and publish.
+
+**Invariant:** GitHub Release assets come only from a tag whose commit is on protected `1.1`, after PR review into `1.1` and `release` environment approval. Nightly `ci-snapshot-*` artifacts are not releases.
+
+## Repository settings (apply once)
+
+`gh` must be authenticated as an org admin (`gh auth refresh -h github.com`). Prefer:
+
+```bash
+.github/scripts/apply-github-settings.sh
+```
+
+Or run the equivalent API calls below:
+
+```bash
+# Branch protection on release line 1.1
+gh api -X PUT repos/graphfoundation/ongdb/branches/1.1/protection \
+  --input - <<'EOF'
+{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": [
+      "compile-unit",
+      "community-gate",
+      "enterprise-security",
+      "enterprise-backup"
+    ]
+  },
+  "enforce_admins": true,
+  "required_pull_request_reviews": {
+    "required_approving_review_count": 1,
+    "dismiss_stale_reviews": true,
+    "require_code_owner_reviews": true
+  },
+  "restrictions": null,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "block_creations": false,
+  "required_conversation_resolution": true
+}
+EOF
+
+# Create release environment (add required reviewers in the UI after this)
+gh api -X PUT repos/graphfoundation/ongdb/environments/release \
+  --input - <<'EOF'
+{
+  "wait_timer": 0,
+  "prevent_self_review": false,
+  "deployment_branch_policy": null
+}
+EOF
+```
+
+Do **not** restrict the environment to tags-only if you want `workflow_dispatch` dry-runs; `release.yml` already refuses tags whose commit is not on `origin/1.1`.
+
+Also in the GitHub UI:
+
+- Environment **`release`** → **Required reviewers** (at least one maintainer).
+- Confirm repository visibility remains **Public** (free standard runners on all branches).
+- Settings → Actions → General: allow GitHub-hosted runners; leave larger runners disabled / budget **$0**.
+- Organization → Billing → Budgets: set an Actions spend alert/budget so accidental larger-runner use cannot surprise-bill.
+
+## Tag discipline
+
+```bash
+git fetch origin 1.1
+git checkout 1.1
+git pull --ff-only origin 1.1
+git tag -a 1.1.0 -m "ONgDB 1.1.0"
+git push origin 1.1.0
+```
+
+`release.yml` fails if the tagged commit is not an ancestor of `origin/1.1`.

--- a/.github/BRANCHING.md
+++ b/.github/BRANCHING.md
@@ -72,10 +72,11 @@ Do **not** restrict the environment to tags-only if you want `workflow_dispatch`
 
 Also in the GitHub UI:
 
-- Environment **`release`** → **Required reviewers** (at least one maintainer).
 - Confirm repository visibility remains **Public** (free standard runners on all branches).
 - Settings → Actions → General: allow GitHub-hosted runners; leave larger runners disabled / budget **$0**.
 - Organization → Billing → Budgets: set an Actions spend alert/budget so accidental larger-runner use cannot surprise-bill.
+
+**Nightly cron:** GitHub only schedules workflows from the repository **default** branch (currently `1.0`). `nightly.yml` is therefore also committed on `1.0`; the job always checks out `1.1-dev` for the build. `workflow_dispatch` works from any branch that contains the file.
 
 ## Tag discipline
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# Release-sensitive paths require review from maintainers on PRs into protected
+# release lines (e.g. 1.1). Update the owner list when the maintainer team changes.
+# Docs: .github/BRANCHING.md
+
+*                               @bradnussbaum
+
+/.github/                       @bradnussbaum
+/enterprise/                    @bradnussbaum
+/packaging/                     @bradnussbaum

--- a/.github/scripts/apply-github-settings.sh
+++ b/.github/scripts/apply-github-settings.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Apply branch protection and release environment for graphfoundation/ongdb.
+# Requires: gh auth with admin on the repo (gh auth refresh -h github.com).
+set -euo pipefail
+
+REPO="${REPO:-graphfoundation/ongdb}"
+BRANCH="${RELEASE_BRANCH:-1.1}"
+
+echo "Applying settings to ${REPO} (release branch ${BRANCH})"
+gh api user --jq .login >/dev/null
+
+gh api -X PUT "repos/${REPO}/branches/${BRANCH}/protection" --input - <<EOF
+{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": [
+      "compile-unit",
+      "community-gate",
+      "enterprise-security",
+      "enterprise-backup"
+    ]
+  },
+  "enforce_admins": true,
+  "required_pull_request_reviews": {
+    "required_approving_review_count": 1,
+    "dismiss_stale_reviews": true,
+    "require_code_owner_reviews": true
+  },
+  "restrictions": null,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "required_conversation_resolution": true
+}
+EOF
+echo "Branch protection applied on ${BRANCH}"
+
+gh api -X PUT "repos/${REPO}/environments/release" --input - <<'EOF'
+{
+  "wait_timer": 0,
+  "prevent_self_review": false,
+  "deployment_branch_policy": null
+}
+EOF
+echo "Environment 'release' created/updated."
+echo
+echo "Manual steps remaining in GitHub UI:"
+echo "  1. Settings → Environments → release → add Required reviewers"
+echo "  2. Org Billing → Budgets → Actions spend alert (larger runners \$0)"
+echo "  3. Confirm ${REPO} is Public"
+echo "  4. Ensure nightly.yml exists on the repository default branch (for cron),"
+echo "     or use workflow_dispatch; job checks out 1.1-dev either way."

--- a/.github/scripts/apply-github-settings.sh
+++ b/.github/scripts/apply-github-settings.sh
@@ -34,18 +34,23 @@ gh api -X PUT "repos/${REPO}/branches/${BRANCH}/protection" --input - <<EOF
 EOF
 echo "Branch protection applied on ${BRANCH}"
 
-gh api -X PUT "repos/${REPO}/environments/release" --input - <<'EOF'
+REVIEWER_LOGIN="${RELEASE_REVIEWER:-$(gh api user --jq .login)}"
+REVIEWER_ID="$(gh api "users/${REVIEWER_LOGIN}" --jq .id)"
+
+gh api -X PUT "repos/${REPO}/environments/release" --input - <<EOF
 {
   "wait_timer": 0,
   "prevent_self_review": false,
+  "reviewers": [
+    {"type": "User", "id": ${REVIEWER_ID}}
+  ],
   "deployment_branch_policy": null
 }
 EOF
-echo "Environment 'release' created/updated."
+echo "Environment 'release' created/updated with required reviewer @${REVIEWER_LOGIN}."
 echo
 echo "Manual steps remaining in GitHub UI:"
-echo "  1. Settings → Environments → release → add Required reviewers"
-echo "  2. Org Billing → Budgets → Actions spend alert (larger runners \$0)"
-echo "  3. Confirm ${REPO} is Public"
-echo "  4. Ensure nightly.yml exists on the repository default branch (for cron),"
+echo "  1. Org Billing → Budgets → Actions spend alert (larger runners \$0)"
+echo "  2. Confirm ${REPO} is Public"
+echo "  3. Ensure nightly.yml exists on the repository default branch (for cron),"
 echo "     or use workflow_dispatch; job checks out 1.1-dev either way."

--- a/.github/scripts/tarball-smoke.sh
+++ b/.github/scripts/tarball-smoke.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Smoke-test an ONgDB standalone unix tarball: extract, start, wait for HTTP, stop.
+set -euo pipefail
+
+TARBALL="${1:?Usage: tarball-smoke.sh <ongdb-*-unix.tar.gz>}"
+if [[ ! -f "$TARBALL" ]]; then
+  echo "Tarball not found: $TARBALL" >&2
+  exit 1
+fi
+
+WORKDIR="$(mktemp -d)"
+cleanup() {
+  if [[ -n "${ONGDB_HOME:-}" && -x "${ONGDB_HOME}/bin/ongdb" ]]; then
+    "${ONGDB_HOME}/bin/ongdb" stop || true
+  fi
+  rm -rf "$WORKDIR"
+}
+trap cleanup EXIT
+
+tar -xzf "$TARBALL" -C "$WORKDIR"
+ONGDB_HOME="$(find "$WORKDIR" -mindepth 1 -maxdepth 1 -type d | head -n 1)"
+if [[ -z "$ONGDB_HOME" || ! -x "${ONGDB_HOME}/bin/ongdb" ]]; then
+  echo "Could not locate bin/ongdb under extracted tarball" >&2
+  exit 1
+fi
+
+echo "Starting ONgDB from ${ONGDB_HOME}"
+"${ONGDB_HOME}/bin/ongdb" start
+
+HTTP_PORT=7474
+ATTEMPTS=0
+RETRIES=90
+STATUS=0
+until [[ "$STATUS" == "200" ]]; do
+  ATTEMPTS=$((ATTEMPTS + 1))
+  STATUS="$(curl -s -o /dev/null -w '%{http_code}' --connect-timeout 1 --max-time 3 \
+    "http://127.0.0.1:${HTTP_PORT}" || echo 0)"
+  if [[ "$ATTEMPTS" -gt "$RETRIES" ]]; then
+    echo "ONgDB did not become ready on :${HTTP_PORT} within ${RETRIES}s (last status=${STATUS})" >&2
+    "${ONGDB_HOME}/bin/ongdb" status || true
+    exit 1
+  fi
+  sleep 1
+done
+
+echo "ONgDB HTTP ready (status ${STATUS}) after ${ATTEMPTS}s"
+"${ONGDB_HOME}/bin/ongdb" stop
+echo "Tarball smoke OK: $(basename "$TARBALL")"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,62 @@
+# Free full-reactor CI for public 1.1-dev.
+# Uploads ci-snapshot-* artifacts for debugging — never creates a GitHub Release.
+#
+# Note: GitHub only schedules workflows from the repository *default* branch.
+# Keep this file on the default branch (or rely on workflow_dispatch) so cron fires;
+# the job always checks out ref 1.1-dev for the build.
+
+name: Nightly full reactor
+
+on:
+  schedule:
+    # 06:00 UTC daily (requires this workflow on the repo default branch)
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: nightly-${{ github.repository }}-1.1-dev
+  cancel-in-progress: false
+
+env:
+  MAVEN_OPTS: -Xmx4g
+  JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF-8
+
+jobs:
+  full-reactor:
+    if: github.repository == 'graphfoundation/ongdb'
+    runs-on: ubuntu-latest
+    timeout-minutes: 480
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: 1.1-dev
+      - name: Raise open file limit
+        run: ulimit -n 40000 && ulimit -n
+      - name: Set up JDK 8
+        uses: actions/setup-java@v4
+        with:
+          java-version: '8'
+          distribution: temurin
+          cache: maven
+      - name: Full reactor clean install
+        run: mvn -B -Drevapi.skip=true clean install
+      - name: Upload CI snapshot distributions
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-snapshot-ongdb-1.1-dev-${{ github.run_id }}
+          path: |
+            packaging/standalone/target/ongdb-community-*-unix.tar.gz
+            packaging/standalone/target/ongdb-enterprise-*-unix.tar.gz
+          if-no-files-found: warn
+          retention-days: 14
+      - name: Upload test reports on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-test-reports-${{ github.run_id }}
+          path: |
+            **/target/surefire-reports/**
+            **/target/failsafe-reports/**
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,125 @@
+# Free quality gate on public graphfoundation/ongdb.
+# Not a release — see .github/BRANCHING.md and release.yml.
+
+name: PR quality gate
+
+on:
+  push:
+    branches: [1.1-dev]
+  pull_request:
+    branches: [1.1-dev, '1.1']
+
+concurrency:
+  group: pr-${{ github.repository }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  MAVEN_OPTS: -Xmx4g
+  JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF-8
+
+jobs:
+  compile-unit:
+    if: github.repository == 'graphfoundation/ongdb'
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@v4
+      - name: Raise open file limit
+        run: ulimit -n 40000 && ulimit -n
+      - name: Set up JDK 8
+        uses: actions/setup-java@v4
+        with:
+          java-version: '8'
+          distribution: temurin
+          cache: maven
+      - name: Compile and unit tests
+        run: mvn -B -Drevapi.skip=true clean test
+      - name: Upload test reports on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: surefire-compile-unit
+          path: '**/target/surefire-reports/**'
+          if-no-files-found: ignore
+          retention-days: 7
+
+  community-gate:
+    if: github.repository == 'graphfoundation/ongdb'
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@v4
+      - name: Raise open file limit
+        run: ulimit -n 40000 && ulimit -n
+      - name: Set up JDK 8
+        uses: actions/setup-java@v4
+        with:
+          java-version: '8'
+          distribution: temurin
+          cache: maven
+      - name: Community neo4j -am
+        run: mvn -B -Drevapi.skip=true clean install -pl community/neo4j -am
+      - name: Upload test reports on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: surefire-community-gate
+          path: '**/target/surefire-reports/**'
+          if-no-files-found: ignore
+          retention-days: 7
+
+  enterprise-security:
+    if: github.repository == 'graphfoundation/ongdb'
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@v4
+      - name: Raise open file limit
+        run: ulimit -n 40000 && ulimit -n
+      - name: Set up JDK 8
+        uses: actions/setup-java@v4
+        with:
+          java-version: '8'
+          distribution: temurin
+          cache: maven
+      - name: Install dependencies then security verify
+        run: |
+          mvn -B -Drevapi.skip=true install -DskipTests -pl enterprise/security -am
+          mvn -B -Drevapi.skip=true verify -pl enterprise/security -DskipCypher
+      - name: Upload test reports on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: reports-enterprise-security
+          path: |
+            **/target/surefire-reports/**
+            **/target/failsafe-reports/**
+          if-no-files-found: ignore
+          retention-days: 7
+
+  enterprise-backup:
+    if: github.repository == 'graphfoundation/ongdb'
+    runs-on: ubuntu-latest
+    timeout-minutes: 240
+    steps:
+      - uses: actions/checkout@v4
+      - name: Raise open file limit
+        run: ulimit -n 40000 && ulimit -n
+      - name: Set up JDK 8
+        uses: actions/setup-java@v4
+        with:
+          java-version: '8'
+          distribution: temurin
+          cache: maven
+      - name: Backup -am with skipCypher
+        run: mvn -B -Drevapi.skip=true clean install -DskipCypher -pl enterprise/backup -am
+      - name: Upload test reports on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: reports-enterprise-backup
+          path: |
+            **/target/surefire-reports/**
+            **/target/failsafe-reports/**
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,132 @@
+# Audited release build for public graphfoundation/ongdb.
+# Requires: tag 1.1.* whose commit is on origin/1.1, plus Environment "release" approval.
+# See .github/BRANCHING.md
+
+name: Release artifacts
+
+on:
+  push:
+    tags:
+      - '1.1.*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing tag to build (must be on origin/1.1), e.g. 1.1.0
+        required: true
+        type: string
+
+concurrency:
+  group: release-${{ github.repository }}-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  MAVEN_OPTS: -Xmx4g
+  JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF-8
+
+jobs:
+  verify-release-ref:
+    if: github.repository == 'graphfoundation/ongdb'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      version: ${{ steps.meta.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+      - name: Resolve version and verify ancestor of origin/1.1
+        id: meta
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            VERSION="${{ inputs.tag }}"
+            VERSION="${VERSION#refs/tags/}"
+          else
+            VERSION="${GITHUB_REF_NAME}"
+          fi
+          if [[ ! "$VERSION" =~ ^1\.1\. ]]; then
+            echo "Ref '$VERSION' does not match 1.1.* release tags" >&2
+            exit 1
+          fi
+          git fetch origin 1.1:refs/remotes/origin/1.1
+          SHA="$(git rev-parse HEAD)"
+          if ! git merge-base --is-ancestor "$SHA" origin/1.1; then
+            echo "Commit $SHA is not an ancestor of origin/1.1 — refuse unaudited tag" >&2
+            echo "Create tags only from the protected 1.1 release line after audit PR merge." >&2
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Audited release ref OK: $VERSION @ $SHA (on origin/1.1)"
+
+  build-and-publish:
+    if: github.repository == 'graphfoundation/ongdb'
+    needs: verify-release-ref
+    runs-on: ubuntu-latest
+    timeout-minutes: 480
+    environment: release
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+      - name: Raise open file limit
+        run: ulimit -n 40000 && ulimit -n
+      - name: Set up JDK 8
+        uses: actions/setup-java@v4
+        with:
+          java-version: '8'
+          distribution: temurin
+          cache: maven
+      - name: Full reactor clean install
+        run: mvn -B -Drevapi.skip=true clean install
+      - name: Locate distribution tarballs
+        id: dist
+        run: |
+          set -euo pipefail
+          COMMUNITY="$(ls packaging/standalone/target/ongdb-community-*-unix.tar.gz | head -n 1)"
+          ENTERPRISE="$(ls packaging/standalone/target/ongdb-enterprise-*-unix.tar.gz | head -n 1)"
+          echo "community=$COMMUNITY" >> "$GITHUB_OUTPUT"
+          echo "enterprise=$ENTERPRISE" >> "$GITHUB_OUTPUT"
+          ls -lh packaging/standalone/target/ongdb-*-unix.tar.gz
+      - name: Tarball smoke (enterprise)
+        run: |
+          chmod +x .github/scripts/tarball-smoke.sh
+          .github/scripts/tarball-smoke.sh "${{ steps.dist.outputs.enterprise }}"
+      - name: Upload release artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ongdb-${{ needs.verify-release-ref.outputs.version }}
+          path: |
+            packaging/standalone/target/ongdb-community-*-unix.tar.gz
+            packaging/standalone/target/ongdb-enterprise-*-unix.tar.gz
+            packaging/standalone/target/ongdb-community-*-windows.zip
+            packaging/standalone/target/ongdb-enterprise-*-windows.zip
+          if-no-files-found: error
+          retention-days: 90
+      - name: Create GitHub Release and attach assets
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.verify-release-ref.outputs.version }}
+          name: ONgDB ${{ needs.verify-release-ref.outputs.version }}
+          generate_release_notes: true
+          files: |
+            packaging/standalone/target/ongdb-community-*-unix.tar.gz
+            packaging/standalone/target/ongdb-enterprise-*-unix.tar.gz
+            packaging/standalone/target/ongdb-community-*-windows.zip
+            packaging/standalone/target/ongdb-enterprise-*-windows.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload test reports on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-test-reports-${{ needs.verify-release-ref.outputs.version }}
+          path: |
+            **/target/surefire-reports/**
+            **/target/failsafe-reports/**
+          if-no-files-found: ignore
+          retention-days: 30


### PR DESCRIPTION
## Summary
- Add PR / nightly / release GitHub Actions workflows, CODEOWNERS, and BRANCHING docs to the protected `1.1` release line.
- Required so `1.1.*` tags can run `release.yml` (workflow file must exist on the tagged commit).
- Does not promote product changes from `1.1-dev`; CI-only cherry-picks.

## Test plan
- [ ] `pr.yml` jobs run on this PR
- [ ] After merge, `workflow_dispatch` / tag release path can see `release.yml` on `1.1`
- [ ] Environment `release` still requires reviewer approval