### PR TITLE
ci: full-reactor gate for release-branch PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,12 @@
-# This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-maven
-
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
+# CI for integration (*-dev) and release-branch gates (1.0 / 1.1 / 2.0).
+#
+# - build: path for pushes/PRs that are not targeting a release branch
+#   (e.g. work on 1.0-dev). Required check on *-dev branch protection.
+# - full-reactor: stronger gate for PRs into release branches (1.0, 1.1, 2.0)
+#   and pushes to those branches. Required check on release branch protection.
+#
+# Both run a full Maven reactor; full-reactor adds a longer timeout and a higher
+# open-file limit to match nightly release integrity runs.
 
 name: Java CI with Maven
 
@@ -12,18 +14,67 @@ on:
   push:
   pull_request:
 
+env:
+  MAVEN_OPTS: -Xmx4g
+  JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF-8
+
 jobs:
   build:
-
+    if: >-
+      (github.event_name == 'push' &&
+      !contains(fromJSON('["1.0","1.1","2.0"]'), github.ref_name)) ||
+      (github.event_name == 'pull_request' &&
+      !contains(fromJSON('["1.0","1.1","2.0"]'), github.base_ref))
     runs-on: ubuntu-latest
-
+    timeout-minutes: 240
     steps:
-    - uses: actions/checkout@v5
-    - name: Set up JDK 8
-      uses: actions/setup-java@v5
-      with:
-        java-version: '8'
-        distribution: 'temurin'
-        cache: maven
-    - name: Build with Maven
-      run: mvn clean install -DfullBuild -Drevapi.skip=true -DcreateChecksum=true
+      - uses: actions/checkout@v5
+      - name: Set up JDK 8
+        uses: actions/setup-java@v5
+        with:
+          java-version: '8'
+          distribution: temurin
+          cache: maven
+      - name: Build with Maven
+        run: mvn -B clean install -DfullBuild -Drevapi.skip=true -DcreateChecksum=true
+
+  full-reactor:
+    if: >-
+      (github.event_name == 'push' &&
+      contains(fromJSON('["1.0","1.1","2.0"]'), github.ref_name)) ||
+      (github.event_name == 'pull_request' &&
+      contains(fromJSON('["1.0","1.1","2.0"]'), github.base_ref))
+    runs-on: ubuntu-latest
+    timeout-minutes: 480
+    steps:
+      - uses: actions/checkout@v5
+      - name: Raise open file limit
+        run: ulimit -n 40000 && ulimit -n
+      - name: Set up JDK 8
+        uses: actions/setup-java@v5
+        with:
+          java-version: '8'
+          distribution: temurin
+          cache: maven
+      - name: Full reactor clean install
+        run: mvn -B clean install -DfullBuild -Drevapi.skip=true -DcreateChecksum=true
+      - name: Upload CI snapshot distributions
+        if: success()
+        uses: actions/upload-artifact@v6
+        with:
+          name: ci-snapshot-ongdb-${{ github.run_id }}
+          path: |
+            packaging/standalone/target/ongdb-community-*-unix.tar.gz
+            packaging/standalone/target/ongdb-enterprise-*-unix.tar.gz
+          if-no-files-found: warn
+          retention-days: 14
+      - name: Upload test reports on failure
+        if: failure()
+        uses: actions/upload-artifact@v6
+        with:
+          name: full-reactor-test-reports-${{ github.run_id }}
+          path: |
+            **/target/surefire-reports/**
+            **/target/failsafe-reports/**
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,9 +1,9 @@
-# Free full-reactor CI for public 1.1-dev.
+# Nightly full-reactor verification for release branches.
 # Uploads ci-snapshot-* artifacts for debugging — never creates a GitHub Release.
 #
 # Note: GitHub only schedules workflows from the repository *default* branch.
 # Keep this file on the default branch (or rely on workflow_dispatch) so cron fires;
-# the job always checks out ref 1.1-dev for the build.
+# each matrix job checks out the release branch under test.
 
 name: Nightly full reactor
 
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: nightly-${{ github.repository }}-1.1-dev
+  group: nightly-${{ github.repository }}-${{ github.event_name }}
   cancel-in-progress: false
 
 env:
@@ -24,12 +24,16 @@ env:
 jobs:
   full-reactor:
     if: github.repository == 'graphfoundation/ongdb'
+    strategy:
+      fail-fast: false
+      matrix:
+        ref: [1.0, 1.1, 2.0]
     runs-on: ubuntu-latest
     timeout-minutes: 480
     steps:
       - uses: actions/checkout@v5
         with:
-          ref: 1.1-dev
+          ref: ${{ matrix.ref }}
       - name: Raise open file limit
         run: ulimit -n 40000 && ulimit -n
       - name: Set up JDK 8
@@ -39,12 +43,12 @@ jobs:
           distribution: temurin
           cache: maven
       - name: Full reactor clean install
-        run: mvn -B -Drevapi.skip=true clean install
+        run: mvn -B clean install -DfullBuild -Drevapi.skip=true -DcreateChecksum=true
       - name: Upload CI snapshot distributions
         if: success()
         uses: actions/upload-artifact@v6
         with:
-          name: ci-snapshot-ongdb-1.1-dev-${{ github.run_id }}
+          name: ci-snapshot-ongdb-${{ matrix.ref }}-${{ github.run_id }}
           path: |
             packaging/standalone/target/ongdb-community-*-unix.tar.gz
             packaging/standalone/target/ongdb-enterprise-*-unix.tar.gz
@@ -54,7 +58,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v6
         with:
-          name: nightly-test-reports-${{ github.run_id }}
+          name: nightly-test-reports-${{ matrix.ref }}-${{ github.run_id }}
           path: |
             **/target/surefire-reports/**
             **/target/failsafe-reports/**


### PR DESCRIPTION
## Summary
- `build` job for `*-dev` / non-release PRs (keeps 1.0-dev required check)
- `full-reactor` job for PRs into / pushes to `1.0`, `1.1`, `2.0` (satisfies release branch protection)
- Nightly matrix verifies `1.0`, `1.1`, `2.0` (replaces missing `1.1-dev` target)

## Test plan
- [ ] `build` green on this PR into `1.0-dev`
- [ ] After merge, PR #127 should start a real `full-reactor` check instead of pending forever