### PR TITLE
Make TLS IT expectations follow JVM protocol capability

### DIFF
--- a/integrationtests/src/test/java/org/neo4j/bolt/BoltTlsIT.java
+++ b/integrationtests/src/test/java/org/neo4j/bolt/BoltTlsIT.java
@@ -55,6 +55,7 @@ import org.neo4j.ssl.SslContextFactory;
 import org.neo4j.ssl.SslResource;
 import org.neo4j.test.TestGraphDatabaseFactory;
 import org.neo4j.test.rule.TestDirectory;
+import org.neo4j.ssl.SupportsTls;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.junit.Assert.assertNotNull;
@@ -119,9 +120,9 @@ public class BoltTlsIT
                 new TestSetup( "TLSv1", "TLSv1.1", false ),
                 new TestSetup( "TLSv1.1", "TLSv1.2", false ),
 
-                new TestSetup( "TLSv1", "TLSv1", false ),
-                new TestSetup( "TLSv1.1", "TLSv1.1", false ),
-                new TestSetup( "TLSv1.2", "TLSv1.2", true ),
+                new TestSetup( "TLSv1", "TLSv1", SupportsTls.supportsTls_1_0() ),
+                new TestSetup( "TLSv1.1", "TLSv1.1", SupportsTls.supportsTls_1_1() ),
+                new TestSetup( "TLSv1.2", "TLSv1.2", SupportsTls.supportsTls_1_2() ),
 
                 new TestSetup( "SSLv3,TLSv1", "TLSv1.1,TLSv1.2", false ),
                 new TestSetup( "TLSv1.1,TLSv1.2", "TLSv1.1,TLSv1.2", true ),

--- a/integrationtests/src/test/java/org/neo4j/ssl/SslNegotiationTest.java
+++ b/integrationtests/src/test/java/org/neo4j/ssl/SslNegotiationTest.java
@@ -98,7 +98,7 @@ public class SslNegotiationTest
                 new TestSetup(
                         protocols( TLSv10 ).ciphers( NEW_CIPHER_A ),
                         protocols( TLSv10 ).ciphers( NEW_CIPHER_A ),
-                        false, TLSv10, NEW_CIPHER_A ),
+                        SupportsTls.supportsTls_1_0(), TLSv10, NEW_CIPHER_A ),
                 new TestSetup(
                         protocols( TLSv11 ).ciphers( OLD_CIPHER_A ),
                         protocols( TLSv11 ).ciphers( OLD_CIPHER_A ),
@@ -106,7 +106,7 @@ public class SslNegotiationTest
                 new TestSetup(
                         protocols( TLSv11 ).ciphers( NEW_CIPHER_A ),
                         protocols( TLSv11 ).ciphers( NEW_CIPHER_A ),
-                        false, TLSv11, NEW_CIPHER_A ),
+                        SupportsTls.supportsTls_1_1(), TLSv11, NEW_CIPHER_A ),
                 new TestSetup(
                         protocols( TLSv12 ).ciphers( NEW_CIPHER_A ),
                         protocols( TLSv12 ).ciphers( NEW_CIPHER_A ),
@@ -164,7 +164,7 @@ public class SslNegotiationTest
                 new TestSetup(
                         protocols( TLSv11 ).ciphers( NEW_CIPHER_B, NEW_CIPHER_A ),
                         protocols( TLSv11 ).ciphers( NEW_CIPHER_C, NEW_CIPHER_A ),
-                        false, TLSv11, NEW_CIPHER_A ),
+                        SupportsTls.supportsTls_1_1(), TLSv11, NEW_CIPHER_A ),
                 new TestSetup(
                         protocols( TLSv12 ).ciphers( NEW_CIPHER_B, NEW_CIPHER_A ),
                         protocols( TLSv12 ).ciphers( NEW_CIPHER_C, NEW_CIPHER_A ),

--- a/integrationtests/src/test/java/org/neo4j/ssl/SupportsTls.java
+++ b/integrationtests/src/test/java/org/neo4j/ssl/SupportsTls.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Graph Foundation, Inc. [https://graphfoundation.org]
+ *
+ * This file is part of ONgDB Enterprise Edition. The included source
+ * code can be redistributed and/or modified under the terms of the
+ * GNU AFFERO GENERAL PUBLIC LICENSE Version 3
+ * (http://www.fsf.org/licensing/licenses/agpl-3.0.html) as found
+ * in the associated LICENSE.txt file.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ */
+package org.neo4j.ssl;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.Security;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import javax.net.ssl.SSLContext;
+
+/**
+ * Reports whether the running JVM can complete a TLS handshake for a given protocol version.
+ * Newer JDKs commonly list legacy protocols in {@code jdk.tls.disabledAlgorithms}; those still appear
+ * in {@link SSLContext#getSupportedSSLParameters()} and can often be passed to
+ * {@code setEnabledProtocols}, but handshakes fail. Version-string checks are intentionally avoided.
+ */
+public class SupportsTls
+{
+    private static final Set<String> PROTOCOL_NAMES = new HashSet<>( Arrays.asList(
+            "SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2", "TLSv1.3" ) );
+
+    private static final Set<String> SUPPORTED_PROTOCOLS = discoverSupportedProtocols();
+    private static final Set<String> DISABLED_PROTOCOLS = discoverDisabledProtocols();
+
+    public static boolean supportsTls_1_0()
+    {
+        return supports( "TLSv1" );
+    }
+
+    public static boolean supportsTls_1_1()
+    {
+        return supports( "TLSv1.1" );
+    }
+
+    public static boolean supportsTls_1_2()
+    {
+        return supports( "TLSv1.2" );
+    }
+
+    public static boolean supportsTls_1_3()
+    {
+        return supports( "TLSv1.3" );
+    }
+
+    private static boolean supports( String protocol )
+    {
+        return SUPPORTED_PROTOCOLS.contains( protocol ) && !DISABLED_PROTOCOLS.contains( protocol );
+    }
+
+    private static Set<String> discoverSupportedProtocols()
+    {
+        try
+        {
+            String[] protocols = SSLContext.getDefault().getSupportedSSLParameters().getProtocols();
+            return Collections.unmodifiableSet( new HashSet<>( Arrays.asList( protocols ) ) );
+        }
+        catch ( NoSuchAlgorithmException e )
+        {
+            return Collections.emptySet();
+        }
+    }
+
+    private static Set<String> discoverDisabledProtocols()
+    {
+        String property = Security.getProperty( "jdk.tls.disabledAlgorithms" );
+        if ( property == null || property.trim().isEmpty() )
+        {
+            return Collections.emptySet();
+        }
+
+        Set<String> disabled = new HashSet<>();
+        for ( String part : property.split( "," ) )
+        {
+            String token = part.trim();
+            if ( PROTOCOL_NAMES.contains( token ) )
+            {
+                disabled.add( token );
+            }
+        }
+        return Collections.unmodifiableSet( disabled );
+    }
+}


### PR DESCRIPTION
## Summary
- Replace brittle `java.version` string pins in `SupportsTls` with a JVM capability probe (protocol supported and not listed in `jdk.tls.disabledAlgorithms`).
- Keep Bolt/SSL negotiation IT `expectedSuccess` gated on that helper so suites stay green across JDK updates that disable legacy TLS.

## Test plan
- [ ] Confirm `full-reactor` / integrationtests SSL and Bolt TLS ITs pass on CI JDK
- [ ] Spot-check that Temurin 8/11 with TLSv1/TLSv1.1 in `jdk.tls.disabledAlgorithms` report `supportsTls_1_0/1_1() == false`