### PR TITLE
Start script improvements (2.0 backport)

### DIFF
--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/ongdb
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/ongdb
@@ -320,6 +320,9 @@ print_active_database() {
   echo "Active database: ${dbms_active_database:-graph.db}"
 }
 
+use_default_main_class() {
+  MAIN_CLASS="#{ongdb.mainClass}"
+}
 
 setup_arbiter_options() {
   is_arbiter() {
@@ -339,7 +342,7 @@ setup_arbiter_options() {
   else
     SHUTDOWN_TIMEOUT="${ONGDB_SHUTDOWN_TIMEOUT:-120}"
     MIN_ALLOWED_OPEN_FILES=40000
-    MAIN_CLASS="#{ongdb.mainClass}"
+    use_default_main_class
 
     print_start_message() {
       # Global default
@@ -542,6 +545,8 @@ do_status() {
 }
 
 do_version() {
+  check_java
+  use_default_main_class
   build_classpath
 
   assemble_command_line
@@ -592,7 +597,6 @@ main() {
       ;;
 
     --version|version)
-      setup_java
       do_version
       ;;
 

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/ongdb
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/ongdb
@@ -43,9 +43,24 @@
 #  * ONGDB_CONF
 #  * ONGDB_START_WAIT
 
-#############################################################
-#      File content is generated based on .m4 template      #
-#############################################################
+# Copyright (c) 2018-2020 "Graph Foundation,"
+# Graph Foundation, Inc. [https://graphfoundation.org]
+#
+# This file is part of ONgDB.
+#
+# ONgDB is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 
 set -o errexit -o nounset -o pipefail
 [[ "${TRACE:-}" ]] && set -o xtrace
@@ -138,7 +153,9 @@ check_java() {
   _find_java_cmd
   setup_memory_opts
 
-  version_command=("${JAVA_CMD}" "-version" ${JAVA_MEMORY_OPTS_XMS-} ${JAVA_MEMORY_OPTS_XMX-})
+  # Probe without heap opts so `ongdb version` (and java -version checks)
+  # can run in memory-constrained environments.
+  version_command=("${JAVA_CMD}" "-version")
 
   JAVA_VERSION=$("${version_command[@]}" 2>&1 | awk -F '"' '/version/ {print $2}')
   if [[ $JAVA_VERSION = "1."* ]]; then
@@ -320,6 +337,7 @@ print_active_database() {
   echo "Active database: ${dbms_active_database:-graph.db}"
 }
 
+
 use_default_main_class() {
   MAIN_CLASS="#{ongdb.mainClass}"
 }
@@ -372,7 +390,7 @@ setup_arbiter_options() {
         ONGDB_SERVER_ADDRESS="http://${ONGDB_SERVER_ADDRESS}"
       fi
 
-      echo "Starting ongdb (pid ${ONGDB_PID}). It is available at ${ONGDB_SERVER_ADDRESS}/"
+      echo "Started ongdb (pid ${ONGDB_PID}). It is available at ${ONGDB_SERVER_ADDRESS}/"
 
       if [[ "$(echo "${dbms_mode:-}" | tr [:lower:] [:upper:])" == "HA" ]]; then
         echo "This HA instance will be operational once it has joined the cluster."

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/ongdb
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/ongdb
@@ -248,7 +248,7 @@ _read_config() {
   # - keys have '.' chars changed to '_'
   # - keys of the form KEY.# (where # is a number) are concatenated into a single environment variable named KEY
   parse_line() {
-    line="$1"
+    line="${1//[$'\r\n']}"
     if [[ "${line}" =~ ^([^#\s][^=]+)=(.+)$ ]]; then
       key="${BASH_REMATCH[1]//./_}"
       value="${BASH_REMATCH[2]}"

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/ongdb-admin
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/ongdb-admin
@@ -138,7 +138,7 @@ check_java() {
   _find_java_cmd
   setup_memory_opts
 
-  version_command=("${JAVA_CMD}" "-version" ${JAVA_MEMORY_OPTS_XMS-} ${JAVA_MEMORY_OPTS_XMX-})
+  version_command=("${JAVA_CMD}" "-version")
 
   JAVA_VERSION=$("${version_command[@]}" 2>&1 | awk -F '"' '/version/ {print $2}')
   if [[ $JAVA_VERSION = "1."* ]]; then
@@ -249,7 +249,7 @@ _read_config() {
   # - keys have '.' chars changed to '_'
   # - keys of the form KEY.# (where # is a number) are concatenated into a single environment variable named KEY
   parse_line() {
-    line="$1"
+    line="${1//[$'\r\n']}"
     if [[ "${line}" =~ ^([^#\s][^=]+)=(.+)$ ]]; then
       key="${BASH_REMATCH[1]//./_}"
       value="${BASH_REMATCH[2]}"

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/ongdb-backup
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/ongdb-backup
@@ -126,7 +126,7 @@ check_java() {
   _find_java_cmd
   setup_memory_opts
 
-  version_command=("${JAVA_CMD}" "-version" ${JAVA_MEMORY_OPTS_XMS-} ${JAVA_MEMORY_OPTS_XMX-})
+  version_command=("${JAVA_CMD}" "-version")
 
   JAVA_VERSION=$("${version_command[@]}" 2>&1 | awk -F '"' '/version/ {print $2}')
   if [[ $JAVA_VERSION = "1."* ]]; then
@@ -236,7 +236,7 @@ _read_config() {
   # - keys have '.' chars changed to '_'
   # - keys of the form KEY.# (where # is a number) are concatenated into a single environment variable named KEY
   parse_line() {
-    line="$1"
+    line="${1//[$'\r\n']}"
     if [[ "${line}" =~ ^([^#\s][^=]+)=(.+)$ ]]; then
       key="${BASH_REMATCH[1]//./_}"
       value="${BASH_REMATCH[2]}"

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/ongdb-import
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/ongdb-import
@@ -127,7 +127,7 @@ check_java() {
   _find_java_cmd
   setup_memory_opts
 
-  version_command=("${JAVA_CMD}" "-version" ${JAVA_MEMORY_OPTS_XMS-} ${JAVA_MEMORY_OPTS_XMX-})
+  version_command=("${JAVA_CMD}" "-version")
 
   JAVA_VERSION=$("${version_command[@]}" 2>&1 | awk -F '"' '/version/ {print $2}')
   if [[ $JAVA_VERSION = "1."* ]]; then
@@ -237,7 +237,7 @@ _read_config() {
   # - keys have '.' chars changed to '_'
   # - keys of the form KEY.# (where # is a number) are concatenated into a single environment variable named KEY
   parse_line() {
-    line="$1"
+    line="${1//[$'\r\n']}"
     if [[ "${line}" =~ ^([^#\s][^=]+)=(.+)$ ]]; then
       key="${BASH_REMATCH[1]//./_}"
       value="${BASH_REMATCH[2]}"

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/ongdb-shared.m4
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/ongdb-shared.m4
@@ -108,7 +108,9 @@ check_java() {
   _find_java_cmd
   setup_memory_opts
 
-  version_command=("${JAVA_CMD}" "-version" ${JAVA_MEMORY_OPTS_XMS-} ${JAVA_MEMORY_OPTS_XMX-})
+  # Probe without heap opts so `ongdb version` (and java -version checks)
+  # can run in memory-constrained environments.
+  version_command=("${JAVA_CMD}" "-version")
 
   JAVA_VERSION=$("${version_command[@]}" 2>&1 | awk -F '"' '/version/ {print $2}')
   if [[ $JAVA_VERSION = "1."* ]]; then
@@ -218,7 +220,7 @@ _read_config() {
   # - keys have '.' chars changed to '_'
   # - keys of the form KEY.# (where # is a number) are concatenated into a single environment variable named KEY
   parse_line() {
-    line="$1"
+    line="${1//[$'\r\n']}"
     if [[ "${line}" =~ ^([^#\s][^=]+)=(.+)$ ]]; then
       key="${BASH_REMATCH[1]//./_}"
       value="${BASH_REMATCH[2]}"

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/ongdb-shell
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/ongdb-shell
@@ -92,8 +92,9 @@ detect_os() {
 check_java() {
   _find_java_cmd
 
+  # Probe without heap opts so java -version checks can run in
+  # memory-constrained environments.
   version_command=("${JAVA_CMD}" "-version")
-  [[ -n "${JAVA_MEMORY_OPTS:-}" ]] && version_command+=("${JAVA_MEMORY_OPTS[@]}")
 
   JAVA_VERSION=$("${version_command[@]}" 2>&1 | awk -F '"' '/version/ {print $2}')
   if [[ "${JAVA_VERSION}" < "1.8" ]]; then
@@ -192,7 +193,7 @@ _read_config() {
   # - keys have '.' chars changed to '_'
   # - keys of the form KEY.# (where # is a number) are concatenated into a single environment variable named KEY
   parse_line() {
-    line="$1"
+    line="${1//[$'\r\n']}"
     if [[ "${line}" =~ ^([^#\s][^=]+)=(.+)$ ]]; then
       key="${BASH_REMATCH[1]//./_}"
       value="${BASH_REMATCH[2]}"

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/ongdb.m4
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/ongdb.m4
@@ -45,6 +45,10 @@
 
 include(src/main/distribution/shell-scripts/bin/ongdb-shared.m4)
 
+use_default_main_class() {
+  MAIN_CLASS="#{ongdb.mainClass}"
+}
+
 setup_arbiter_options() {
   is_arbiter() {
     compgen -G "${ONGDB_LIB}/ongdb-server-enterprise-*.jar" >/dev/null && \
@@ -63,7 +67,7 @@ setup_arbiter_options() {
   else
     SHUTDOWN_TIMEOUT="${ONGDB_SHUTDOWN_TIMEOUT:-120}"
     MIN_ALLOWED_OPEN_FILES=40000
-    MAIN_CLASS="#{ongdb.mainClass}"
+    use_default_main_class
 
     print_start_message() {
       # Global default
@@ -266,6 +270,8 @@ do_status() {
 }
 
 do_version() {
+  check_java
+  use_default_main_class
   build_classpath
 
   assemble_command_line
@@ -316,7 +322,6 @@ main() {
       ;;
 
     --version|version)
-      setup_java
       do_version
       ;;
 

--- a/packaging/standalone/src/tests/shell-scripts/sharness.d/assertions.sh
+++ b/packaging/standalone/src/tests/shell-scripts/sharness.d/assertions.sh
@@ -17,6 +17,15 @@ test_expect_java_arg() {
   done
 }
 
+test_expect_java_arg_absent() {
+  arg="$1"
+  java_args="${SHARNESS_TRASH_DIRECTORY}/java-args"
+  if [[ -f "${java_args}" ]] && grep --fixed-strings --regexp "${arg}" "${java_args}" >/dev/null ; then
+    echo >&2 "test_expect_java_arg_absent: did not expect argument '$arg' but got '$(cat "${java_args}")'"
+    return 1
+  fi
+}
+
 test_expect_stdout_matching() {
   expected_pattern=$1
   shift

--- a/packaging/standalone/src/tests/shell-scripts/sharness.d/fake-java
+++ b/packaging/standalone/src/tests/shell-scripts/sharness.d/fake-java
@@ -3,7 +3,9 @@ set -eu
 
 args="$@"
 record_args() {
-  [[ "${FAKE_JAVA_DISABLE_RECORD_ARGS:-}" ]] || echo -n "${args}" >java-args
+  # Append so callers that invoke java more than once (e.g. check_java then
+  # main) keep a full record of every probe/launch for assertions.
+  [[ "${FAKE_JAVA_DISABLE_RECORD_ARGS:-}" ]] || echo "${args}" >>java-args
 }
 trap record_args EXIT
 

--- a/packaging/standalone/src/tests/shell-scripts/sharness.d/fixture.sh
+++ b/packaging/standalone/src/tests/shell-scripts/sharness.d/fixture.sh
@@ -13,6 +13,7 @@ fake_install() {
 
 clear_config() {
   rm -f ongdb-home/conf/*
+  rm -f "${SHARNESS_TRASH_DIRECTORY}/java-args"
 }
 
 set_config() {

--- a/packaging/standalone/src/tests/shell-scripts/test-config.sh
+++ b/packaging/standalone/src/tests/shell-scripts/test-config.sh
@@ -45,6 +45,12 @@ test_expect_success "https: should display default https if http disabled and no
   test_expect_stdout_matching 'It is available at https://localhost:7473/' run_daemon
 "
 
+test_expect_success "https: should tolerate Windows CRLF line endings in ongdb.conf" "
+  clear_config &&
+  printf 'dbms.connector.http.enabled=false\r\n' >'$(ongdb_home)/conf/ongdb.conf' &&
+  test_expect_stdout_matching 'It is available at https://localhost:7473/' run_daemon
+"
+
 test_expect_success "https: should read port and address from config" "
   clear_config &&
   set_config 'dbms.connector.http.enabled' 'false' ongdb.conf &&

--- a/packaging/standalone/src/tests/shell-scripts/test-java-arguments.sh
+++ b/packaging/standalone/src/tests/shell-scripts/test-java-arguments.sh
@@ -5,22 +5,22 @@ test_description="Test Java arguments"
 . ./lib/sharness.sh
 fake_install
 
-test_expect_success "should set heap size constraints when checking version from wrapper conf" "
+test_expect_success "should not set heap size constraints when checking version from wrapper conf" "
   clear_config &&
   set_config 'dbms.memory.heap.initial_size' '512m' ongdb-wrapper.conf &&
   set_config 'dbms.memory.heap.max_size' '1024m' ongdb-wrapper.conf &&
   ongdb-home/bin/ongdb version || true &&
-  test_expect_java_arg '-Xms512m' &&
-  test_expect_java_arg '-Xmx1024m'
+  ! test_expect_java_arg '-Xms512m' &&
+  ! test_expect_java_arg '-Xmx1024m'
 "
 
-test_expect_success "should set heap size constraints when checking version" "
+test_expect_success "should not set heap size constraints when checking version" "
   clear_config &&
   set_config 'dbms.memory.heap.initial_size' '512m' ongdb.conf &&
   set_config 'dbms.memory.heap.max_size' '1024m' ongdb.conf &&
   ongdb-home/bin/ongdb version || true &&
-  test_expect_java_arg '-Xms512m' &&
-  test_expect_java_arg '-Xmx1024m'
+  ! test_expect_java_arg '-Xms512m' &&
+  ! test_expect_java_arg '-Xmx1024m'
 "
 
 for run_command in run_console run_daemon; do

--- a/packaging/standalone/src/tests/shell-scripts/test-java-arguments.sh
+++ b/packaging/standalone/src/tests/shell-scripts/test-java-arguments.sh
@@ -10,8 +10,10 @@ test_expect_success "should not set heap size constraints when checking version 
   set_config 'dbms.memory.heap.initial_size' '512m' ongdb-wrapper.conf &&
   set_config 'dbms.memory.heap.max_size' '1024m' ongdb-wrapper.conf &&
   ongdb-home/bin/ongdb version || true &&
-  ! test_expect_java_arg '-Xms512m' &&
-  ! test_expect_java_arg '-Xmx1024m'
+  test_expect_java_arg_absent '-Xms512m' &&
+  test_expect_java_arg_absent '-Xmx1024m' &&
+  test_expect_java_arg_absent '-Xms' &&
+  test_expect_java_arg_absent '-Xmx'
 "
 
 test_expect_success "should not set heap size constraints when checking version" "
@@ -19,8 +21,10 @@ test_expect_success "should not set heap size constraints when checking version"
   set_config 'dbms.memory.heap.initial_size' '512m' ongdb.conf &&
   set_config 'dbms.memory.heap.max_size' '1024m' ongdb.conf &&
   ongdb-home/bin/ongdb version || true &&
-  ! test_expect_java_arg '-Xms512m' &&
-  ! test_expect_java_arg '-Xmx1024m'
+  test_expect_java_arg_absent '-Xms512m' &&
+  test_expect_java_arg_absent '-Xmx1024m' &&
+  test_expect_java_arg_absent '-Xms' &&
+  test_expect_java_arg_absent '-Xmx'
 "
 
 for run_command in run_console run_daemon; do


### PR DESCRIPTION
## Summary
- Backport of [#120](https://github.com/graphfoundation/ongdb/pull/120) for the `2.0` branch: tolerate CRLF in conf parsing, run `ongdb version` without heap/JVM preallocation, and keep m4 sources in sync.
- Drops heap opts from the `java -version` probe so version checks work in memory-constrained containers.
- Adds Sharness coverage (heap-absent on version, CRLF conf) so verification does not require a full package build.

## Test plan
- [x] `./test-arguments.sh` in `packaging/standalone/src/tests/shell-scripts`
- [x] `./test-java-arguments.sh` (version path asserts no `-Xms`/`-Xmx`)
- [x] `./test-config.sh` (includes CRLF `ongdb.conf` case)
- [ ] CI full-reactor green on this PR