### PR TITLE
Merge 1.0-dev: TLS capability gates and yearless GF CMI headers

### DIFF
--- a/build-resources/src/main/resources/checkstyle/checkstyle.xml
+++ b/build-resources/src/main/resources/checkstyle/checkstyle.xml
@@ -11,7 +11,7 @@
   <!-- Require license headers (GPL, AGPL or Apache 2.0) -->
   <module name="RegexpSingleline">
     <property name="format"
-              value="^(\s|\*)*Copyright \(c\) 2018-[0-9]{4} &quot;Graph Foundation,&quot;*$"/>
+              value="^(\s|\*)*Copyright \(c\) &quot;Graph Foundation,&quot;*$"/>
     <property name="minimum" value="1"/>
     <property name="maximum" value="1"/>
     <property name="message" value="Missing, wrong or duplicated license header"/>

--- a/build-resources/src/main/resources/headers/AGPL-3-header.txt
+++ b/build-resources/src/main/resources/headers/AGPL-3-header.txt
@@ -1,4 +1,4 @@
-Copyright (c) ${project.inceptionYear}-${currentYear} "Graph Foundation,"
+Copyright (c) "Graph Foundation,"
 Graph Foundation, Inc. [https://graphfoundation.org]
 
 This file is part of ONgDB Enterprise Edition. The included source

--- a/build-resources/src/main/resources/headers/ASL-2-header.txt
+++ b/build-resources/src/main/resources/headers/ASL-2-header.txt
@@ -1,4 +1,4 @@
-Copyright (c) ${project.inceptionYear}-${currentYear} "Graph Foundation,"
+Copyright (c) "Graph Foundation,"
 Graph Foundation, Inc. [https://graphfoundation.org]
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/build-resources/src/main/resources/headers/GPL-3-header.txt
+++ b/build-resources/src/main/resources/headers/GPL-3-header.txt
@@ -1,4 +1,4 @@
-Copyright (c) ${project.inceptionYear}-${currentYear} "Graph Foundation,"
+Copyright (c) "Graph Foundation,"
 Graph Foundation, Inc. [https://graphfoundation.org]
 
 This file is part of ONgDB.

--- a/build-resources/src/main/resources/licensing/licensing-requirements-base.xml
+++ b/build-resources/src/main/resources/licensing/licensing-requirements-base.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018-2020 "Graph Foundation,"
+    Copyright (c) "Graph Foundation,"
     Graph Foundation, Inc. [https://graphfoundation.org]
 
     This file is part of ONgDB Enterprise Edition. The included source

--- a/build-resources/src/main/resources/licensing/licensing-requirements-browser.xml
+++ b/build-resources/src/main/resources/licensing/licensing-requirements-browser.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018-2020 "Graph Foundation,"
+    Copyright (c) "Graph Foundation,"
     Graph Foundation, Inc. [https://graphfoundation.org]
 
     This file is part of ONgDB Enterprise Edition. The included source

--- a/build-resources/src/main/resources/licensing/notice-agpl-prefix.txt
+++ b/build-resources/src/main/resources/licensing/notice-agpl-prefix.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/build-resources/src/main/resources/licensing/notice-asl-prefix.txt
+++ b/build-resources/src/main/resources/licensing/notice-asl-prefix.txt
@@ -1,5 +1,5 @@
 ONgBD
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/build-resources/src/main/resources/licensing/notice-gpl-prefix.txt
+++ b/build-resources/src/main/resources/licensing/notice-gpl-prefix.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/community/bolt/NOTICE.txt
+++ b/community/bolt/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/community/bolt/src/main/java/org/neo4j/bolt/BoltChannel.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/BoltChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/BoltConnectionDescriptor.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/BoltConnectionDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/BoltKernelExtension.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/BoltKernelExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/diagnostics/BoltDiagnosticsOfflineReportProvider.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/diagnostics/BoltDiagnosticsOfflineReportProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/logging/BoltMessageLog.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/logging/BoltMessageLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/logging/BoltMessageLogger.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/logging/BoltMessageLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/logging/BoltMessageLoggerImpl.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/logging/BoltMessageLoggerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/logging/BoltMessageLogging.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/logging/BoltMessageLogging.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/logging/NullBoltMessageLogger.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/logging/NullBoltMessageLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/messaging/StructType.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/messaging/StructType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/runtime/BoltConnection.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/runtime/BoltConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/runtime/BoltConnectionFactory.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/runtime/BoltConnectionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/runtime/BoltConnectionLifetimeListener.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/runtime/BoltConnectionLifetimeListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/runtime/BoltConnectionMetricsMonitor.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/runtime/BoltConnectionMetricsMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/runtime/BoltConnectionQueueMonitor.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/runtime/BoltConnectionQueueMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/runtime/BoltConnectionQueueMonitorAggregate.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/runtime/BoltConnectionQueueMonitorAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/runtime/BoltConnectionReadLimiter.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/runtime/BoltConnectionReadLimiter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/runtime/BoltScheduler.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/runtime/BoltScheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/runtime/BoltSchedulerProvider.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/runtime/BoltSchedulerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/runtime/CachedThreadPoolExecutorFactory.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/runtime/CachedThreadPoolExecutorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/runtime/DefaultBoltConnection.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/runtime/DefaultBoltConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/runtime/DefaultBoltConnectionFactory.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/runtime/DefaultBoltConnectionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/runtime/ExecutorBoltScheduler.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/runtime/ExecutorBoltScheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/runtime/ExecutorBoltSchedulerProvider.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/runtime/ExecutorBoltSchedulerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/runtime/ExecutorFactory.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/runtime/ExecutorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/runtime/MetricsReportingBoltConnection.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/runtime/MetricsReportingBoltConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/security/auth/Authentication.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/security/auth/Authentication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/security/auth/AuthenticationException.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/security/auth/AuthenticationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/security/auth/AuthenticationResult.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/security/auth/AuthenticationResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/security/auth/BasicAuthentication.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/security/auth/BasicAuthentication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/security/auth/BasicAuthenticationResult.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/security/auth/BasicAuthenticationResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/transport/BoltProtocolPipelineInstaller.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/transport/BoltProtocolPipelineInstaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/transport/BoltProtocolPipelineInstallerFactory.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/transport/BoltProtocolPipelineInstallerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/transport/DefaultBoltProtocolPipelineInstaller.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/transport/DefaultBoltProtocolPipelineInstaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/transport/DefaultBoltProtocolPipelineInstallerFactory.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/transport/DefaultBoltProtocolPipelineInstallerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/transport/DefaultThrottleLock.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/transport/DefaultThrottleLock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/transport/Netty4LoggerFactory.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/transport/Netty4LoggerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/transport/NettyServer.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/transport/NettyServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/transport/SocketTransport.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/transport/SocketTransport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/transport/ThrottleLock.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/transport/ThrottleLock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/transport/TransportSelectionHandler.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/transport/TransportSelectionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/transport/TransportThrottle.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/transport/TransportThrottle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/transport/TransportThrottleException.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/transport/TransportThrottleException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/transport/TransportThrottleGroup.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/transport/TransportThrottleGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/transport/TransportWriteThrottle.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/transport/TransportWriteThrottle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/transport/configuration/EpollConfigurationProvider.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/transport/configuration/EpollConfigurationProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/transport/configuration/NioConfigurationProvider.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/transport/configuration/NioConfigurationProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/transport/configuration/ServerConfigurationProvider.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/transport/configuration/ServerConfigurationProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/transport/pipeline/ChunkDecoder.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/transport/pipeline/ChunkDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/transport/pipeline/HouseKeeper.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/transport/pipeline/HouseKeeper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/transport/pipeline/MessageAccumulator.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/transport/pipeline/MessageAccumulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/transport/pipeline/MessageDecoder.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/transport/pipeline/MessageDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/transport/pipeline/ProtocolHandshaker.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/transport/pipeline/ProtocolHandshaker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/transport/pipeline/WebSocketFrameTranslator.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/transport/pipeline/WebSocketFrameTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/AuthTokenValuesWriter.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/AuthTokenValuesWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/BoltIOException.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/BoltIOException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/BoltMessageRouter.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/BoltMessageRouter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/BoltRequestMessage.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/BoltRequestMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/BoltRequestMessageHandler.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/BoltRequestMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/BoltRequestMessageReader.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/BoltRequestMessageReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/BoltResponseMessage.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/BoltResponseMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/BoltResponseMessageHandler.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/BoltResponseMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/BoltResponseMessageWriter.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/BoltResponseMessageWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/MessageProcessingHandler.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/MessageProcessingHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/Neo4jPack.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/Neo4jPack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/Neo4jPackV1.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/Neo4jPackV1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/packstream/ByteBufInput.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/packstream/ByteBufInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/packstream/PackInput.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/packstream/PackInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/packstream/PackOutput.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/packstream/PackOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/packstream/PackOutputClosedException.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/packstream/PackOutputClosedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/packstream/PackStream.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/packstream/PackStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/packstream/PackType.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/packstream/PackType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/packstream/PackedInputArray.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/packstream/PackedInputArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/packstream/utf8/SunMiscUTF8Encoder.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/packstream/utf8/SunMiscUTF8Encoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/packstream/utf8/UTF8Encoder.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/packstream/utf8/UTF8Encoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/packstream/utf8/VanillaUTF8Encoder.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/packstream/utf8/VanillaUTF8Encoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltConnectionAuthFatality.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltConnectionAuthFatality.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltConnectionFatality.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltConnectionFatality.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltFactory.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltFactoryImpl.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltFactoryImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltProtocolBreachFatality.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltProtocolBreachFatality.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltQuerySource.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltQuerySource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltResponseHandler.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltResponseHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltStateMachine.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltStateMachine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltStateMachineSPI.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltStateMachineSPI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/CypherAdapterStream.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/CypherAdapterStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/ErrorReporter.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/ErrorReporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/ExecutionPlanConverter.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/ExecutionPlanConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/Job.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/Job.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/Neo4jError.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/Neo4jError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/StatementMetadata.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/StatementMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/StatementProcessor.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/StatementProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/TransactionStateMachine.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/TransactionStateMachine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/TransactionStateMachineSPI.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/TransactionStateMachineSPI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/bookmarking/Bookmark.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/bookmarking/Bookmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/spi/BoltResult.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/spi/BoltResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/spi/BookmarkResult.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/spi/BookmarkResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/spi/ImmutableRecord.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/spi/ImmutableRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/spi/Record.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/spi/Record.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/spi/Records.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/spi/Records.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/transport/ChunkedOutput.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/transport/ChunkedOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/main/java/org/neo4j/bolt/v2/messaging/Neo4jPackV2.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v2/messaging/Neo4jPackV2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/AbstractBoltTransportsTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/AbstractBoltTransportsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/BoltChannelTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/BoltChannelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/logging/BoltMessageLoggerImplTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/logging/BoltMessageLoggerImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/logging/BoltMessageLoggingTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/logging/BoltMessageLoggingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/runtime/BoltConnectionQueueMonitorAggregateTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/runtime/BoltConnectionQueueMonitorAggregateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/runtime/BoltConnectionReadLimiterTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/runtime/BoltConnectionReadLimiterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/runtime/CachedThreadPoolExecutorFactoryTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/runtime/CachedThreadPoolExecutorFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/runtime/DefaultBoltConnectionTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/runtime/DefaultBoltConnectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/runtime/ExecutorBoltSchedulerConcurrencyTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/runtime/ExecutorBoltSchedulerConcurrencyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/runtime/ExecutorBoltSchedulerTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/runtime/ExecutorBoltSchedulerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/runtime/MetricsReportingBoltConnectionTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/runtime/MetricsReportingBoltConnectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/runtime/SynchronousBoltConnection.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/runtime/SynchronousBoltConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/runtime/integration/BoltSchedulerBusyIT.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/runtime/integration/BoltSchedulerBusyIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/security/auth/BasicAuthenticationTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/security/auth/BasicAuthenticationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/testing/BoltMatchers.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/testing/BoltMatchers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/testing/BoltResponseRecorder.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/testing/BoltResponseRecorder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/testing/BoltTestUtil.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/testing/BoltTestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/testing/Jobs.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/testing/Jobs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/testing/NullResponseHandler.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/testing/NullResponseHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/testing/RecordedBoltResponse.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/testing/RecordedBoltResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/transport/DefaultBoltProtocolPipelineInstallerFactoryTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/transport/DefaultBoltProtocolPipelineInstallerFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/transport/DefaultBoltProtocolPipelineInstallerTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/transport/DefaultBoltProtocolPipelineInstallerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/transport/TransportSelectionHandlerTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/transport/TransportSelectionHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/transport/TransportWriteThrottleTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/transport/TransportWriteThrottleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/transport/pipeline/ChunkDecoderTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/transport/pipeline/ChunkDecoderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/transport/pipeline/HouseKeeperTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/transport/pipeline/HouseKeeperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/transport/pipeline/MessageAccumulatorTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/transport/pipeline/MessageAccumulatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/transport/pipeline/MessageDecoderTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/transport/pipeline/MessageDecoderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/transport/pipeline/ProtocolHandshakerTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/transport/pipeline/ProtocolHandshakerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/AuthTokenValuesWriterTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/AuthTokenValuesWriterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/BoltRequestMessageRecorder.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/BoltRequestMessageRecorder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/BoltRequestMessageTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/BoltRequestMessageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/BoltRequestMessageWriter.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/BoltRequestMessageWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/BoltResponseMessageReader.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/BoltResponseMessageReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/BoltResponseMessageRecorder.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/BoltResponseMessageRecorder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/BoltResponseMessageTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/BoltResponseMessageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/BoltResponseMessageWriterTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/BoltResponseMessageWriterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/MessageProcessingHandlerTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/MessageProcessingHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/MessageRecorder.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/MessageRecorder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/Neo4jPackV1Test.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/Neo4jPackV1Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/RecordingByteChannel.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/RecordingByteChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/RecordingByteChannelTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/RecordingByteChannelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/example/Edges.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/example/Edges.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/example/Nodes.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/example/Nodes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/example/Paths.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/example/Paths.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/example/Support.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/example/Support.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/message/AckFailureMessage.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/message/AckFailureMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/message/DiscardAllMessage.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/message/DiscardAllMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/message/FailureMessage.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/message/FailureMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/message/IgnoredMessage.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/message/IgnoredMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/message/InitMessage.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/message/InitMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/message/PullAllMessage.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/message/PullAllMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/message/RecordMessage.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/message/RecordMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/message/RequestMessage.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/message/RequestMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/message/ResetMessage.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/message/ResetMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/message/ResponseMessage.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/message/ResponseMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/message/RunMessage.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/message/RunMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/message/SuccessMessage.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/message/SuccessMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/util/ArrayByteChannel.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/util/ArrayByteChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/util/MessageMatchers.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/util/MessageMatchers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/packstream/BufferedChannelInput.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/packstream/BufferedChannelInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/packstream/BufferedChannelOutput.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/packstream/BufferedChannelOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/packstream/PackStreamTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/packstream/PackStreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/packstream/PackedOutputArray.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/packstream/PackedOutputArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/packstream/utf8/UTF8EncoderTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/packstream/utf8/UTF8EncoderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/BoltFactoryImplTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/BoltFactoryImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/BoltStateMachineTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/BoltStateMachineTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/CypherAdapterStreamTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/CypherAdapterStreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/ErrorReporterTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/ErrorReporterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/ExecutionPlanConverterTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/ExecutionPlanConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/MachineRoom.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/MachineRoom.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/Neo4jErrorTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/Neo4jErrorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/ResetFuzzTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/ResetFuzzTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/TransactionStateMachineSPITest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/TransactionStateMachineSPITest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/TransactionStateMachineTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/TransactionStateMachineTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/bookmarking/BookmarkTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/bookmarking/BookmarkTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/BoltConfigIT.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/BoltConfigIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/BoltConnectionAuthIT.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/BoltConnectionAuthIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/BoltConnectionIT.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/BoltConnectionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/SessionRule.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/SessionRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/TransactionIT.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/TransactionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/spi/StreamMatchers.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/spi/StreamMatchers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/NettyServerTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/NettyServerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/AuthenticationIT.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/AuthenticationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/BoltChannelAutoReadLimiterIT.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/BoltChannelAutoReadLimiterIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/BoltThrottleMaxDurationIT.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/BoltThrottleMaxDurationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/ConcurrentAccessIT.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/ConcurrentAccessIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/ConnectionIT.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/ConnectionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/Neo4jWithSocket.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/Neo4jWithSocket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/RejectTransportEncryptionIT.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/RejectTransportEncryptionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/RequiredTransportEncryptionIT.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/RequiredTransportEncryptionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/TestNotification.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/TestNotification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/TransportErrorIT.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/TransportErrorIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/TransportSessionIT.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/TransportSessionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/TransportTestUtil.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/TransportTestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/UnsupportedStructTypesV1IT.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/UnsupportedStructTypesV1IT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/UnsupportedStructTypesV1V2IT.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/UnsupportedStructTypesV1V2IT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/socket/ChunkedOutputTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/socket/ChunkedOutputTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/socket/Chunker.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/socket/Chunker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/socket/FragmentedMessageDeliveryTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/socket/FragmentedMessageDeliveryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/socket/client/NaiveTrustManager.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/socket/client/NaiveTrustManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/socket/client/SecureSocketConnection.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/socket/client/SecureSocketConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/socket/client/SecureWebSocketConnection.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/socket/client/SecureWebSocketConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/socket/client/SocketConnection.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/socket/client/SocketConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/socket/client/SocketConnectionTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/socket/client/SocketConnectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/socket/client/TransportConnection.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/socket/client/TransportConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/socket/client/WebSocketConnection.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/socket/client/WebSocketConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/socket/client/WebSocketConnectionTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/socket/client/WebSocketConnectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v2/messaging/Neo4jPackV2Test.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v2/messaging/Neo4jPackV2Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v2/transport/integration/BoltV2TransportIT.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v2/transport/integration/BoltV2TransportIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/bolt/src/test/java/org/neo4j/bolt/v2/transport/integration/UnsupportedStructTypesV2IT.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v2/transport/integration/UnsupportedStructTypesV2IT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/codegen/NOTICE.txt
+++ b/community/codegen/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/community/codegen/src/main/java/org/neo4j/codegen/Binding.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/Binding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/codegen/src/main/java/org/neo4j/codegen/ByteCodeUtils.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/ByteCodeUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/codegen/src/main/java/org/neo4j/codegen/ByteCodeVisitor.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/ByteCodeVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/codegen/src/main/java/org/neo4j/codegen/ByteCodes.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/ByteCodes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/codegen/src/main/java/org/neo4j/codegen/CatchClause.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/CatchClause.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/codegen/src/main/java/org/neo4j/codegen/ClassEmitter.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/ClassEmitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/codegen/src/main/java/org/neo4j/codegen/ClassGenerator.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/ClassGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/codegen/src/main/java/org/neo4j/codegen/ClassHandle.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/ClassHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/codegen/src/main/java/org/neo4j/codegen/CodeBlock.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/CodeBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/codegen/src/main/java/org/neo4j/codegen/CodeGenerationNotSupportedException.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/CodeGenerationNotSupportedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/codegen/src/main/java/org/neo4j/codegen/CodeGenerationStrategy.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/CodeGenerationStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/codegen/src/main/java/org/neo4j/codegen/CodeGenerationStrategyNotSupportedException.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/CodeGenerationStrategyNotSupportedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/codegen/src/main/java/org/neo4j/codegen/CodeGenerator.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/CodeGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/codegen/src/main/java/org/neo4j/codegen/CodeGeneratorOption.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/CodeGeneratorOption.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/codegen/src/main/java/org/neo4j/codegen/CodeLoader.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/CodeLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/codegen/src/main/java/org/neo4j/codegen/CompilationFailureException.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/CompilationFailureException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/codegen/src/main/java/org/neo4j/codegen/DisassemblyVisitor.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/DisassemblyVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/codegen/src/main/java/org/neo4j/codegen/Expression.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/Expression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/codegen/src/main/java/org/neo4j/codegen/ExpressionTemplate.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/ExpressionTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/codegen/src/main/java/org/neo4j/codegen/ExpressionToString.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/ExpressionToString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/codegen/src/main/java/org/neo4j/codegen/ExpressionVisitor.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/ExpressionVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/codegen/src/main/java/org/neo4j/codegen/FieldReference.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/FieldReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/codegen/src/main/java/org/neo4j/codegen/InvalidState.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/InvalidState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/codegen/src/main/java/org/neo4j/codegen/LocalVariable.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/LocalVariable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/codegen/src/main/java/org/neo4j/codegen/LocalVariables.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/LocalVariables.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/codegen/src/main/java/org/neo4j/codegen/Lookup.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/Lookup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/codegen/src/main/java/org/neo4j/codegen/MethodDeclaration.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/MethodDeclaration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/codegen/src/main/java/org/neo4j/codegen/MethodEmitter.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/MethodEmitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/codegen/src/main/java/org/neo4j/codegen/MethodReference.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/MethodReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/codegen/src/main/java/org/neo4j/codegen/MethodTemplate.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/MethodTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/codegen/src/main/java/org/neo4j/codegen/Parameter.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/Parameter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/codegen/src/main/java/org/neo4j/codegen/Resource.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/Resource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/codegen/src/main/java/org/neo4j/codegen/Statement.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/Statement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/codegen/src/main/java/org/neo4j/codegen/TypeReference.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/TypeReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/codegen/src/main/java/org/neo4j/codegen/bytecode/Block.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/bytecode/Block.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/codegen/src/main/java/org/neo4j/codegen/bytecode/ByteCode.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/bytecode/ByteCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/codegen/src/main/java/org/neo4j/codegen/bytecode/ByteCodeChecker.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/bytecode/ByteCodeChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/codegen/src/main/java/org/neo4j/codegen/bytecode/ByteCodeExpressionVisitor.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/bytecode/ByteCodeExpressionVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/codegen/src/main/java/org/neo4j/codegen/bytecode/ByteCodeGenerator.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/bytecode/ByteCodeGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/codegen/src/main/java/org/neo4j/codegen/bytecode/ByteCodeVerifier.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/bytecode/ByteCodeVerifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/codegen/src/main/java/org/neo4j/codegen/bytecode/BytecodeDiagnostic.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/bytecode/BytecodeDiagnostic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/codegen/src/main/java/org/neo4j/codegen/bytecode/ClassByteCodeWriter.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/bytecode/ClassByteCodeWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/codegen/src/main/java/org/neo4j/codegen/bytecode/Configuration.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/bytecode/Configuration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/codegen/src/main/java/org/neo4j/codegen/bytecode/If.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/bytecode/If.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/codegen/src/main/java/org/neo4j/codegen/bytecode/JumpVisitor.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/bytecode/JumpVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/codegen/src/main/java/org/neo4j/codegen/bytecode/Method.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/bytecode/Method.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/codegen/src/main/java/org/neo4j/codegen/bytecode/MethodByteCodeEmitter.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/bytecode/MethodByteCodeEmitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/codegen/src/main/java/org/neo4j/codegen/bytecode/While.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/bytecode/While.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/codegen/src/main/java/org/neo4j/codegen/source/BaseUri.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/source/BaseUri.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/codegen/src/main/java/org/neo4j/codegen/source/ClassSourceWriter.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/source/ClassSourceWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/codegen/src/main/java/org/neo4j/codegen/source/ClasspathHelper.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/source/ClasspathHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/codegen/src/main/java/org/neo4j/codegen/source/Configuration.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/source/Configuration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/codegen/src/main/java/org/neo4j/codegen/source/FileManager.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/source/FileManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/codegen/src/main/java/org/neo4j/codegen/source/JavaSourceFile.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/source/JavaSourceFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/codegen/src/main/java/org/neo4j/codegen/source/JdkCompiler.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/source/JdkCompiler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/codegen/src/main/java/org/neo4j/codegen/source/MethodSourceWriter.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/source/MethodSourceWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/codegen/src/main/java/org/neo4j/codegen/source/SourceCode.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/source/SourceCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/codegen/src/main/java/org/neo4j/codegen/source/SourceCodeGenerator.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/source/SourceCodeGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/codegen/src/main/java/org/neo4j/codegen/source/SourceCompiler.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/source/SourceCompiler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/codegen/src/main/java/org/neo4j/codegen/source/SourceVisitor.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/source/SourceVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/codegen/src/main/java/org/neo4j/codegen/source/WarningsHandler.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/source/WarningsHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/codegen/src/test/java/org/neo4j/codegen/ByteCodeUtilsTest.java
+++ b/community/codegen/src/test/java/org/neo4j/codegen/ByteCodeUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/codegen/src/test/java/org/neo4j/codegen/CodeGenerationTest.java
+++ b/community/codegen/src/test/java/org/neo4j/codegen/CodeGenerationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/codegen/src/test/java/org/neo4j/codegen/ExpressionTest.java
+++ b/community/codegen/src/test/java/org/neo4j/codegen/ExpressionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/codegen/src/test/java/org/neo4j/codegen/bytecode/ByteCodeVerifierTest.java
+++ b/community/codegen/src/test/java/org/neo4j/codegen/bytecode/ByteCodeVerifierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/codegen/src/test/java/org/neo4j/codegen/source/ClasspathHelperTest.java
+++ b/community/codegen/src/test/java/org/neo4j/codegen/source/ClasspathHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/collections/NOTICE.txt
+++ b/community/collections/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/community/collections/src/main/java/org/neo4j/collection/PrefetchingRawIterator.java
+++ b/community/collections/src/main/java/org/neo4j/collection/PrefetchingRawIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/collections/src/main/java/org/neo4j/collection/RawIterator.java
+++ b/community/collections/src/main/java/org/neo4j/collection/RawIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/collections/src/main/java/org/neo4j/helpers/collection/ArrayIterator.java
+++ b/community/collections/src/main/java/org/neo4j/helpers/collection/ArrayIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/collections/src/main/java/org/neo4j/helpers/collection/CachingIterator.java
+++ b/community/collections/src/main/java/org/neo4j/helpers/collection/CachingIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/collections/src/main/java/org/neo4j/helpers/collection/CastingIterator.java
+++ b/community/collections/src/main/java/org/neo4j/helpers/collection/CastingIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/collections/src/main/java/org/neo4j/helpers/collection/CatchingIteratorWrapper.java
+++ b/community/collections/src/main/java/org/neo4j/helpers/collection/CatchingIteratorWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/collections/src/main/java/org/neo4j/helpers/collection/CollectorsUtil.java
+++ b/community/collections/src/main/java/org/neo4j/helpers/collection/CollectorsUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/collections/src/main/java/org/neo4j/helpers/collection/CombiningIterable.java
+++ b/community/collections/src/main/java/org/neo4j/helpers/collection/CombiningIterable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/collections/src/main/java/org/neo4j/helpers/collection/CombiningIterator.java
+++ b/community/collections/src/main/java/org/neo4j/helpers/collection/CombiningIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/collections/src/main/java/org/neo4j/helpers/collection/CombiningResourceIterator.java
+++ b/community/collections/src/main/java/org/neo4j/helpers/collection/CombiningResourceIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/collections/src/main/java/org/neo4j/helpers/collection/ExceptionHandlingIterable.java
+++ b/community/collections/src/main/java/org/neo4j/helpers/collection/ExceptionHandlingIterable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/collections/src/main/java/org/neo4j/helpers/collection/FilterIterable.java
+++ b/community/collections/src/main/java/org/neo4j/helpers/collection/FilterIterable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/collections/src/main/java/org/neo4j/helpers/collection/FilteringIterable.java
+++ b/community/collections/src/main/java/org/neo4j/helpers/collection/FilteringIterable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/collections/src/main/java/org/neo4j/helpers/collection/FilteringIterator.java
+++ b/community/collections/src/main/java/org/neo4j/helpers/collection/FilteringIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/collections/src/main/java/org/neo4j/helpers/collection/FirstItemIterable.java
+++ b/community/collections/src/main/java/org/neo4j/helpers/collection/FirstItemIterable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/collections/src/main/java/org/neo4j/helpers/collection/IterableWrapper.java
+++ b/community/collections/src/main/java/org/neo4j/helpers/collection/IterableWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/collections/src/main/java/org/neo4j/helpers/collection/Iterables.java
+++ b/community/collections/src/main/java/org/neo4j/helpers/collection/Iterables.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/collections/src/main/java/org/neo4j/helpers/collection/IteratorWrapper.java
+++ b/community/collections/src/main/java/org/neo4j/helpers/collection/IteratorWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/collections/src/main/java/org/neo4j/helpers/collection/Iterators.java
+++ b/community/collections/src/main/java/org/neo4j/helpers/collection/Iterators.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/collections/src/main/java/org/neo4j/helpers/collection/LimitingResourceIterable.java
+++ b/community/collections/src/main/java/org/neo4j/helpers/collection/LimitingResourceIterable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/collections/src/main/java/org/neo4j/helpers/collection/LimitingResourceIterator.java
+++ b/community/collections/src/main/java/org/neo4j/helpers/collection/LimitingResourceIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/collections/src/main/java/org/neo4j/helpers/collection/LruCache.java
+++ b/community/collections/src/main/java/org/neo4j/helpers/collection/LruCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/collections/src/main/java/org/neo4j/helpers/collection/MapIterable.java
+++ b/community/collections/src/main/java/org/neo4j/helpers/collection/MapIterable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/collections/src/main/java/org/neo4j/helpers/collection/MapUtil.java
+++ b/community/collections/src/main/java/org/neo4j/helpers/collection/MapUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/collections/src/main/java/org/neo4j/helpers/collection/MappingResourceIterator.java
+++ b/community/collections/src/main/java/org/neo4j/helpers/collection/MappingResourceIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/collections/src/main/java/org/neo4j/helpers/collection/MultiSet.java
+++ b/community/collections/src/main/java/org/neo4j/helpers/collection/MultiSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/collections/src/main/java/org/neo4j/helpers/collection/NestingIterable.java
+++ b/community/collections/src/main/java/org/neo4j/helpers/collection/NestingIterable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/collections/src/main/java/org/neo4j/helpers/collection/NestingIterator.java
+++ b/community/collections/src/main/java/org/neo4j/helpers/collection/NestingIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/collections/src/main/java/org/neo4j/helpers/collection/NestingResourceIterator.java
+++ b/community/collections/src/main/java/org/neo4j/helpers/collection/NestingResourceIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/collections/src/main/java/org/neo4j/helpers/collection/PagingIterator.java
+++ b/community/collections/src/main/java/org/neo4j/helpers/collection/PagingIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/collections/src/main/java/org/neo4j/helpers/collection/Pair.java
+++ b/community/collections/src/main/java/org/neo4j/helpers/collection/Pair.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/collections/src/main/java/org/neo4j/helpers/collection/PrefetchingIterator.java
+++ b/community/collections/src/main/java/org/neo4j/helpers/collection/PrefetchingIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/collections/src/main/java/org/neo4j/helpers/collection/PrefetchingResourceIterator.java
+++ b/community/collections/src/main/java/org/neo4j/helpers/collection/PrefetchingResourceIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/collections/src/main/java/org/neo4j/helpers/collection/RangeIterator.java
+++ b/community/collections/src/main/java/org/neo4j/helpers/collection/RangeIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/collections/src/main/java/org/neo4j/helpers/collection/RawMapIterator.java
+++ b/community/collections/src/main/java/org/neo4j/helpers/collection/RawMapIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/collections/src/main/java/org/neo4j/helpers/collection/ResourceClosingIterator.java
+++ b/community/collections/src/main/java/org/neo4j/helpers/collection/ResourceClosingIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/collections/src/main/java/org/neo4j/helpers/collection/ResourceIterableWrapper.java
+++ b/community/collections/src/main/java/org/neo4j/helpers/collection/ResourceIterableWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/collections/src/main/java/org/neo4j/helpers/collection/ReverseArrayIterator.java
+++ b/community/collections/src/main/java/org/neo4j/helpers/collection/ReverseArrayIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/collections/src/main/java/org/neo4j/helpers/collection/Visitable.java
+++ b/community/collections/src/main/java/org/neo4j/helpers/collection/Visitable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/collections/src/main/java/org/neo4j/helpers/collection/Visitor.java
+++ b/community/collections/src/main/java/org/neo4j/helpers/collection/Visitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/collections/src/main/java/org/neo4j/helpers/collection/WrappingResourceIterator.java
+++ b/community/collections/src/main/java/org/neo4j/helpers/collection/WrappingResourceIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/collections/src/main/java/org/neo4j/helpers/collection/package-info.java
+++ b/community/collections/src/main/java/org/neo4j/helpers/collection/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/collections/src/test/java/org/neo4j/collection/RawIteratorTest.java
+++ b/community/collections/src/test/java/org/neo4j/collection/RawIteratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/collections/src/test/java/org/neo4j/helpers/collection/CombiningResourceIteratorTest.java
+++ b/community/collections/src/test/java/org/neo4j/helpers/collection/CombiningResourceIteratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/collections/src/test/java/org/neo4j/helpers/collection/ExceptionHandlingIterableTest.java
+++ b/community/collections/src/test/java/org/neo4j/helpers/collection/ExceptionHandlingIterableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/collections/src/test/java/org/neo4j/helpers/collection/FirstItemIterableTest.java
+++ b/community/collections/src/test/java/org/neo4j/helpers/collection/FirstItemIterableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/collections/src/test/java/org/neo4j/helpers/collection/LruCacheTest.java
+++ b/community/collections/src/test/java/org/neo4j/helpers/collection/LruCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/collections/src/test/java/org/neo4j/helpers/collection/MapUtilTest.java
+++ b/community/collections/src/test/java/org/neo4j/helpers/collection/MapUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/collections/src/test/java/org/neo4j/helpers/collection/MultiSetTest.java
+++ b/community/collections/src/test/java/org/neo4j/helpers/collection/MultiSetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/collections/src/test/java/org/neo4j/helpers/collection/TestCommonIterators.java
+++ b/community/collections/src/test/java/org/neo4j/helpers/collection/TestCommonIterators.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/command-line/NOTICE.txt
+++ b/community/command-line/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/community/command-line/src/main/java/org/neo4j/commandline/Util.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/Util.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/AdminCommand.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/AdminCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/AdminCommandSection.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/AdminCommandSection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/AdminTool.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/AdminTool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/BlockerLocator.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/BlockerLocator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/CommandFailed.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/CommandFailed.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/CommandLocator.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/CommandLocator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/CommandUsage.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/CommandUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/HelpCommand.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/HelpCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/HelpCommandProvider.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/HelpCommandProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/IncorrectUsage.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/IncorrectUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/OutsideWorld.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/OutsideWorld.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/ParameterisedOutsideWorld.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/ParameterisedOutsideWorld.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/RealOutsideWorld.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/RealOutsideWorld.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/Usage.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/Usage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/command-line/src/main/java/org/neo4j/commandline/arguments/Arguments.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/arguments/Arguments.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/command-line/src/main/java/org/neo4j/commandline/arguments/MandatoryNamedArg.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/arguments/MandatoryNamedArg.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/command-line/src/main/java/org/neo4j/commandline/arguments/MandatoryPositionalArgument.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/arguments/MandatoryPositionalArgument.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/command-line/src/main/java/org/neo4j/commandline/arguments/NamedArgument.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/arguments/NamedArgument.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/command-line/src/main/java/org/neo4j/commandline/arguments/OptionalBooleanArg.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/arguments/OptionalBooleanArg.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/command-line/src/main/java/org/neo4j/commandline/arguments/OptionalNamedArg.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/arguments/OptionalNamedArg.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/command-line/src/main/java/org/neo4j/commandline/arguments/OptionalNamedArgWithMetadata.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/arguments/OptionalNamedArgWithMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/command-line/src/main/java/org/neo4j/commandline/arguments/OptionalPositionalArgument.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/arguments/OptionalPositionalArgument.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/command-line/src/main/java/org/neo4j/commandline/arguments/PositionalArgument.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/arguments/PositionalArgument.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/command-line/src/main/java/org/neo4j/commandline/arguments/common/Database.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/arguments/common/Database.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/command-line/src/main/java/org/neo4j/commandline/arguments/common/MandatoryCanonicalPath.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/arguments/common/MandatoryCanonicalPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/command-line/src/main/java/org/neo4j/commandline/arguments/common/OptionalCanonicalPath.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/arguments/common/OptionalCanonicalPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/command-line/src/test/java/org/neo4j/commandline/admin/AdminCommandSectionTest.java
+++ b/community/command-line/src/test/java/org/neo4j/commandline/admin/AdminCommandSectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/command-line/src/test/java/org/neo4j/commandline/admin/AdminToolTest.java
+++ b/community/command-line/src/test/java/org/neo4j/commandline/admin/AdminToolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/command-line/src/test/java/org/neo4j/commandline/admin/CannedLocator.java
+++ b/community/command-line/src/test/java/org/neo4j/commandline/admin/CannedLocator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/command-line/src/test/java/org/neo4j/commandline/admin/HelpCommandTest.java
+++ b/community/command-line/src/test/java/org/neo4j/commandline/admin/HelpCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/command-line/src/test/java/org/neo4j/commandline/admin/NullOutsideWorld.java
+++ b/community/command-line/src/test/java/org/neo4j/commandline/admin/NullOutsideWorld.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/command-line/src/test/java/org/neo4j/commandline/admin/RealOutsideWorldTest.java
+++ b/community/command-line/src/test/java/org/neo4j/commandline/admin/RealOutsideWorldTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/command-line/src/test/java/org/neo4j/commandline/admin/UsageTest.java
+++ b/community/command-line/src/test/java/org/neo4j/commandline/admin/UsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/command-line/src/test/java/org/neo4j/commandline/arguments/ArgumentsTest.java
+++ b/community/command-line/src/test/java/org/neo4j/commandline/arguments/ArgumentsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/command-line/src/test/java/org/neo4j/commandline/arguments/OptionalBooleanArgTest.java
+++ b/community/command-line/src/test/java/org/neo4j/commandline/arguments/OptionalBooleanArgTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/command-line/src/test/java/org/neo4j/commandline/arguments/common/DatabaseTest.java
+++ b/community/command-line/src/test/java/org/neo4j/commandline/arguments/common/DatabaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/NOTICE.txt
+++ b/community/common/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/community/common/src/main/java/org/neo4j/function/Factory.java
+++ b/community/common/src/main/java/org/neo4j/function/Factory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/main/java/org/neo4j/function/FailableConsumer.java
+++ b/community/common/src/main/java/org/neo4j/function/FailableConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/main/java/org/neo4j/function/IOFunction.java
+++ b/community/common/src/main/java/org/neo4j/function/IOFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/main/java/org/neo4j/function/IOFunctions.java
+++ b/community/common/src/main/java/org/neo4j/function/IOFunctions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/main/java/org/neo4j/function/Predicates.java
+++ b/community/common/src/main/java/org/neo4j/function/Predicates.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/main/java/org/neo4j/function/Suppliers.java
+++ b/community/common/src/main/java/org/neo4j/function/Suppliers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/main/java/org/neo4j/function/ThrowingAction.java
+++ b/community/common/src/main/java/org/neo4j/function/ThrowingAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/main/java/org/neo4j/function/ThrowingBiConsumer.java
+++ b/community/common/src/main/java/org/neo4j/function/ThrowingBiConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/main/java/org/neo4j/function/ThrowingBooleanSupplier.java
+++ b/community/common/src/main/java/org/neo4j/function/ThrowingBooleanSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/main/java/org/neo4j/function/ThrowingConsumer.java
+++ b/community/common/src/main/java/org/neo4j/function/ThrowingConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/main/java/org/neo4j/function/ThrowingFunction.java
+++ b/community/common/src/main/java/org/neo4j/function/ThrowingFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/main/java/org/neo4j/function/ThrowingLongFunction.java
+++ b/community/common/src/main/java/org/neo4j/function/ThrowingLongFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/main/java/org/neo4j/function/ThrowingPredicate.java
+++ b/community/common/src/main/java/org/neo4j/function/ThrowingPredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/main/java/org/neo4j/function/ThrowingSupplier.java
+++ b/community/common/src/main/java/org/neo4j/function/ThrowingSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/main/java/org/neo4j/function/UncaughtCheckedException.java
+++ b/community/common/src/main/java/org/neo4j/function/UncaughtCheckedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/main/java/org/neo4j/hashing/HashFunction.java
+++ b/community/common/src/main/java/org/neo4j/hashing/HashFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/main/java/org/neo4j/hashing/IncrementalXXH64.java
+++ b/community/common/src/main/java/org/neo4j/hashing/IncrementalXXH64.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/main/java/org/neo4j/hashing/JavaUtilHashFunction.java
+++ b/community/common/src/main/java/org/neo4j/hashing/JavaUtilHashFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/main/java/org/neo4j/hashing/XorShift32HashFunction.java
+++ b/community/common/src/main/java/org/neo4j/hashing/XorShift32HashFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/main/java/org/neo4j/helpers/Exceptions.java
+++ b/community/common/src/main/java/org/neo4j/helpers/Exceptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/main/java/org/neo4j/helpers/MathUtil.java
+++ b/community/common/src/main/java/org/neo4j/helpers/MathUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/main/java/org/neo4j/helpers/Numbers.java
+++ b/community/common/src/main/java/org/neo4j/helpers/Numbers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/main/java/org/neo4j/helpers/TextUtil.java
+++ b/community/common/src/main/java/org/neo4j/helpers/TextUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
+++ b/community/common/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/main/java/org/neo4j/kernel/lifecycle/LifeSupport.java
+++ b/community/common/src/main/java/org/neo4j/kernel/lifecycle/LifeSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/main/java/org/neo4j/kernel/lifecycle/Lifecycle.java
+++ b/community/common/src/main/java/org/neo4j/kernel/lifecycle/Lifecycle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/main/java/org/neo4j/kernel/lifecycle/LifecycleAdapter.java
+++ b/community/common/src/main/java/org/neo4j/kernel/lifecycle/LifecycleAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/main/java/org/neo4j/kernel/lifecycle/LifecycleException.java
+++ b/community/common/src/main/java/org/neo4j/kernel/lifecycle/LifecycleException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/main/java/org/neo4j/kernel/lifecycle/LifecycleListener.java
+++ b/community/common/src/main/java/org/neo4j/kernel/lifecycle/LifecycleListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/main/java/org/neo4j/kernel/lifecycle/LifecycleStatus.java
+++ b/community/common/src/main/java/org/neo4j/kernel/lifecycle/LifecycleStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/main/java/org/neo4j/kernel/lifecycle/Lifecycles.java
+++ b/community/common/src/main/java/org/neo4j/kernel/lifecycle/Lifecycles.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/main/java/org/neo4j/kernel/lifecycle/Lifespan.java
+++ b/community/common/src/main/java/org/neo4j/kernel/lifecycle/Lifespan.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/main/java/org/neo4j/kernel/lifecycle/SafeLifecycle.java
+++ b/community/common/src/main/java/org/neo4j/kernel/lifecycle/SafeLifecycle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/main/java/org/neo4j/memory/GlobalMemoryTracker.java
+++ b/community/common/src/main/java/org/neo4j/memory/GlobalMemoryTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/main/java/org/neo4j/memory/LocalMemoryTracker.java
+++ b/community/common/src/main/java/org/neo4j/memory/LocalMemoryTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/main/java/org/neo4j/memory/MemoryAllocationTracker.java
+++ b/community/common/src/main/java/org/neo4j/memory/MemoryAllocationTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/main/java/org/neo4j/memory/MemoryTracker.java
+++ b/community/common/src/main/java/org/neo4j/memory/MemoryTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/main/java/org/neo4j/resources/CpuClock.java
+++ b/community/common/src/main/java/org/neo4j/resources/CpuClock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/main/java/org/neo4j/resources/HeapAllocation.java
+++ b/community/common/src/main/java/org/neo4j/resources/HeapAllocation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/main/java/org/neo4j/resources/SunManagementHeapAllocation.java
+++ b/community/common/src/main/java/org/neo4j/resources/SunManagementHeapAllocation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/main/java/org/neo4j/scheduler/JobScheduler.java
+++ b/community/common/src/main/java/org/neo4j/scheduler/JobScheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/main/java/org/neo4j/scheduler/LockingExecutor.java
+++ b/community/common/src/main/java/org/neo4j/scheduler/LockingExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/main/java/org/neo4j/stream/Streams.java
+++ b/community/common/src/main/java/org/neo4j/stream/Streams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/main/java/org/neo4j/string/HexString.java
+++ b/community/common/src/main/java/org/neo4j/string/HexString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/main/java/org/neo4j/string/UTF8.java
+++ b/community/common/src/main/java/org/neo4j/string/UTF8.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/main/java/org/neo4j/time/Clocks.java
+++ b/community/common/src/main/java/org/neo4j/time/Clocks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/main/java/org/neo4j/time/FakeClock.java
+++ b/community/common/src/main/java/org/neo4j/time/FakeClock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/main/java/org/neo4j/time/SystemNanoClock.java
+++ b/community/common/src/main/java/org/neo4j/time/SystemNanoClock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/main/java/org/neo4j/time/TickOnAccessClock.java
+++ b/community/common/src/main/java/org/neo4j/time/TickOnAccessClock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/main/java/org/neo4j/util/FeatureToggles.java
+++ b/community/common/src/main/java/org/neo4j/util/FeatureToggles.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/main/java/org/neo4j/util/Preconditions.java
+++ b/community/common/src/main/java/org/neo4j/util/Preconditions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/main/java/org/neo4j/util/VisibleForTesting.java
+++ b/community/common/src/main/java/org/neo4j/util/VisibleForTesting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/test/java/org/neo4j/function/SuppliersTest.java
+++ b/community/common/src/test/java/org/neo4j/function/SuppliersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/test/java/org/neo4j/helpers/NumbersTest.java
+++ b/community/common/src/test/java/org/neo4j/helpers/NumbersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/test/java/org/neo4j/helpers/TextUtilTest.java
+++ b/community/common/src/test/java/org/neo4j/helpers/TextUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/test/java/org/neo4j/kernel/lifecycle/LifeRule.java
+++ b/community/common/src/test/java/org/neo4j/kernel/lifecycle/LifeRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/test/java/org/neo4j/kernel/lifecycle/LifeSupportTest.java
+++ b/community/common/src/test/java/org/neo4j/kernel/lifecycle/LifeSupportTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/test/java/org/neo4j/kernel/lifecycle/SafeLifecycleTest.java
+++ b/community/common/src/test/java/org/neo4j/kernel/lifecycle/SafeLifecycleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/test/java/org/neo4j/kernel/lifecycle/TestLifecycleException.java
+++ b/community/common/src/test/java/org/neo4j/kernel/lifecycle/TestLifecycleException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/test/java/org/neo4j/memory/GlobalMemoryTrackerTest.java
+++ b/community/common/src/test/java/org/neo4j/memory/GlobalMemoryTrackerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/test/java/org/neo4j/memory/LocalMemoryTrackerTest.java
+++ b/community/common/src/test/java/org/neo4j/memory/LocalMemoryTrackerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/test/java/org/neo4j/ports/allocation/CoordinatingPortProvider.java
+++ b/community/common/src/test/java/org/neo4j/ports/allocation/CoordinatingPortProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/test/java/org/neo4j/ports/allocation/CoordinatingPortProviderTest.java
+++ b/community/common/src/test/java/org/neo4j/ports/allocation/CoordinatingPortProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/test/java/org/neo4j/ports/allocation/DefaultPortProbe.java
+++ b/community/common/src/test/java/org/neo4j/ports/allocation/DefaultPortProbe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/test/java/org/neo4j/ports/allocation/PortAuthority.java
+++ b/community/common/src/test/java/org/neo4j/ports/allocation/PortAuthority.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/test/java/org/neo4j/ports/allocation/PortConstants.java
+++ b/community/common/src/test/java/org/neo4j/ports/allocation/PortConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/test/java/org/neo4j/ports/allocation/PortProbe.java
+++ b/community/common/src/test/java/org/neo4j/ports/allocation/PortProbe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/test/java/org/neo4j/ports/allocation/PortProvider.java
+++ b/community/common/src/test/java/org/neo4j/ports/allocation/PortProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/test/java/org/neo4j/ports/allocation/PortRepository.java
+++ b/community/common/src/test/java/org/neo4j/ports/allocation/PortRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/test/java/org/neo4j/ports/allocation/PortRepositoryIT.java
+++ b/community/common/src/test/java/org/neo4j/ports/allocation/PortRepositoryIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/test/java/org/neo4j/ports/allocation/SimplePortProvider.java
+++ b/community/common/src/test/java/org/neo4j/ports/allocation/SimplePortProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/test/java/org/neo4j/ports/allocation/SimplePortProviderTest.java
+++ b/community/common/src/test/java/org/neo4j/ports/allocation/SimplePortProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/test/java/org/neo4j/resources/SunManagementHeapAllocationTest.java
+++ b/community/common/src/test/java/org/neo4j/resources/SunManagementHeapAllocationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/test/java/org/neo4j/scheduler/JobSchedulerAdapter.java
+++ b/community/common/src/test/java/org/neo4j/scheduler/JobSchedulerAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/test/java/org/neo4j/string/HexStringTest.java
+++ b/community/common/src/test/java/org/neo4j/string/HexStringTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/test/java/org/neo4j/test/Barrier.java
+++ b/community/common/src/test/java/org/neo4j/test/Barrier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/test/java/org/neo4j/test/OtherThreadExecutor.java
+++ b/community/common/src/test/java/org/neo4j/test/OtherThreadExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/test/java/org/neo4j/test/Race.java
+++ b/community/common/src/test/java/org/neo4j/test/Race.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/test/java/org/neo4j/test/Randoms.java
+++ b/community/common/src/test/java/org/neo4j/test/Randoms.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/test/java/org/neo4j/test/matchers/ByteArrayMatcher.java
+++ b/community/common/src/test/java/org/neo4j/test/matchers/ByteArrayMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/test/java/org/neo4j/test/matchers/CommonMatchers.java
+++ b/community/common/src/test/java/org/neo4j/test/matchers/CommonMatchers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/test/java/org/neo4j/test/matchers/ExceptionMessageMatcher.java
+++ b/community/common/src/test/java/org/neo4j/test/matchers/ExceptionMessageMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/test/java/org/neo4j/test/matchers/NestedThrowableMatcher.java
+++ b/community/common/src/test/java/org/neo4j/test/matchers/NestedThrowableMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/test/java/org/neo4j/test/matchers/matchertests/ByteArrayMatcherTest.java
+++ b/community/common/src/test/java/org/neo4j/test/matchers/matchertests/ByteArrayMatcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/test/java/org/neo4j/test/matchers/matchertests/package-info.java
+++ b/community/common/src/test/java/org/neo4j/test/matchers/matchertests/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/test/java/org/neo4j/test/rule/ExternalResource.java
+++ b/community/common/src/test/java/org/neo4j/test/rule/ExternalResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/test/java/org/neo4j/test/rule/RandomRule.java
+++ b/community/common/src/test/java/org/neo4j/test/rule/RandomRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/test/java/org/neo4j/test/rule/RepeatRule.java
+++ b/community/common/src/test/java/org/neo4j/test/rule/RepeatRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/test/java/org/neo4j/test/rule/SuppressOutput.java
+++ b/community/common/src/test/java/org/neo4j/test/rule/SuppressOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/test/java/org/neo4j/test/rule/concurrent/OtherThreadRule.java
+++ b/community/common/src/test/java/org/neo4j/test/rule/concurrent/OtherThreadRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/common/src/test/java/org/neo4j/util/PreconditionsTest.java
+++ b/community/common/src/test/java/org/neo4j/util/PreconditionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/configuration/NOTICE.txt
+++ b/community/configuration/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/community/configuration/src/main/java/org/neo4j/configuration/ConfigOptions.java
+++ b/community/configuration/src/main/java/org/neo4j/configuration/ConfigOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/configuration/src/main/java/org/neo4j/configuration/ConfigValue.java
+++ b/community/configuration/src/main/java/org/neo4j/configuration/ConfigValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/configuration/src/main/java/org/neo4j/configuration/Description.java
+++ b/community/configuration/src/main/java/org/neo4j/configuration/Description.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/configuration/src/main/java/org/neo4j/configuration/DocumentedDefaultValue.java
+++ b/community/configuration/src/main/java/org/neo4j/configuration/DocumentedDefaultValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/configuration/src/main/java/org/neo4j/configuration/Dynamic.java
+++ b/community/configuration/src/main/java/org/neo4j/configuration/Dynamic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/configuration/src/main/java/org/neo4j/configuration/ExternalSettings.java
+++ b/community/configuration/src/main/java/org/neo4j/configuration/ExternalSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/configuration/src/main/java/org/neo4j/configuration/Internal.java
+++ b/community/configuration/src/main/java/org/neo4j/configuration/Internal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/configuration/src/main/java/org/neo4j/configuration/LoadableConfig.java
+++ b/community/configuration/src/main/java/org/neo4j/configuration/LoadableConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/configuration/src/main/java/org/neo4j/configuration/ReplacedBy.java
+++ b/community/configuration/src/main/java/org/neo4j/configuration/ReplacedBy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/configuration/src/main/java/org/neo4j/configuration/Secret.java
+++ b/community/configuration/src/main/java/org/neo4j/configuration/Secret.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/configuration/src/test/java/org/neo4j/configuration/ConfigOptionsTest.java
+++ b/community/configuration/src/test/java/org/neo4j/configuration/ConfigOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/configuration/src/test/java/org/neo4j/configuration/ConfigValueTest.java
+++ b/community/configuration/src/test/java/org/neo4j/configuration/ConfigValueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/configuration/src/test/java/org/neo4j/configuration/LoadableConfigTest.java
+++ b/community/configuration/src/test/java/org/neo4j/configuration/LoadableConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/NOTICE.txt
+++ b/community/consistency-check/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/CheckConsistencyCommand.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/CheckConsistencyCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/CheckConsistencyCommandProvider.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/CheckConsistencyCommandProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/ConsistencyCheckService.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/ConsistencyCheckService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/ConsistencyCheckSettings.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/ConsistencyCheckSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/ConsistencyCheckTool.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/ConsistencyCheckTool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/ConsistencyCheckingError.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/ConsistencyCheckingError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/ConsistencyReportLog.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/ConsistencyReportLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/ConsistencyReportLogger.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/ConsistencyReportLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/RecordType.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/RecordType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/AbstractStoreProcessor.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/AbstractStoreProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/ChainCheck.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/ChainCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/CheckDecorator.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/CheckDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/CheckerEngine.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/CheckerEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/ComparativeRecordChecker.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/ComparativeRecordChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/DynamicRecordCheck.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/DynamicRecordCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/DynamicStore.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/DynamicStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/InconsistentStoreException.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/InconsistentStoreException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/LabelChainWalker.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/LabelChainWalker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/LabelTokenRecordCheck.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/LabelTokenRecordCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/NeoStoreCheck.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/NeoStoreCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/NodeDynamicLabelOrphanChainStartCheck.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/NodeDynamicLabelOrphanChainStartCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/NodeField.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/NodeField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/NodeRecordCheck.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/NodeRecordCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/OwnerChain.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/OwnerChain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/OwningRecordCheck.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/OwningRecordCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/PrimitiveRecordCheck.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/PrimitiveRecordCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/PropertyChain.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/PropertyChain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/PropertyKeyTokenRecordCheck.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/PropertyKeyTokenRecordCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/PropertyRecordCheck.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/PropertyRecordCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/RecordCheck.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/RecordCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/RecordField.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/RecordField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/RelationshipGroupRecordCheck.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/RelationshipGroupRecordCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/RelationshipRecordCheck.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/RelationshipRecordCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/RelationshipTypeTokenRecordCheck.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/RelationshipTypeTokenRecordCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/SchemaRecordCheck.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/SchemaRecordCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/TokenRecordCheck.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/TokenRecordCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/cache/CacheAccess.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/cache/CacheAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/cache/CacheSlots.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/cache/CacheSlots.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/cache/CacheTask.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/cache/CacheTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/cache/DefaultCacheAccess.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/cache/DefaultCacheAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/cache/PackedMultiFieldCache.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/cache/PackedMultiFieldCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/CheckStage.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/CheckStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/CloningRecordIterable.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/CloningRecordIterable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/CloningRecordIterator.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/CloningRecordIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/ConsistencyCheckIncompleteException.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/ConsistencyCheckIncompleteException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/ConsistencyCheckTasks.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/ConsistencyCheckTasks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/ConsistencyCheckerTask.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/ConsistencyCheckerTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/ConsistencyFlags.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/ConsistencyFlags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/CountsBuilderDecorator.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/CountsBuilderDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/DynamicOwner.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/DynamicOwner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/FullCheck.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/FullCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/GapFreeAllEntriesLabelScanReader.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/GapFreeAllEntriesLabelScanReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/IdAssigningThreadLocal.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/IdAssigningThreadLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/IndexCheck.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/IndexCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/IterableStore.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/IterableStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/MandatoryProperties.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/MandatoryProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/MultiPassStore.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/MultiPassStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/NodeInUseWithCorrectLabelsCheck.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/NodeInUseWithCorrectLabelsCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/NodeLabelReader.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/NodeLabelReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/Owner.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/Owner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/OwnerCheck.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/OwnerCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/ParallelRecordScanner.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/ParallelRecordScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/PropertyAndNode2LabelIndexProcessor.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/PropertyAndNode2LabelIndexProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/PropertyAndNodeIndexedCheck.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/PropertyAndNodeIndexedCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/PropertyOwner.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/PropertyOwner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/PropertyReader.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/PropertyReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/QueueDistribution.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/QueueDistribution.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/RecordCheckWorker.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/RecordCheckWorker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/RecordDistributor.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/RecordDistributor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/RecordProcessor.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/RecordProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/RecordScanner.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/RecordScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/SchemaStoreProcessorTask.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/SchemaStoreProcessorTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/SequentialRecordScanner.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/SequentialRecordScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/Stage.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/Stage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/StoreProcessor.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/StoreProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/StoreProcessorTask.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/StoreProcessorTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/TaskExecutor.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/TaskExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/index/IndexAccessors.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/index/IndexAccessors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/index/IndexEntryProcessor.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/index/IndexEntryProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/index/IndexIterator.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/index/IndexIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/labelscan/LabelScanCheck.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/labelscan/LabelScanCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/labelscan/LabelScanDocumentProcessor.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/labelscan/LabelScanDocumentProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/internal/SchemaIndexExtensionLoader.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/internal/SchemaIndexExtensionLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/repair/OwningNodeRelationshipChain.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/repair/OwningNodeRelationshipChain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/repair/RecordSet.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/repair/RecordSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/repair/RelationshipChainDirection.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/repair/RelationshipChainDirection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/repair/RelationshipChainExplorer.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/repair/RelationshipChainExplorer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/repair/RelationshipChainField.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/repair/RelationshipChainField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/repair/RelationshipNodeField.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/repair/RelationshipNodeField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/report/ConsistencyReport.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/report/ConsistencyReport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/report/ConsistencyReporter.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/report/ConsistencyReporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/report/ConsistencySummaryStatistics.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/report/ConsistencySummaryStatistics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/report/InconsistencyLogger.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/report/InconsistencyLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/report/InconsistencyMessageLogger.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/report/InconsistencyMessageLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/report/InconsistencyReport.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/report/InconsistencyReport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/report/PendingReferenceCheck.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/report/PendingReferenceCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/statistics/AccessStatistics.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/statistics/AccessStatistics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/statistics/AccessStatsKeepingStoreAccess.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/statistics/AccessStatsKeepingStoreAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/statistics/Counts.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/statistics/Counts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/statistics/DefaultCounts.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/statistics/DefaultCounts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/statistics/Statistics.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/statistics/Statistics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/statistics/VerboseStatistics.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/statistics/VerboseStatistics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/store/CacheSmallStoresRecordAccess.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/store/CacheSmallStoresRecordAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/store/DelegatingRecordAccess.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/store/DelegatingRecordAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/store/DirectRecordAccess.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/store/DirectRecordAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/store/DirectRecordReference.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/store/DirectRecordReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/store/FilteringRecordAccess.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/store/FilteringRecordAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/store/RecordAccess.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/store/RecordAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/store/RecordReference.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/store/RecordReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/store/synthetic/CountsEntry.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/store/synthetic/CountsEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/store/synthetic/IndexEntry.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/store/synthetic/IndexEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/store/synthetic/IndexRecord.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/store/synthetic/IndexRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/store/synthetic/LabelScanDocument.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/store/synthetic/LabelScanDocument.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/store/synthetic/LabelScanIndex.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/store/synthetic/LabelScanIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/CheckConsistencyCommandTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/CheckConsistencyCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/ConsistencyCheckServiceIntegrationTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/ConsistencyCheckServiceIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/ConsistencyCheckToolTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/ConsistencyCheckToolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/LabelScanStoreTxApplyRaceIT.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/LabelScanStoreTxApplyRaceIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/AllNodesInStoreExistInLabelIndexTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/AllNodesInStoreExistInLabelIndexTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/DynamicRecordCheckTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/DynamicRecordCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/GraphStoreFixture.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/GraphStoreFixture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/IndexConsistencyIT.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/IndexConsistencyIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/LabelTokenRecordCheckTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/LabelTokenRecordCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/MetaDataStoreCheckTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/MetaDataStoreCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/NodeDynamicLabelOrphanChainStartCheckTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/NodeDynamicLabelOrphanChainStartCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/NodeRecordCheckTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/NodeRecordCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/PropertyKeyTokenRecordCheckTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/PropertyKeyTokenRecordCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/PropertyRecordCheckTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/PropertyRecordCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/RecordCheckTestBase.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/RecordCheckTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/RelationshipRecordCheckTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/RelationshipRecordCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/RelationshipTypeTokenRecordCheckTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/RelationshipTypeTokenRecordCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/SchemaRecordCheckTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/SchemaRecordCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/SchemaRuleUtil.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/SchemaRuleUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/TransactionWriter.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/TransactionWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/cache/CheckNextRelTaskTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/cache/CheckNextRelTaskTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/cache/DefaultClientTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/cache/DefaultClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/cache/PackedMultiFieldCacheTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/cache/PackedMultiFieldCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/DetectAllRelationshipInconsistenciesIT.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/DetectAllRelationshipInconsistenciesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/DuplicatePropertyTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/DuplicatePropertyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/ExecutionOrderIntegrationTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/ExecutionOrderIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/FullCheckIntegrationTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/FullCheckIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/GapFreeAllEntriesLabelScanReaderTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/GapFreeAllEntriesLabelScanReaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/MultiPassStoreTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/MultiPassStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/NodeInUseWithCorrectLabelsCheckTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/NodeInUseWithCorrectLabelsCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/NullReporter.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/NullReporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/OwnerCheckTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/OwnerCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/PropertyReaderTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/PropertyReaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/QueueDistributionTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/QueueDistributionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/RecordCheckWorkerTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/RecordCheckWorkerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/RecordDistributorTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/RecordDistributorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/RecordScannerTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/RecordScannerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/StoreProcessorTaskTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/StoreProcessorTaskTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/StoreProcessorTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/StoreProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/repair/OwningNodeRelationshipChainTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/repair/OwningNodeRelationshipChainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/repair/RecordSetTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/repair/RecordSetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/repair/RelationshipChainExplorerTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/repair/RelationshipChainExplorerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/report/ConsistencyReporterTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/report/ConsistencyReporterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/report/MessageConsistencyLoggerTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/report/MessageConsistencyLoggerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/report/PendingReferenceCheckTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/report/PendingReferenceCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/statistics/DefaultCountsTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/statistics/DefaultCountsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/store/CacheSmallStoresRecordAccessTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/store/CacheSmallStoresRecordAccessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/store/RecordAccessStub.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/store/RecordAccessStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/store/StoreAssertions.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/store/StoreAssertions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/csv/NOTICE.txt
+++ b/community/csv/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/community/csv/src/main/java/org/neo4j/csv/reader/AutoReadingSource.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/AutoReadingSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/csv/src/main/java/org/neo4j/csv/reader/BufferOverflowException.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/BufferOverflowException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/csv/src/main/java/org/neo4j/csv/reader/BufferedCharSeeker.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/BufferedCharSeeker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/csv/src/main/java/org/neo4j/csv/reader/CharReadable.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/CharReadable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/csv/src/main/java/org/neo4j/csv/reader/CharReadableChunker.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/CharReadableChunker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/csv/src/main/java/org/neo4j/csv/reader/CharSeeker.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/CharSeeker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/csv/src/main/java/org/neo4j/csv/reader/CharSeekers.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/CharSeekers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/csv/src/main/java/org/neo4j/csv/reader/Chunker.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/Chunker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/csv/src/main/java/org/neo4j/csv/reader/ClosestNewLineChunker.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/ClosestNewLineChunker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/csv/src/main/java/org/neo4j/csv/reader/Configuration.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/Configuration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/csv/src/main/java/org/neo4j/csv/reader/DataAfterQuoteException.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/DataAfterQuoteException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/csv/src/main/java/org/neo4j/csv/reader/Extractor.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/Extractor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/csv/src/main/java/org/neo4j/csv/reader/Extractors.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/Extractors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/csv/src/main/java/org/neo4j/csv/reader/FormatException.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/FormatException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/csv/src/main/java/org/neo4j/csv/reader/IllegalMultilineFieldException.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/IllegalMultilineFieldException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/csv/src/main/java/org/neo4j/csv/reader/Magic.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/Magic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/csv/src/main/java/org/neo4j/csv/reader/Mark.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/Mark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/csv/src/main/java/org/neo4j/csv/reader/MissingEndQuoteException.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/MissingEndQuoteException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/csv/src/main/java/org/neo4j/csv/reader/MultiReadable.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/MultiReadable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/csv/src/main/java/org/neo4j/csv/reader/Readables.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/Readables.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/csv/src/main/java/org/neo4j/csv/reader/SectionedCharBuffer.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/SectionedCharBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/csv/src/main/java/org/neo4j/csv/reader/Source.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/Source.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/csv/src/main/java/org/neo4j/csv/reader/SourceTraceability.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/SourceTraceability.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/csv/src/main/java/org/neo4j/csv/reader/ThreadAhead.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/ThreadAhead.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/csv/src/main/java/org/neo4j/csv/reader/ThreadAheadReadable.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/ThreadAheadReadable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/csv/src/main/java/org/neo4j/csv/reader/WrappedCharReadable.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/WrappedCharReadable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/csv/src/test/java/org/neo4j/csv/reader/BufferedCharSeekerTest.java
+++ b/community/csv/src/test/java/org/neo4j/csv/reader/BufferedCharSeekerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/csv/src/test/java/org/neo4j/csv/reader/ClosestNewLineChunkerTest.java
+++ b/community/csv/src/test/java/org/neo4j/csv/reader/ClosestNewLineChunkerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/csv/src/test/java/org/neo4j/csv/reader/ExtractorsTest.java
+++ b/community/csv/src/test/java/org/neo4j/csv/reader/ExtractorsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/csv/src/test/java/org/neo4j/csv/reader/MultiReadableTest.java
+++ b/community/csv/src/test/java/org/neo4j/csv/reader/MultiReadableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/csv/src/test/java/org/neo4j/csv/reader/ReadablesTest.java
+++ b/community/csv/src/test/java/org/neo4j/csv/reader/ReadablesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/csv/src/test/java/org/neo4j/csv/reader/SectionedCharBufferTest.java
+++ b/community/csv/src/test/java/org/neo4j/csv/reader/SectionedCharBufferTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/csv/src/test/java/org/neo4j/csv/reader/ThreadAheadReadableTest.java
+++ b/community/csv/src/test/java/org/neo4j/csv/reader/ThreadAheadReadableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/NOTICE.txt
+++ b/community/cypher/cypher-logical-plans-3.4/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/ActiveRead.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/ActiveRead.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/Aggregation.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/Aggregation.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/AllNodesScan.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/AllNodesScan.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/AntiConditionalApply.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/AntiConditionalApply.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/Apply.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/Apply.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/Argument.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/Argument.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/AssertSameNode.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/AssertSameNode.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/Bound.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/Bound.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/CartesianProduct.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/CartesianProduct.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/ColumnOrder.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/ColumnOrder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/ConditionalApply.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/ConditionalApply.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/CreateNode.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/CreateNode.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/CreateRelationship.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/CreateRelationship.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/DeleteExpression.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/DeleteExpression.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/DeleteNode.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/DeleteNode.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/DeletePath.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/DeletePath.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/DeleteRelationship.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/DeleteRelationship.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/DetachDeleteExpression.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/DetachDeleteExpression.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/DetachDeleteNode.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/DetachDeleteNode.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/DetachDeletePath.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/DetachDeletePath.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/DirectedRelationshipByIdSeek.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/DirectedRelationshipByIdSeek.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/Distinct.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/Distinct.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/DropResult.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/DropResult.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/Eager.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/Eager.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/EmptyResult.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/EmptyResult.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/ErrorPlan.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/ErrorPlan.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/Expand.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/Expand.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/FindShortestPaths.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/FindShortestPaths.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/ForeachApply.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/ForeachApply.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/LeftOuterHashJoin.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/LeftOuterHashJoin.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/LetSelectOrSemiApply.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/LetSelectOrSemiApply.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/LetSemiApply.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/LetSemiApply.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/Limit.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/Limit.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/LoadCSV.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/LoadCSV.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/LockNodes.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/LockNodes.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/LogicalPlan.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/LogicalPlan.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/MergeCreateNode.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/MergeCreateNode.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/MergeCreateRelationship.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/MergeCreateRelationship.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/NestedPlanExpression.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/NestedPlanExpression.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/NodeByIdSeek.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/NodeByIdSeek.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/NodeByLabelScan.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/NodeByLabelScan.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/NodeCountFromCountStore.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/NodeCountFromCountStore.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/NodeHashJoin.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/NodeHashJoin.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/NodeIndexContainsScan.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/NodeIndexContainsScan.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/NodeIndexEndsWithScan.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/NodeIndexEndsWithScan.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/NodeIndexScan.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/NodeIndexScan.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/NodeIndexSeek.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/NodeIndexSeek.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/NodeUniqueIndexSeek.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/NodeUniqueIndexSeek.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/NonSargable.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/NonSargable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/Optional.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/Optional.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/ProceduralLogicalPlan.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/ProceduralLogicalPlan.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/ProcedureCall.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/ProcedureCall.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/ProcedureSignature.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/ProcedureSignature.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/ProduceResult.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/ProduceResult.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/ProjectEndpoints.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/ProjectEndpoints.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/Projection.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/Projection.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/QueryExpression.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/QueryExpression.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/RelationshipCountFromCountStore.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/RelationshipCountFromCountStore.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/RemoveLabels.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/RemoveLabels.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/ResolvedCall.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/ResolvedCall.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/ResolvedFunctionInvocation.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/ResolvedFunctionInvocation.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/RightOuterHashJoin.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/RightOuterHashJoin.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/RollUpApply.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/RollUpApply.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/SeekRange.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/SeekRange.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/SeekRangeWrapper.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/SeekRangeWrapper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/SeekableArgs.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/SeekableArgs.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/SelectOrSemiApply.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/SelectOrSemiApply.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/Selection.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/Selection.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/SemiApply.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/SemiApply.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/SetLabels.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/SetLabels.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/SetNodePropertiesFromMap.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/SetNodePropertiesFromMap.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/SetNodeProperty.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/SetNodeProperty.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/SetProperty.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/SetProperty.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/SetRelationshipPropertiesFromMap.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/SetRelationshipPropertiesFromMap.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/SetRelationshipPropery.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/SetRelationshipPropery.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/Skip.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/Skip.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/Sort.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/Sort.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/Strictness.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/Strictness.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/Top.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/Top.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/TreeBuilder.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/TreeBuilder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/TriadicSelection.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/TriadicSelection.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/UndirectedRelationshipByIdSeek.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/UndirectedRelationshipByIdSeek.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/Union.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/Union.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/UnwindCollection.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/UnwindCollection.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/ValueHashJoin.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/ValueHashJoin.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/package.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-logical-plans-3.4/src/test/scala/org/neo4j/cypher/internal/v3_4/logical/plans/NullOrderingTest.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/test/scala/org/neo4j/cypher/internal/v3_4/logical/plans/NullOrderingTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/NOTICE.txt
+++ b/community/cypher/cypher-planner-3.4/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/community/cypher/cypher-planner-3.4/src/main/java/org/neo4j/cypher/internal/compiler/v3_4/common/CypherOrderability.java
+++ b/community/cypher/cypher-planner-3.4/src/main/java/org/neo4j/cypher/internal/compiler/v3_4/common/CypherOrderability.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/ContextCreator.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/ContextCreator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/CypherCompiler.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/CypherCompiler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/CypherCompilerFactory.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/CypherCompilerFactory.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/HasOptionalDefault.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/HasOptionalDefault.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/ProcedureCallOrSchemaCommandPlanBuilder.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/ProcedureCallOrSchemaCommandPlanBuilder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/StatsDivergenceCalculator.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/StatsDivergenceCalculator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/SyntaxExceptionCreator.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/SyntaxExceptionCreator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/UpdateStrategy.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/UpdateStrategy.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/QueryTagger.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/QueryTagger.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/conditions/containsNamedPathOnlyForShortestPath.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/conditions/containsNamedPathOnlyForShortestPath.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/convert/plannerQuery/ClauseConverters.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/convert/plannerQuery/ClauseConverters.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/convert/plannerQuery/PlannerQueryBuilder.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/convert/plannerQuery/PlannerQueryBuilder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/convert/plannerQuery/StatementConverters.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/convert/plannerQuery/StatementConverters.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/convert/plannerQuery/groupInequalityPredicates.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/convert/plannerQuery/groupInequalityPredicates.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/package.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/InliningContext.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/InliningContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/inlineProjections.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/inlineProjections.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/inliningContextCreator.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/inliningContextCreator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/namePatternPredicatePatternElements.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/namePatternPredicatePatternElements.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/reattachAliasedExpressions.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/reattachAliasedExpressions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/helpers/CachedFunction.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/helpers/CachedFunction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/helpers/IteratorSupport.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/helpers/IteratorSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/helpers/ListSupport.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/helpers/ListSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/helpers/MapSupport.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/helpers/MapSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/helpers/Materialized.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/helpers/Materialized.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/helpers/StringRenderingSupport.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/helpers/StringRenderingSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/helpers/Tapper.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/helpers/Tapper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/phases/CompilationContains.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/phases/CompilationContains.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/phases/CompilerContext.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/phases/CompilerContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/phases/CreatePlannerQuery.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/phases/CreatePlannerQuery.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/phases/DeprecationWarnings.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/phases/DeprecationWarnings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/phases/LogicalPlanState.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/phases/LogicalPlanState.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/phases/RewriteProcedureCalls.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/phases/RewriteProcedureCalls.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/CantCompileQueryException.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/CantCompileQueryException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/CheckForUnresolvedTokens.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/CheckForUnresolvedTokens.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/ProcedureCallProjection.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/ProcedureCallProjection.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/ResolveTokens.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/ResolveTokens.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/Selections.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/Selections.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/CachedMetricsFactory.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/CachedMetricsFactory.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/CardinalityCostModel.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/CardinalityCostModel.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/Eagerness.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/Eagerness.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/LeafPlannerIterable.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/LeafPlannerIterable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/LogicalPlanningContext.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/LogicalPlanningContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/LogicalPlanningFunction.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/LogicalPlanningFunction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/LogicalPlanningSupport.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/LogicalPlanningSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/Metrics.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/Metrics.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/OptionalMatchRemover.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/OptionalMatchRemover.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/PlanEventHorizon.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/PlanEventHorizon.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/PlanSingleQuery.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/PlanSingleQuery.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/PlanUpdates.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/PlanUpdates.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/PlanWithTail.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/PlanWithTail.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/ProjectingSelector.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/ProjectingSelector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/QueryGraphSolver.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/QueryGraphSolver.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/QueryPlanner.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/QueryPlanner.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/QueryPlannerConfiguration.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/QueryPlannerConfiguration.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/ReportCostComparisonsAsRows.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/ReportCostComparisonsAsRows.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/SimpleMetricsFactory.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/SimpleMetricsFactory.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/Solvable.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/Solvable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/StatisticsBackedCardinalityModel.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/StatisticsBackedCardinalityModel.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/cardinality/ExpressionSelectivityCalculator.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/cardinality/ExpressionSelectivityCalculator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/cardinality/QueryGraphCardinalityModel.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/cardinality/QueryGraphCardinalityModel.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/cardinality/SelectivityCombiner.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/cardinality/SelectivityCombiner.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/cardinality/SelectivityEstimator.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/cardinality/SelectivityEstimator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/cardinality/TokenSpec.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/cardinality/TokenSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/cardinality/assumeIndependence/AssumeIndependenceQueryGraphCardinalityModel.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/cardinality/assumeIndependence/AssumeIndependenceQueryGraphCardinalityModel.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/cardinality/assumeIndependence/PatternSelectivityCalculator.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/cardinality/assumeIndependence/PatternSelectivityCalculator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/debug/DebugPrinter.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/debug/DebugPrinter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/idp/IDPCache.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/idp/IDPCache.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/idp/IDPPlanTable.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/idp/IDPPlanTable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/idp/IDPQueryGraphSolver.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/idp/IDPQueryGraphSolver.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/idp/IDPSolver.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/idp/IDPSolver.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/idp/IDPSolverConfig.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/idp/IDPSolverConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/idp/IDPSolverStep.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/idp/IDPSolverStep.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/idp/IDPTable.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/idp/IDPTable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/idp/IdRegistry.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/idp/IdRegistry.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/idp/SingleComponentPlanner.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/idp/SingleComponentPlanner.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/idp/cartesianProductsOrValueJoins.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/idp/cartesianProductsOrValueJoins.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/idp/expandSolverStep.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/idp/expandSolverStep.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/idp/extractPredicates.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/idp/extractPredicates.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/idp/joinSolverStep.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/idp/joinSolverStep.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/idp/package.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/idp/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/package.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/patternExpressionRewriter.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/patternExpressionRewriter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/Sargable.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/Sargable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/rewriter/LogicalPlanRewriter.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/rewriter/LogicalPlanRewriter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/rewriter/cleanUpEager.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/rewriter/cleanUpEager.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/rewriter/fuseSelections.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/rewriter/fuseSelections.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/rewriter/predicateRemovalThroughJoins.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/rewriter/predicateRemovalThroughJoins.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/rewriter/pruningVarExpander.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/rewriter/pruningVarExpander.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/rewriter/removeIdenticalPlans.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/rewriter/removeIdenticalPlans.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/rewriter/simplifyPredicates.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/rewriter/simplifyPredicates.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/rewriter/simplifySelections.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/rewriter/simplifySelections.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/rewriter/unnestApply.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/rewriter/unnestApply.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/rewriter/unnestOptional.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/rewriter/unnestOptional.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/rewriter/useTop.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/rewriter/useTop.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/AbstractIndexSeekLeafPlanner.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/AbstractIndexSeekLeafPlanner.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/CostComparisonListener.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/CostComparisonListener.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/DynamicPropertyNotifier.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/DynamicPropertyNotifier.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/IndexSeekLeafPlanner.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/IndexSeekLeafPlanner.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/LogicalPlanProducer.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/LogicalPlanProducer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/OrLeafPlanner.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/OrLeafPlanner.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/PatternExpressionSolver.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/PatternExpressionSolver.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/Selector.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/Selector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/aggregation.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/aggregation.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/allNodesLeafPlanner.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/allNodesLeafPlanner.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/argumentLeafPlanner.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/argumentLeafPlanner.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/countStorePlanner.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/countStorePlanner.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/getDegreeRewriter.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/getDegreeRewriter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/idSeekLeafPlanner.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/idSeekLeafPlanner.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/indexScanLeafPlanner.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/indexScanLeafPlanner.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/labelScanLeafPlanner.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/labelScanLeafPlanner.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/leafPlanOptions.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/leafPlanOptions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/mergeUniqueIndexSeekLeafPlanner.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/mergeUniqueIndexSeekLeafPlanner.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/pickBestPlanUsingHintsAndCost.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/pickBestPlanUsingHintsAndCost.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/planShortestPaths.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/planShortestPaths.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/projection.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/projection.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/selectCovered.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/selectCovered.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/selectHasLabelWithJoin.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/selectHasLabelWithJoin.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/selectPatternPredicates.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/selectPatternPredicates.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/solveOptionalMatches.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/solveOptionalMatches.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/sortSkipAndLimit.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/sortSkipAndLimit.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/triadicSelectionFinder.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/triadicSelectionFinder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/uniqueIndexSeekLeafPlanner.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/uniqueIndexSeekLeafPlanner.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/verifyBestPlan.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/verifyBestPlan.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/package.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/prettifier/Prettifier.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/prettifier/Prettifier.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/java/org/neo4j/cypher/internal/compiler/v3_4/common/CypherOrderabilityTest.java
+++ b/community/cypher/cypher-planner-3.4/src/test/java/org/neo4j/cypher/internal/compiler/v3_4/common/CypherOrderabilityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/IdentityMapTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/IdentityMapTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/InputPositionTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/InputPositionTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/NotImplementedPlanContext.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/NotImplementedPlanContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/RewriteProcedureCallsTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/RewriteProcedureCallsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ScopeTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ScopeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ScopeTreeTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ScopeTreeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ScopeTreeVerificationTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ScopeTreeVerificationTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/SemanticCheckableTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/SemanticCheckableTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/SemanticStateTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/SemanticStateTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/CallClauseTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/CallClauseTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/QueryTaggerTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/QueryTaggerTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/QueryTagsTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/QueryTagsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/conditions/AggregationsAreIsolatedTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/conditions/AggregationsAreIsolatedTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/conditions/CollectNodesOfTypeTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/conditions/CollectNodesOfTypeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/conditions/ContainsNamedPathOnlyForShortestPathTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/conditions/ContainsNamedPathOnlyForShortestPathTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/conditions/ContainsNoMatchingNodesTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/conditions/ContainsNoMatchingNodesTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/conditions/ContainsNoNodesOfTypeTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/conditions/ContainsNoNodesOfTypeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/conditions/NoDuplicatesInReturnItemsTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/conditions/NoDuplicatesInReturnItemsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/conditions/NoReferenceEqualityAmongVariablesTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/conditions/NoReferenceEqualityAmongVariablesTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/conditions/NoUnnamedPatternElementsInMatchTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/conditions/NoUnnamedPatternElementsInMatchTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/conditions/NormalizedEqualsArgumentsTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/conditions/NormalizedEqualsArgumentsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/conditions/OrderByOnlyOnVariablesTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/conditions/OrderByOnlyOnVariablesTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/conditions/noUnnamedPatternElementsInPatternComprehensionTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/conditions/noUnnamedPatternElementsInPatternComprehensionTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/convert/plannerQuery/GroupInequalityPredicatesTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/convert/plannerQuery/GroupInequalityPredicatesTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/convert/plannerQuery/MutatingStatementConvertersTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/convert/plannerQuery/MutatingStatementConvertersTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/convert/plannerQuery/PatternExpressionConverterTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/convert/plannerQuery/PatternExpressionConverterTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/convert/plannerQuery/StatementConvertersTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/convert/plannerQuery/StatementConvertersTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/convert/plannerQuery/UnionStatementConvertersTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/convert/plannerQuery/UnionStatementConvertersTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/AddUniquenessPredicatesTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/AddUniquenessPredicatesTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/CNFNormalizerTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/CNFNormalizerTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/CollapseInCollectionsTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/CollapseInCollectionsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/DeMorganRewriterTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/DeMorganRewriterTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/DesugarDesugaredMapProjectionTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/DesugarDesugaredMapProjectionTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/DistributeLawRewriterTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/DistributeLawRewriterTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/ExpandCallWhereTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/ExpandCallWhereTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/ExpandStarTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/ExpandStarTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/FlattenBooleanOperatorsTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/FlattenBooleanOperatorsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/FoldConstantsTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/FoldConstantsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/InlineProjectionsTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/InlineProjectionsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/InliningContextCreatorTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/InliningContextCreatorTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/InliningContextTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/InliningContextTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/IsolateAggregationTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/IsolateAggregationTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/LiteralReplacementTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/LiteralReplacementTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/MatchPredicateNormalizerTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/MatchPredicateNormalizerTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/NameMatchPatternElementTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/NameMatchPatternElementTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/NamespacerTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/NamespacerTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/NormalizeArgumentOrderTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/NormalizeArgumentOrderTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/NormalizeComparisonsTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/NormalizeComparisonsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/NormalizeNotEqualsTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/NormalizeNotEqualsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/NormalizeReturnClausesTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/NormalizeReturnClausesTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/NormalizeSargablePredicatesTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/NormalizeSargablePredicatesTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/NormalizeWithClausesTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/NormalizeWithClausesTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/PredicateTestSupport.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/PredicateTestSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/ProjectFreshSortExpressionsTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/ProjectFreshSortExpressionsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/ProjectNamedPathsTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/ProjectNamedPathsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/ReattachAliasedExpressionsTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/ReattachAliasedExpressionsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/ReplaceAliasedFunctionInvocationsTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/ReplaceAliasedFunctionInvocationsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/ReplaceLiteralDynamicPropertyLookupsTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/ReplaceLiteralDynamicPropertyLookupsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/ReturnItemSafeTopDownRewriterTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/ReturnItemSafeTopDownRewriterTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/RewriteEqualityToInPredicateTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/RewriteEqualityToInPredicateTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/RewriteTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/RewriteTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/SimplifyPredicatesTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/SimplifyPredicatesTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/TransitiveClosureTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/TransitiveClosureTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/inlineNamedPathsInPatternComprehensionsTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/inlineNamedPathsInPatternComprehensionsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/mergeInPredicatesTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/mergeInPredicatesTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/namePatternComprehensionPatternElementsTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/namePatternComprehensionPatternElementsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/helpers/CachedFunctionTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/helpers/CachedFunctionTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/helpers/ScopeTestHelper.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/helpers/ScopeTestHelper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/helpers/SemanticTableHelper.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/helpers/SemanticTableHelper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/helpers/TreeZipperTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/helpers/TreeZipperTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/parser/ParserFixture.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/parser/ParserFixture.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/parser/PeriodicCommitHintTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/parser/PeriodicCommitHintTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/phases/AssertionsShouldBeEnabledTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/phases/AssertionsShouldBeEnabledTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/phases/StatsDivergenceCalculatorTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/phases/StatsDivergenceCalculatorTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/AstRewritingTestSupport.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/AstRewritingTestSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/BeLikeMatcher.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/BeLikeMatcher.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/CheckForUnresolvedTokensTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/CheckForUnresolvedTokensTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/DbStructureGraphStatistics.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/DbStructureGraphStatistics.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/DbStructureLogicalPlanningConfiguration.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/DbStructureLogicalPlanningConfiguration.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/HardcodedGraphStatistics.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/HardcodedGraphStatistics.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/LogicalPlanningConfiguration.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/LogicalPlanningConfiguration.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/LogicalPlanningTestSupport.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/LogicalPlanningTestSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/LogicalPlanningTestSupport2.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/LogicalPlanningTestSupport2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/PlannerQueryTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/PlannerQueryTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/QueryGraphTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/QueryGraphTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/RealLogicalPlanningConfiguration.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/RealLogicalPlanningConfiguration.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/ResolveTokensTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/ResolveTokensTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/SelectionsTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/SelectionsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/SemanticTableBuilder.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/SemanticTableBuilder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/SemanticTableTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/SemanticTableTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/StubbedLogicalPlanningConfiguration.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/StubbedLogicalPlanningConfiguration.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/UpdateGraphTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/UpdateGraphTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/ArgumentPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/ArgumentPlanningIntegrationTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/BenchmarkCardinalityEstimationTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/BenchmarkCardinalityEstimationTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/CardinalityCostModelTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/CardinalityCostModelTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/CardinalitySupport.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/CardinalitySupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/CartesianProductPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/CartesianProductPlanningIntegrationTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/CreateNodePlanningIntegrationTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/CreateNodePlanningIntegrationTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/CreateRelationshipPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/CreateRelationshipPlanningIntegrationTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/DefaultQueryPlannerTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/DefaultQueryPlannerTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/ExpandPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/ExpandPlanningIntegrationTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/FindShortestPathsPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/FindShortestPathsPlanningIntegrationTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/LeafPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/LeafPlanningIntegrationTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/MergeNodePlanningIntegrationTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/MergeNodePlanningIntegrationTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/MergeRelationshipPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/MergeRelationshipPlanningIntegrationTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/NamedPathProjectionPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/NamedPathProjectionPlanningIntegrationTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/NodeHashJoinPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/NodeHashJoinPlanningIntegrationTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/OptionalMatchPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/OptionalMatchPlanningIntegrationTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/OptionalMatchRemoverTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/OptionalMatchRemoverTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/OrLeafPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/OrLeafPlanningIntegrationTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/PatternExpressionPatternElementNamerTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/PatternExpressionPatternElementNamerTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/PatternPredicatePlanningIntegrationTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/PatternPredicatePlanningIntegrationTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/PickBestPlanUsingHintsAndCostTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/PickBestPlanUsingHintsAndCostTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/PlanEventHorizonTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/PlanEventHorizonTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/PlanRewritingPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/PlanRewritingPlanningIntegrationTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/PriorityLeafPlannerListTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/PriorityLeafPlannerListTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/QueryGraphConnectedComponentsTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/QueryGraphConnectedComponentsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/QueryGraphProducer.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/QueryGraphProducer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/SolvablesTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/SolvablesTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/StatisticsBackedCardinalityModelTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/StatisticsBackedCardinalityModelTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/UnionPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/UnionPlanningIntegrationTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/WithPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/WithPlanningIntegrationTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/cardinality/CardinalityData.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/cardinality/CardinalityData.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/cardinality/CardinalityModelTestHelper.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/cardinality/CardinalityModelTestHelper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/cardinality/CardinalityTestHelper.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/cardinality/CardinalityTestHelper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/cardinality/ExpressionSelectivityCalculatorTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/cardinality/ExpressionSelectivityCalculatorTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/cardinality/RandomizedCardinalityModelTestSuite.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/cardinality/RandomizedCardinalityModelTestSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/cardinality/SelectivityCombinerTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/cardinality/SelectivityCombinerTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/cardinality/assumeIndependence/AssumeIndependenceQueryGraphCardinalityModelTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/cardinality/assumeIndependence/AssumeIndependenceQueryGraphCardinalityModelTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/cardinality/assumeIndependence/PatternSelectivityCalculatorTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/cardinality/assumeIndependence/PatternSelectivityCalculatorTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/idp/CartesianProductsOrValueJoinsTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/idp/CartesianProductsOrValueJoinsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/idp/ExpandSolverStepTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/idp/ExpandSolverStepTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/idp/IDPQueryGraphSolverTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/idp/IDPQueryGraphSolverTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/idp/IDPSolverTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/idp/IDPSolverTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/idp/IDPTableTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/idp/IDPTableTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/idp/JoinSolverStepTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/idp/JoinSolverStepTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/idp/SingleComponentPlannerTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/idp/SingleComponentPlannerTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/idp/extractPredicatesTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/idp/extractPredicatesTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/patternExpressionRewriterTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/patternExpressionRewriterTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/AllNodesLeafPlannerTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/AllNodesLeafPlannerTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/ArgumentLeafPlannerTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/ArgumentLeafPlannerTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/IdSeekLeafPlannerTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/IdSeekLeafPlannerTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/IndexLeafPlannerTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/IndexLeafPlannerTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/IndexScanLeafPlannerTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/IndexScanLeafPlannerTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/IndexSeekLeafPlannerTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/IndexSeekLeafPlannerTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/InequalityRangeSeekableTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/InequalityRangeSeekableTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/LabelScanLeafPlannerTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/LabelScanLeafPlannerTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/LogicalPlanAssignedIdTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/LogicalPlanAssignedIdTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/LogicalPlanEqualityTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/LogicalPlanEqualityTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/LogicalPlanTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/LogicalPlanTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/SargableTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/SargableTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/rewriter/FuseSelectionsTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/rewriter/FuseSelectionsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/rewriter/PredicateRemovalThroughJoinsTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/rewriter/PredicateRemovalThroughJoinsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/rewriter/PruningVarExpanderTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/rewriter/PruningVarExpanderTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/rewriter/SimplifyPredicatesTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/rewriter/SimplifyPredicatesTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/rewriter/SimplifySelectionsTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/rewriter/SimplifySelectionsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/rewriter/UnnestApplyTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/rewriter/UnnestApplyTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/rewriter/UnnestOptionalTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/rewriter/UnnestOptionalTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/rewriter/UseTopTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/rewriter/UseTopTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/rewriter/cleanUpEagerTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/rewriter/cleanUpEagerTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/rewriter/removeIdenticalPlansTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/rewriter/removeIdenticalPlansTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/AggregationTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/AggregationTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/ExtractBestPlanTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/ExtractBestPlanTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/LeftOuterHashJoinTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/LeftOuterHashJoinTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/OrLeafPlannerTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/OrLeafPlannerTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/PatternExpressionSolverTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/PatternExpressionSolverTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/ProjectionTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/ProjectionTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/RightOuterHashJoinTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/RightOuterHashJoinTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/SelectCoveredTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/SelectCoveredTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/SelectHasLabelWithJoinTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/SelectHasLabelWithJoinTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/SelectPatternPredicatesTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/SelectPatternPredicatesTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/SortSkipAndLimitTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/SortSkipAndLimitTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/TriadicSelectionFinderTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/TriadicSelectionFinderTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/countStorePlannerTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/countStorePlannerTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/getDegreeRewriterTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/getDegreeRewriterTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/unnestEagerTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/unnestEagerTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/prettifier/PrettifierParserTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/prettifier/PrettifierParserTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/prettifier/PrettifierTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/prettifier/PrettifierTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/spi/GraphStatisticsSnapshotTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/spi/GraphStatisticsSnapshotTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/test_helpers/ContextHelper.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/test_helpers/ContextHelper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/test_helpers/CustomMatchers.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/test_helpers/CustomMatchers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/test_helpers/RandomizedTestSupport.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/test_helpers/RandomizedTestSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/test_helpers/testRandomizer.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/test_helpers/testRandomizer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/NOTICE.txt
+++ b/community/cypher/cypher/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/export/CypherResultSubGraph.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/export/CypherResultSubGraph.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/export/DatabaseSubGraph.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/export/DatabaseSubGraph.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/export/SubGraph.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/export/SubGraph.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/export/SubGraphExporter.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/export/SubGraphExporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledConversionUtils.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledConversionUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledCursorUtils.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledCursorUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledEquivalenceUtils.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledEquivalenceUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledExpandUtils.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledExpandUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledIndexUtils.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledIndexUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledMaterializeValueMapper.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledMaterializeValueMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledMathHelper.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledMathHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/ParameterConverter.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/ParameterConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/PrimitiveEntityStream.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/PrimitiveEntityStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/PrimitiveNodeStream.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/PrimitiveNodeStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/PrimitiveRelationshipStream.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/PrimitiveRelationshipStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/javacompat/CommunityCypherEngineProvider.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/javacompat/CommunityCypherEngineProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/javacompat/EagerResult.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/javacompat/EagerResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/javacompat/ExecutionEngine.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/javacompat/ExecutionEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/javacompat/ExecutionResult.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/javacompat/ExecutionResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/javacompat/MapRow.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/javacompat/MapRow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/javacompat/PlanDescription.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/javacompat/PlanDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/javacompat/ProfilerStatistics.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/javacompat/ProfilerStatistics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/javacompat/QueryResultProvider.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/javacompat/QueryResultProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/javacompat/ResultRecord.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/javacompat/ResultRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/javacompat/ResultRowImpl.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/javacompat/ResultRowImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/javacompat/SnapshotExecutionEngine.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/javacompat/SnapshotExecutionEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/javacompat/UnstableSnapshotException.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/javacompat/UnstableSnapshotException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/tracing/CompilationTracer.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/tracing/CompilationTracer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/tracing/TimingCompilationTracer.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/tracing/TimingCompilationTracer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/CypherExecutionMode.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/CypherExecutionMode.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/CypherOption.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/CypherOption.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/CypherPlanner.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/CypherPlanner.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/CypherRuntime.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/CypherRuntime.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/CypherUpdateStrategy.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/CypherUpdateStrategy.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/CypherVersion.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/CypherVersion.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/PlanCacheMetricsMonitor.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/PlanCacheMetricsMonitor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/CompatibilityCache.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/CompatibilityCache.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/CompilerEngineDelegator.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/CompilerEngineDelegator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/CypherPreParser.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/CypherPreParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/CypherStatementWithOptions.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/CypherStatementWithOptions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/ExecutionEngine.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/ExecutionEngine.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/ExecutionPlan.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/ExecutionPlan.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/ParsedQuery.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/ParsedQuery.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/PreParserOption.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/PreParserOption.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/PreparedPlanExecution.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/PreparedPlanExecution.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CacheAccessor.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CacheAccessor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/ClosingExecutionResult.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/ClosingExecutionResult.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/LFUCache.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/LFUCache.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/LatestRuntimeVariablePlannerCompatibility.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/LatestRuntimeVariablePlannerCompatibility.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/OnlyOnceQueryExecutionMonitor.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/OnlyOnceQueryExecutionMonitor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/RunSafely.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/RunSafely.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/package.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v2_3/Compatibility.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v2_3/Compatibility.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v2_3/CostCompatibility.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v2_3/CostCompatibility.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v2_3/ExceptionTranslatingQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v2_3/ExceptionTranslatingQueryContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v2_3/ExecutionResultWrapper.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v2_3/ExecutionResultWrapper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v2_3/RuleCompatibility.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v2_3/RuleCompatibility.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v2_3/WrappedMonitors.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v2_3/WrappedMonitors.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v2_3/exceptionHandler.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v2_3/exceptionHandler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v2_3/helpers.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v2_3/helpers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_1/Compatibility.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_1/Compatibility.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_1/CostCompatibility.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_1/CostCompatibility.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_1/ExceptionTranslatingQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_1/ExceptionTranslatingQueryContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_1/ExecutionResultWrapper.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_1/ExecutionResultWrapper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_1/RuleCompatibility.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_1/RuleCompatibility.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_1/WrappedMonitors.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_1/WrappedMonitors.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_1/exceptionHandler.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_1/exceptionHandler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_1/helpers.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_1/helpers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_1/typeConversions.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_1/typeConversions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/ActiveReadInjector.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/ActiveReadInjector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/CommunityRuntimeContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/CommunityRuntimeContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/Compatibility.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/Compatibility.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/IdConverter.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/IdConverter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/LogicalPlanConverter.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/LogicalPlanConverter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/PlannerQueryWrapper.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/PlannerQueryWrapper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/ProfileKernelStatisticProvider.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/ProfileKernelStatisticProvider.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/SemanticTableConverter.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/SemanticTableConverter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/StatementWrapper.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/StatementWrapper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/WrappedInstrumentedGraphStatistics.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/WrappedInstrumentedGraphStatistics.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/WrappedMonitors.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/WrappedMonitors.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/exceptionHandler.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/exceptionHandler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/helpers.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/helpers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/Compatibility.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/Compatibility.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/ExceptionTranslatingPlanContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/ExceptionTranslatingPlanContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/ExceptionTranslatingQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/ExceptionTranslatingQueryContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/ExceptionTranslationSupport.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/ExceptionTranslationSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/WrappedMonitors.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/WrappedMonitors.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/notifications/LogicalPlanNotifications.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/notifications/LogicalPlanNotifications.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/notifications/checkForEagerLoadCsv.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/notifications/checkForEagerLoadCsv.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/notifications/checkForIndexLimitation.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/notifications/checkForIndexLimitation.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/notifications/checkForLoadCsvAndMatchOnLargeLabel.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/notifications/checkForLoadCsvAndMatchOnLargeLabel.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/BuildInterpretedExecutionPlan.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/BuildInterpretedExecutionPlan.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/CommunityPipeBuilder.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/CommunityPipeBuilder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/CommunityRuntimeContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/CommunityRuntimeContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ExecutionResultDumper.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ExecutionResultDumper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ExplainExecutionResult.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ExplainExecutionResult.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/PipeBuilderFactory.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/PipeBuilderFactory.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/PipeExecutionBuilderContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/PipeExecutionBuilderContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/PipeExecutionPlanBuilder.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/PipeExecutionPlanBuilder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/PipeExecutionResult.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/PipeExecutionResult.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ResultIterator.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ResultIterator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/RuntimeBuilder.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/RuntimeBuilder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/RuntimeName.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/RuntimeName.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/Completable.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/Completable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/DefaultExecutionResultBuilderFactory.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/DefaultExecutionResultBuilderFactory.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/ExecutionPlan.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/ExecutionPlan.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/ExecutionPlanBuilder.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/ExecutionPlanBuilder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/ExecutionResultBuilder.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/ExecutionResultBuilder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/LoadCsvIterator.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/LoadCsvIterator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/LoadCsvPeriodicCommitObserver.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/LoadCsvPeriodicCommitObserver.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/PlanFingerprint.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/PlanFingerprint.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/Provider.java
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/Provider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/StandardInternalExecutionResult.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/StandardInternalExecutionResult.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/UpdateCounter.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/UpdateCounter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/builders/prepare/KeyTokenResolver.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/builders/prepare/KeyTokenResolver.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/formatOutput.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/formatOutput.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/procs/ProcedureCallExecutionPlan.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/procs/ProcedureCallExecutionPlan.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/procs/ProcedureCallOrSchemaCommandExecutionPlanBuilder.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/procs/ProcedureCallOrSchemaCommandExecutionPlanBuilder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/procs/ProcedureExecutionResult.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/procs/ProcedureExecutionResult.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/procs/PureSideEffectExecutionPlan.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/procs/PureSideEffectExecutionPlan.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/procs/PureSideEffectInternalExecutionResult.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/procs/PureSideEffectInternalExecutionResult.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/helpers/InternalWrapping.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/helpers/InternalWrapping.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/helpers/MapBasedRow.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/helpers/MapBasedRow.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/helpers/PrimitiveLongHelper.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/helpers/PrimitiveLongHelper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/helpers/RuntimeTextValueConverter.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/helpers/RuntimeTextValueConverter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/helpers/simpleExpressionEvaluator.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/helpers/simpleExpressionEvaluator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/phases/CompilationState.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/phases/CompilationState.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/pipes/DropResultPipe.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/pipes/DropResultPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/profiler/Profiler.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/profiler/Profiler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/valueHelper.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/valueHelper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/CursorIterator.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/CursorIterator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/BidirectionalTraversalMatcher.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/BidirectionalTraversalMatcher.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/MonodirectionalTraversalMatcher.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/MonodirectionalTraversalMatcher.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/SchemaDescriptorTranslation.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/SchemaDescriptorTranslation.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/TransactionBoundGraphStatistics.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/TransactionBoundGraphStatistics.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/TransactionBoundPlanContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/TransactionBoundPlanContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/TransactionBoundQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/TransactionBoundQueryContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/TransactionBoundTokenContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/TransactionBoundTokenContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/BidirectionalTraversalMatcher.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/BidirectionalTraversalMatcher.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/ExceptionTranslatingPlanContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/ExceptionTranslatingPlanContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/ExceptionTranslationSupport.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/ExceptionTranslationSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/MonodirectionalTraversalMatcher.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/MonodirectionalTraversalMatcher.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/SchemaDescriptorTranslation.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/SchemaDescriptorTranslation.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/TransactionBoundGraphStatistics.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/TransactionBoundGraphStatistics.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/TransactionBoundPlanContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/TransactionBoundPlanContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/TransactionBoundQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/TransactionBoundQueryContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/TransactionBoundTokenContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/TransactionBoundTokenContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/TransactionalContextWrapper.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/TransactionalContextWrapper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_3/ExceptionTranslatingPlanContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_3/ExceptionTranslatingPlanContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_3/ExceptionTranslationSupport.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_3/ExceptionTranslationSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_3/IndexDescriptorCompatibility.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_3/IndexDescriptorCompatibility.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_3/TransactionBoundGraphStatistics.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_3/TransactionBoundGraphStatistics.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_3/TransactionBoundPlanContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_3/TransactionBoundPlanContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_3/TransactionBoundTokenContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_3/TransactionBoundTokenContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/java/org/neo4j/cypher/CreateIndexStressIT.java
+++ b/community/cypher/cypher/src/test/java/org/neo4j/cypher/CreateIndexStressIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/java/org/neo4j/cypher/DeleteNodeStressIT.java
+++ b/community/cypher/cypher/src/test/java/org/neo4j/cypher/DeleteNodeStressIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/java/org/neo4j/cypher/DeleteRelationshipStressIT.java
+++ b/community/cypher/cypher/src/test/java/org/neo4j/cypher/DeleteRelationshipStressIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/java/org/neo4j/cypher/GraphDatabaseServiceExecuteTest.java
+++ b/community/cypher/cypher/src/test/java/org/neo4j/cypher/GraphDatabaseServiceExecuteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/java/org/neo4j/cypher/ManyMergesStressTest.java
+++ b/community/cypher/cypher/src/test/java/org/neo4j/cypher/ManyMergesStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/java/org/neo4j/cypher/QueryExecutionMonitorTest.scala
+++ b/community/cypher/cypher/src/test/java/org/neo4j/cypher/QueryExecutionMonitorTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/java/org/neo4j/cypher/QueryInvalidationIT.java
+++ b/community/cypher/cypher/src/test/java/org/neo4j/cypher/QueryInvalidationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/java/org/neo4j/cypher/export/ExportTest.java
+++ b/community/cypher/cypher/src/test/java/org/neo4j/cypher/export/ExportTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/java/org/neo4j/cypher/internal/CypherStatementWithOptionsTest.scala
+++ b/community/cypher/cypher/src/test/java/org/neo4j/cypher/internal/CypherStatementWithOptionsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/java/org/neo4j/cypher/internal/codegen/CompiledExpandUtilsTest.java
+++ b/community/cypher/cypher/src/test/java/org/neo4j/cypher/internal/codegen/CompiledExpandUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/java/org/neo4j/cypher/internal/codegen/CompiledIndexUtilsTest.java
+++ b/community/cypher/cypher/src/test/java/org/neo4j/cypher/internal/codegen/CompiledIndexUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/java/org/neo4j/cypher/internal/codegen/CompiledMaterializeValueMapperTest.java
+++ b/community/cypher/cypher/src/test/java/org/neo4j/cypher/internal/codegen/CompiledMaterializeValueMapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/java/org/neo4j/cypher/internal/codegen/ParameterConverterTest.java
+++ b/community/cypher/cypher/src/test/java/org/neo4j/cypher/internal/codegen/ParameterConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/java/org/neo4j/cypher/internal/javacompat/CommunityCypherEngineProviderTest.java
+++ b/community/cypher/cypher/src/test/java/org/neo4j/cypher/internal/javacompat/CommunityCypherEngineProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/java/org/neo4j/cypher/internal/javacompat/CypherLoggingTest.java
+++ b/community/cypher/cypher/src/test/java/org/neo4j/cypher/internal/javacompat/CypherLoggingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/java/org/neo4j/cypher/internal/javacompat/CypherUpdateMapTest.java
+++ b/community/cypher/cypher/src/test/java/org/neo4j/cypher/internal/javacompat/CypherUpdateMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/java/org/neo4j/cypher/internal/javacompat/EagerResultIT.java
+++ b/community/cypher/cypher/src/test/java/org/neo4j/cypher/internal/javacompat/EagerResultIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/java/org/neo4j/cypher/internal/javacompat/ExecutionEngineTest.java
+++ b/community/cypher/cypher/src/test/java/org/neo4j/cypher/internal/javacompat/ExecutionEngineTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/java/org/neo4j/cypher/internal/javacompat/ExecutionResultTest.java
+++ b/community/cypher/cypher/src/test/java/org/neo4j/cypher/internal/javacompat/ExecutionResultTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/java/org/neo4j/cypher/internal/javacompat/JavaValueCompatibilityTest.java
+++ b/community/cypher/cypher/src/test/java/org/neo4j/cypher/internal/javacompat/JavaValueCompatibilityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/java/org/neo4j/cypher/internal/javacompat/NotificationAcceptanceTest.java
+++ b/community/cypher/cypher/src/test/java/org/neo4j/cypher/internal/javacompat/NotificationAcceptanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/java/org/neo4j/cypher/internal/javacompat/RegularExpressionMatcher.java
+++ b/community/cypher/cypher/src/test/java/org/neo4j/cypher/internal/javacompat/RegularExpressionMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/java/org/neo4j/cypher/internal/javacompat/ServerExecutionEngineTest.java
+++ b/community/cypher/cypher/src/test/java/org/neo4j/cypher/internal/javacompat/ServerExecutionEngineTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/java/org/neo4j/cypher/internal/javacompat/SnapshotExecutionEngineTest.java
+++ b/community/cypher/cypher/src/test/java/org/neo4j/cypher/internal/javacompat/SnapshotExecutionEngineTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/CypherIsolationIntegrationTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/CypherIsolationIntegrationTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/DeleteConcurrencyIT.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/DeleteConcurrencyIT.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ErrorMessagesTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ErrorMessagesTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ExecutionEngineFunSuite.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ExecutionEngineFunSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ExecutionEngineIT.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ExecutionEngineIT.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ExecutionEngineTestSupport.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ExecutionEngineTestSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ExecutionResultTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ExecutionResultTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/HttpServerTestSupport.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/HttpServerTestSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/IndexOpAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/IndexOpAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/JoinHintPlanningIntegrationTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/JoinHintPlanningIntegrationTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/KillQueryTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/KillQueryTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/MergeConcurrencyIT.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/MergeConcurrencyIT.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/PatternGen.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/PatternGen.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/QueryCachingTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/QueryCachingTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/QueryPlanTestSupport.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/QueryPlanTestSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/QueryStatisticsTestSupport.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/QueryStatisticsTestSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/RewindableExecutionResultTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/RewindableExecutionResultTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/RootPlanAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/RootPlanAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/RunWithConfigTestSupport.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/RunWithConfigTestSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/RuntimeUnsupportedNotificationTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/RuntimeUnsupportedNotificationTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/SystemPropertyTestSupport.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/SystemPropertyTestSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/SystemPropertyTestSupportTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/SystemPropertyTestSupportTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/TxCountsTrackingTestSupport.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/TxCountsTrackingTestSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/RewindableExecutionResult.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/RewindableExecutionResult.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/codegen/CompiledConversionUtilsTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/codegen/CompiledConversionUtilsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/codegen/CompiledCursorUtilsTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/codegen/CompiledCursorUtilsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/codegen/CompiledEquivalenceUtilsTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/codegen/CompiledEquivalenceUtilsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/codegen/CompiledMathHelperTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/codegen/CompiledMathHelperTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/LFUCacheTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/LFUCacheTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/ActiveReadInjectorTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/ActiveReadInjectorTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/LogicalPlanConverterTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/LogicalPlanConverterTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/SemanticTableConverterTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/SemanticTableConverterTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/CypherCompilerAstCacheAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/CypherCompilerAstCacheAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/notifications/CheckForEagerLoadCsvTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/notifications/CheckForEagerLoadCsvTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/notifications/CheckForIndexLimitationTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/notifications/CheckForIndexLimitationTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/notifications/CheckForLoadCsvAndMatchOnLargeLabelTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/notifications/CheckForLoadCsvAndMatchOnLargeLabelTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ClosingIteratorTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ClosingIteratorTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/PipeExecutionPlanBuilderIT.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/PipeExecutionPlanBuilderIT.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/PipeExecutionPlanBuilderTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/PipeExecutionPlanBuilderTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/ExecutionWorkflowBuilderTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/ExecutionWorkflowBuilderTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/LoadCsvIteratorTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/LoadCsvIteratorTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/LoadCsvPeriodicCommitObserverTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/LoadCsvPeriodicCommitObserverTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/PlanFingerprintReferenceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/PlanFingerprintReferenceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/builders/PatternGraphBuilderTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/builders/PatternGraphBuilderTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/procs/ProcedureCallExecutionPlanTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/procs/ProcedureCallExecutionPlanTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/helpers/RowIteratorVisitationTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/helpers/RowIteratorVisitationTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/helpers/simpleExpressionEvaluatorTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/helpers/simpleExpressionEvaluatorTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/profiler/ProfilerTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/profiler/ProfilerTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/CypherPreParserTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/CypherPreParserTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ActualCostCalculationTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ActualCostCalculationTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/PathExpressionTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/PathExpressionTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/PatternMatchingTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/PatternMatchingTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/PatternNodeTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/PatternNodeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/PipeLazynessTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/PipeLazynessTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ScalaPatternMatchingTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ScalaPatternMatchingTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/SemanticIndexAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/SemanticIndexAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/helpers/ConstraintCreator.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/helpers/ConstraintCreator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/javacompat/ResultRowImplTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/javacompat/ResultRowImplTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/parser/CaseExpressionTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/parser/CaseExpressionTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/parser/ExpressionsTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/parser/ExpressionsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/parser/ListComprehensionTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/parser/ListComprehensionTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/parser/MapLiteralTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/parser/MapLiteralTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/tracing/TimingCompilationTracerTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/tracing/TimingCompilationTracerTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/expressions-3.4/NOTICE.txt
+++ b/community/cypher/expressions-3.4/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgBD
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/AndedPropertyInequalities.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/AndedPropertyInequalities.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/ArithmeticExpressions.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/ArithmeticExpressions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/CaseExpression.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/CaseExpression.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/CoerceTo.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/CoerceTo.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/ConstantExpression.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/ConstantExpression.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/CountStar.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/CountStar.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/Expression.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/Expression.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/FunctionInvocation.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/FunctionInvocation.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/GetDegree.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/GetDegree.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/HasLabels.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/HasLabels.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/IsAggregate.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/IsAggregate.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/IterableExpressions.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/IterableExpressions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/ListLiteral.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/ListLiteral.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/Literal.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/Literal.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/LogicalProperty.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/LogicalProperty.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/LogicalVariable.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/LogicalVariable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/MapExpression.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/MapExpression.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/MapProjection.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/MapProjection.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/NameToken.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/NameToken.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/OperatorExpression.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/OperatorExpression.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/Parameter.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/Parameter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/PathExpression.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/PathExpression.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/Pattern.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/Pattern.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/PatternExpression.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/PatternExpression.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/PredicateExpressions.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/PredicateExpressions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/Property.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/Property.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/Range.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/Range.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/ScopeExpression.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/ScopeExpression.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/SemanticDirection.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/SemanticDirection.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/ShortestPathExpression.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/ShortestPathExpression.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/SymbolicName.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/SymbolicName.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/TypeSignature.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/TypeSignature.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/TypeSignatures.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/TypeSignatures.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/Variable.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/Variable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/containsAggregate.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/containsAggregate.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Abs.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Abs.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Acos.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Acos.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Asin.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Asin.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Atan.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Atan.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Atan2.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Atan2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Avg.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Avg.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Ceil.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Ceil.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Coalesce.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Coalesce.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Collect.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Collect.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Cos.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Cos.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Cot.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Cot.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Count.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Count.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Degrees.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Degrees.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Distance.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Distance.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/E.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/E.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/EndNode.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/EndNode.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Exists.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Exists.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Exp.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Exp.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Floor.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Floor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Function.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Function.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Haversin.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Haversin.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Head.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Head.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Id.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Id.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Keys.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Keys.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/LTrim.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/LTrim.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Labels.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Labels.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Last.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Last.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Left.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Left.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Length.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Length.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Log.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Log.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Log10.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Log10.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Max.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Max.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Min.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Min.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Nodes.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Nodes.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/PercentileCont.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/PercentileCont.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/PercentileDisc.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/PercentileDisc.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Pi.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Pi.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Point.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Point.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Properties.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Properties.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/RTrim.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/RTrim.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Radians.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Radians.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Rand.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Rand.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Range.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Range.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Reduce.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Reduce.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Relationships.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Relationships.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Replace.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Replace.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Reverse.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Reverse.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Right.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Right.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Round.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Round.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Sign.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Sign.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Sin.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Sin.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Size.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Size.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Split.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Split.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Sqrt.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Sqrt.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/StartNode.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/StartNode.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/StdDev.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/StdDev.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/StdDevP.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/StdDevP.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Substring.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Substring.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Sum.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Sum.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Tail.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Tail.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Tan.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Tan.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Timestamp.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Timestamp.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/ToBoolean.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/ToBoolean.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/ToFloat.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/ToFloat.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/ToInteger.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/ToInteger.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/ToLower.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/ToLower.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/ToString.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/ToString.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/ToUpper.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/ToUpper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Trim.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Trim.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Type.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/Type.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/UnresolvedFunction.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/UnresolvedFunction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/UserDefinedFunctionInvocation.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/UserDefinedFunctionInvocation.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/expressions-3.4/src/test/scala/org/neo4j/cypher/internal/v3_4/expressions/DummyExpression.scala
+++ b/community/cypher/expressions-3.4/src/test/scala/org/neo4j/cypher/internal/v3_4/expressions/DummyExpression.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/NOTICE.txt
+++ b/community/cypher/frontend-3.4/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgBD
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/community/cypher/frontend-3.4/src/main/java/org/neo4j/cypher/internal/frontend/v3_4/phases/CompilationPhaseTracer.java
+++ b/community/cypher/frontend-3.4/src/main/java/org/neo4j/cypher/internal/frontend/v3_4/phases/CompilationPhaseTracer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/AstRewritingMonitor.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/AstRewritingMonitor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/IdentityMap.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/IdentityMap.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/PlannerName.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/PlannerName.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ScopeTreeVerifier.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ScopeTreeVerifier.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/ASTAnnotationMap.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/ASTAnnotationMap.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/ASTSlicingPhrase.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/ASTSlicingPhrase.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/Clause.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/Clause.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/Command.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/Command.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/GraphRef.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/GraphRef.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/GraphReturnItems.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/GraphReturnItems.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/GraphUrl.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/GraphUrl.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/Hint.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/Hint.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/Limit.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/Limit.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/MergeAction.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/MergeAction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/Order.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/Order.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/PeriodicCommitHint.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/PeriodicCommitHint.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/ProcedureResult.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/ProcedureResult.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/ProcedureResultItem.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/ProcedureResultItem.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/Query.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/Query.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/RemoveItem.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/RemoveItem.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/ReturnItem.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/ReturnItem.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/SetItem.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/SetItem.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/SingleGraphAs.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/SingleGraphAs.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/Skip.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/Skip.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/Statement.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/Statement.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/Where.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/Where.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/conditions/StatementCondition.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/conditions/StatementCondition.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/conditions/aggregationsAreIsolated.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/conditions/aggregationsAreIsolated.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/conditions/collectNodesOfType.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/conditions/collectNodesOfType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/conditions/containsNoMatchingNodes.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/conditions/containsNoMatchingNodes.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/conditions/containsNoNodesOfType.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/conditions/containsNoNodesOfType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/conditions/containsNoReturnAll.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/conditions/containsNoReturnAll.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/conditions/noDuplicatesInReturnItems.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/conditions/noDuplicatesInReturnItems.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/conditions/noReferenceEqualityAmongVariables.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/conditions/noReferenceEqualityAmongVariables.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/conditions/noUnnamedGraphs.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/conditions/noUnnamedGraphs.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/conditions/noUnnamedPatternElementsInGraphOf.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/conditions/noUnnamedPatternElementsInGraphOf.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/conditions/noUnnamedPatternElementsInMatch.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/conditions/noUnnamedPatternElementsInMatch.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/conditions/noUnnamedPatternElementsInPatternComprehension.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/conditions/noUnnamedPatternElementsInPatternComprehension.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/conditions/normalizedEqualsArguments.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/conditions/normalizedEqualsArguments.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/conditions/orderByOnlyOnVariables.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/conditions/orderByOnlyOnVariables.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/connectedComponents.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/connectedComponents.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/hasAggregateButIsNotAggregate.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/hasAggregateButIsNotAggregate.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/ASTRewriter.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/ASTRewriter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/CNFNormalizer.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/CNFNormalizer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/LabelPredicateNormalizer.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/LabelPredicateNormalizer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/MatchPredicateNormalization.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/MatchPredicateNormalization.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/MatchPredicateNormalizer.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/MatchPredicateNormalizer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/MatchPredicateNormalizerChain.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/MatchPredicateNormalizerChain.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/Namespacer.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/Namespacer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/PatternExpressionPatternElementNamer.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/PatternExpressionPatternElementNamer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/PropertyPredicateNormalizer.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/PropertyPredicateNormalizer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/ReturnItemSafeTopDownRewriter.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/ReturnItemSafeTopDownRewriter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/StatementRewriter.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/StatementRewriter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/addUniquenessPredicates.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/addUniquenessPredicates.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/collapseMultipleInPredicates.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/collapseMultipleInPredicates.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/copyVariables.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/copyVariables.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/desugarMapProjection.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/desugarMapProjection.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/expandCallWhere.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/expandCallWhere.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/expandStar.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/expandStar.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/foldConstants.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/foldConstants.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/inlineNamedPathsInPatternComprehensions.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/inlineNamedPathsInPatternComprehensions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/isolateAggregation.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/isolateAggregation.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/literalReplacement.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/literalReplacement.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/mergeInPredicates.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/mergeInPredicates.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/nameAllPatternElements.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/nameAllPatternElements.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/nameGraphOfPatternElements.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/nameGraphOfPatternElements.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/nameMatchPatternElements.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/nameMatchPatternElements.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/namePatternComprehensionPatternElements.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/namePatternComprehensionPatternElements.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/nameUpdatingClauses.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/nameUpdatingClauses.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/normalizeArgumentOrder.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/normalizeArgumentOrder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/normalizeComparisons.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/normalizeComparisons.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/normalizeMatchPredicates.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/normalizeMatchPredicates.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/normalizeNotEquals.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/normalizeNotEquals.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/normalizeReturnClauses.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/normalizeReturnClauses.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/normalizeWithClauses.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/normalizeWithClauses.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/projectFreshSortExpressions.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/projectFreshSortExpressions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/projectNamedPaths.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/projectNamedPaths.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/recordScopes.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/recordScopes.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/repeatWithSizeLimit.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/repeatWithSizeLimit.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/replaceAliasedFunctionInvocations.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/replaceAliasedFunctionInvocations.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/replaceLiteralDynamicPropertyLookups.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/replaceLiteralDynamicPropertyLookups.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/rewriteEqualityToInPredicate.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/rewriteEqualityToInPredicate.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/transitiveClosure.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/transitiveClosure.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/helpers/PartialFunctionSupport.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/helpers/PartialFunctionSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/helpers/SeqCombiner.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/helpers/SeqCombiner.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/helpers/StringHelper.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/helpers/StringHelper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/helpers/TreeZipper.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/helpers/TreeZipper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/helpers/calculateUsingGetDegree.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/helpers/calculateUsingGetDegree.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/helpers/fixedPoint.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/helpers/fixedPoint.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/helpers/package.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/helpers/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/helpers/rewriting/RewriterCondition.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/helpers/rewriting/RewriterCondition.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/helpers/rewriting/RewriterStep.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/helpers/rewriting/RewriterStep.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/helpers/rewriting/RewriterStepSequencer.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/helpers/rewriting/RewriterStepSequencer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/helpers/rewriting/RewriterTask.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/helpers/rewriting/RewriterTask.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/helpers/rewriting/RewriterTaskBuilder.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/helpers/rewriting/RewriterTaskBuilder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/helpers/rewriting/RewriterTaskProcessor.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/helpers/rewriting/RewriterTaskProcessor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/notification/InternalNotification.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/notification/InternalNotification.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/package.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/parser/Base.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/parser/Base.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/parser/BufferPosition.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/parser/BufferPosition.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/parser/Clauses.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/parser/Clauses.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/parser/Command.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/parser/Command.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/parser/CypherParser.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/parser/CypherParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/parser/Expressions.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/parser/Expressions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/parser/InvalidInputErrorFormatter.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/parser/InvalidInputErrorFormatter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/parser/LikePatternParser.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/parser/LikePatternParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/parser/Literals.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/parser/Literals.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/parser/Patterns.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/parser/Patterns.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/parser/ProcedureCalls.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/parser/ProcedureCalls.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/parser/Query.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/parser/Query.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/parser/StartPoints.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/parser/StartPoints.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/parser/Statement.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/parser/Statement.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/parser/Strings.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/parser/Strings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/parser/convertLikePatternToRegex.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/parser/convertLikePatternToRegex.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/parser/matchers/IdentifierPartMatcher.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/parser/matchers/IdentifierPartMatcher.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/parser/matchers/IdentifierStartMatcher.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/parser/matchers/IdentifierStartMatcher.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/parser/matchers/ScalaCharMatcher.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/parser/matchers/ScalaCharMatcher.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/parser/matchers/WhitespaceCharMatcher.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/parser/matchers/WhitespaceCharMatcher.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/parser/package.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/parser/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/phases/AstRewriting.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/phases/AstRewriting.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/phases/BaseContext.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/phases/BaseContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/phases/BaseState.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/phases/BaseState.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/phases/CompilationPhases.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/phases/CompilationPhases.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/phases/Condition.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/phases/Condition.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/phases/InternalNotificationLogger.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/phases/InternalNotificationLogger.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/phases/LateAstRewriting.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/phases/LateAstRewriting.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/phases/Monitors.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/phases/Monitors.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/phases/Parsing.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/phases/Parsing.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/phases/Phase.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/phases/Phase.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/phases/PreparatoryRewriting.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/phases/PreparatoryRewriting.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/phases/SemanticAnalysis.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/phases/SemanticAnalysis.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/phases/SyntaxDeprecationWarnings.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/phases/SyntaxDeprecationWarnings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/phases/Transformer.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/phases/Transformer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/prettifier/ExpressionStringifier.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/prettifier/ExpressionStringifier.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/prettifier/Prettifier.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/prettifier/Prettifier.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/SemanticAnalysisTooling.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/SemanticAnalysisTooling.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/SemanticCheck.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/SemanticCheck.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/SemanticChecker.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/SemanticChecker.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/SemanticError.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/SemanticError.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/SemanticExpressionCheck.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/SemanticExpressionCheck.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/SemanticFeature.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/SemanticFeature.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/SemanticFunctionCheck.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/SemanticFunctionCheck.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/SemanticPatternCheck.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/SemanticPatternCheck.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/SemanticState.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/SemanticState.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/SemanticTable.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/SemanticTable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/FoldableTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/FoldableTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/RepeatTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/RepeatTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/SemanticAnalysisTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/SemanticAnalysisTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/ASTNodeTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/ASTNodeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/AstConstructionTestSupport.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/AstConstructionTestSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/ConnectedComponentsTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/ConnectedComponentsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/ConstantExpressionTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/ConstantExpressionTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/ContainsAggregateTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/ContainsAggregateTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/ExpressionCallTypeCheckerTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/ExpressionCallTypeCheckerTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/ExpressionTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/ExpressionTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/FindDuplicateRelationshipsTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/FindDuplicateRelationshipsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/FunctionNameTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/FunctionNameTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/IsAggregateTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/IsAggregateTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/LoadCSVTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/LoadCSVTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/MapProjectionTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/MapProjectionTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/PeriodicCommitHintTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/PeriodicCommitHintTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/ProjectionClauseTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/ProjectionClauseTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/ReturnItemsTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/ReturnItemsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/SetClauseTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/SetClauseTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/StatementReturnColumnsTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/StatementReturnColumnsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/TestExpression.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/TestExpression.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/helpers/NonEmptyListTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/helpers/NonEmptyListTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/helpers/StatementHelper.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/helpers/StatementHelper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/helpers/StringHelperTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/helpers/StringHelperTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/helpers/rewriting/RewriterStepSequencerTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/helpers/rewriting/RewriterStepSequencerTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/parser/BaseRulesTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/parser/BaseRulesTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/parser/ComparisonTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/parser/ComparisonTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/parser/FunctionInvocationParserTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/parser/FunctionInvocationParserTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/parser/LiteralsTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/parser/LiteralsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/parser/ParserAstTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/parser/ParserAstTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/parser/ParserTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/parser/ParserTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/parser/ProcedureCallParserTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/parser/ProcedureCallParserTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/parser/ProjectionClauseParserTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/parser/ProjectionClauseParserTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/prettifier/ExpressionStringifierTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/prettifier/ExpressionStringifierTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/prettifier/PrettifierTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/prettifier/PrettifierTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/AddTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/AddTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/AndTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/AndTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/AndsTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/AndsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/ContainerIndexTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/ContainerIndexTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/DivideTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/DivideTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/FilterExpressionTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/FilterExpressionTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/FilteringExpressionTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/FilteringExpressionTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/GreaterThanOrEqualTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/GreaterThanOrEqualTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/GreaterThanTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/GreaterThanTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/HexIntegerLiteralTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/HexIntegerLiteralTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/InfixExpressionTestBase.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/InfixExpressionTestBase.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/LessThanOrEqualTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/LessThanOrEqualTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/LessThanTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/LessThanTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/ListComprehensionTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/ListComprehensionTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/ListSliceTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/ListSliceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/LiteralTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/LiteralTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/ModuloTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/ModuloTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/MultiplyTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/MultiplyTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/OctalIntegerLiteralTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/OctalIntegerLiteralTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/OrTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/OrTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/OrsTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/OrsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/PatternComprehensionTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/PatternComprehensionTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/PowTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/PowTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/PropertyTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/PropertyTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/ReduceExpressionTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/ReduceExpressionTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/SemanticAnalysisToolingTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/SemanticAnalysisToolingTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/SemanticCaseExpressionTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/SemanticCaseExpressionTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/SemanticExtractExpressionTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/SemanticExtractExpressionTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/SemanticFunSuite.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/SemanticFunSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/ShortestPathExpressionTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/ShortestPathExpressionTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/SubtractTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/SubtractTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/VariableTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/VariableTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/XorTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/XorTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/functions/AbsTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/functions/AbsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/functions/AggregationFunctionTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/functions/AggregationFunctionTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/functions/DistanceTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/functions/DistanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/functions/FunctionTestBase.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/functions/FunctionTestBase.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/functions/LabelsTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/functions/LabelsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/functions/PercentileContTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/functions/PercentileContTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/functions/PercentileDiscTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/functions/PercentileDiscTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/functions/PointTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/functions/PointTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/functions/ReverseTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/functions/ReverseTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/functions/SplitTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/functions/SplitTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/functions/ToFloatTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/functions/ToFloatTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/functions/ToIntegerTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/functions/ToIntegerTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/functions/ToStringTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/functions/ToStringTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/symbols/CypherTypeTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/symbols/CypherTypeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/symbols/TypeRangeTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/symbols/TypeRangeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/symbols/TypeSpecTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/symbols/TypeSpecTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/interpreted-runtime/NOTICE.txt
+++ b/community/cypher/interpreted-runtime/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/community/cypher/interpreted-runtime/src/main/java/org/neo4j/cypher/internal/javacompat/GraphDatabaseCypherService.java
+++ b/community/cypher/interpreted-runtime/src/main/java/org/neo4j/cypher/internal/javacompat/GraphDatabaseCypherService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/CSVResources.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/CSVResources.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/CastSupport.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/CastSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/DelegatingQueryContext.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/DelegatingQueryContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/ExecutionContext.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/ExecutionContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/GraphElementPropertyFunctions.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/GraphElementPropertyFunctions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/IndexDescriptorCompatibility.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/IndexDescriptorCompatibility.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/JavaConversionSupport.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/JavaConversionSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/LastCommittedTxIdProvider.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/LastCommittedTxIdProvider.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/ListSupport.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/ListSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/MapSupport.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/MapSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/MutableMaps.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/MutableMaps.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/PatternGraphBuilder.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/PatternGraphBuilder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/ProfileKernelStatisticProvider.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/ProfileKernelStatisticProvider.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/ResourceManager.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/ResourceManager.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionBoundGraphStatistics.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionBoundGraphStatistics.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionBoundPlanContext.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionBoundPlanContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionBoundQueryContext.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionBoundQueryContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionBoundTokenContext.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionBoundTokenContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionalContextWrapper.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionalContextWrapper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/UpdateCountingQueryContext.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/UpdateCountingQueryContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/ValueConversion.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/ValueConversion.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/AstNode.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/AstNode.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/InList.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/InList.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/IndexOperation.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/IndexOperation.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/PathExpression.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/PathExpression.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/PathExtractor.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/PathExtractor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/Pattern.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/Pattern.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/Query.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/Query.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/QueryString.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/QueryString.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/ReturnItem.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/ReturnItem.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/SortItem.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/SortItem.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/coerce.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/coerce.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/convert/CommunityExpressionConverter.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/convert/CommunityExpressionConverter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/convert/ExpressionConverters.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/convert/ExpressionConverters.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/convert/PatternConverters.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/convert/PatternConverters.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/Add.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/Add.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/AggregationExpression.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/AggregationExpression.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/AggregationFunctionInvocation.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/AggregationFunctionInvocation.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/Avg.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/Avg.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/Closure.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/Closure.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/CoalesceFunction.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/CoalesceFunction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/CoerceTo.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/CoerceTo.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/Collect.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/Collect.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/ContainerIndex.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/ContainerIndex.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/Count.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/Count.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/CountStar.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/CountStar.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/DesugaredMapProjection.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/DesugaredMapProjection.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/DistanceFunction.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/DistanceFunction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/Distinct.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/Distinct.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/Divide.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/Divide.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/Expression.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/Expression.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/ExtractFunction.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/ExtractFunction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/FilterFunction.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/FilterFunction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/FunctionInvocation.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/FunctionInvocation.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/GenericCase.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/GenericCase.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/GetDegree.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/GetDegree.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/IdFunction.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/IdFunction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/IndexedInclusiveLongRange.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/IndexedInclusiveLongRange.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/InequalitySeekRangeExpression.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/InequalitySeekRangeExpression.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/KeysFunction.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/KeysFunction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/LabelsFunction.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/LabelsFunction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/LengthFunction.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/LengthFunction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/ListLiteral.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/ListLiteral.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/ListSlice.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/ListSlice.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/Literal.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/Literal.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/LiteralMap.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/LiteralMap.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/MathFunction.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/MathFunction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/Max.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/Max.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/Min.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/Min.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/Modulo.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/Modulo.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/Multiply.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/Multiply.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/NestedPipeExpression.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/NestedPipeExpression.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/NestedPlanExpression.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/NestedPlanExpression.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/NodesFunction.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/NodesFunction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/Null.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/Null.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/NullInNullOutExpression.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/NullInNullOutExpression.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/ParameterExpression.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/ParameterExpression.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/PathValueBuilder.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/PathValueBuilder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/Percentile.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/Percentile.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/PointDistanceSeekRangeExpression.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/PointDistanceSeekRangeExpression.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/PointFunction.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/PointFunction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/Pow.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/Pow.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/PrefixSeekRangeExpression.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/PrefixSeekRangeExpression.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/ProjectedPath.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/ProjectedPath.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/PropertiesFunction.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/PropertiesFunction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/Property.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/Property.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/ReduceFunction.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/ReduceFunction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/RelationshipEndPoints.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/RelationshipEndPoints.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/RelationshipFunction.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/RelationshipFunction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/RelationshipTypeFunction.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/RelationshipTypeFunction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/ReverseFunction.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/ReverseFunction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/ShortestPathExpression.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/ShortestPathExpression.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/ShortestPathSPI.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/ShortestPathSPI.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/SimpleCase.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/SimpleCase.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/SizeFunction.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/SizeFunction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/Stdev.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/Stdev.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/StringFunctions.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/StringFunctions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/Subtract.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/Subtract.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/Sum.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/Sum.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/TimestampFunction.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/TimestampFunction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/ToBooleanFunction.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/ToBooleanFunction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/ToFloatFunction.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/ToFloatFunction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/ToIntegerFunction.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/ToIntegerFunction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/Variable.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/Variable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/predicates/Ands.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/predicates/Ands.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/predicates/Checker.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/predicates/Checker.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/predicates/ComparablePredicate.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/predicates/ComparablePredicate.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/predicates/ConstantCachedIn.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/predicates/ConstantCachedIn.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/predicates/Ors.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/predicates/Ors.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/predicates/Predicate.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/predicates/Predicate.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/predicates/groupInequalityPredicatesForLegacy.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/predicates/groupInequalityPredicatesForLegacy.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/values/KeyToken.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/values/KeyToken.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/values/TokenType.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/values/TokenType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/makeValueNeoSafe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/makeValueNeoSafe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ActiveReadPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ActiveReadPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/AllNodesScanPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/AllNodesScanPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ApplyPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ApplyPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/AssertSameNodePipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/AssertSameNodePipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/CachingExpandInto.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/CachingExpandInto.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/CartesianProductPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/CartesianProductPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ConditionalApplyPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ConditionalApplyPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ConstraintOperationPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ConstraintOperationPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/CreateNodePipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/CreateNodePipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/CreateRelationshipPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/CreateRelationshipPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/DeletePipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/DeletePipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/DirectedRelationshipByIdSeekPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/DirectedRelationshipByIdSeekPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/DistinctPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/DistinctPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/EagerAggregationPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/EagerAggregationPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/EagerPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/EagerPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/EmptyResultPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/EmptyResultPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/EntityProducer.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/EntityProducer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ErrorPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ErrorPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ExpandAllPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ExpandAllPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ExpandIntoPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ExpandIntoPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ExternalCSVResource.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ExternalCSVResource.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/FilterPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/FilterPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ForeachPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ForeachPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/IdSeekIterator.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/IdSeekIterator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/IndexOperationPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/IndexOperationPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/IndexSeekMode.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/IndexSeekMode.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/LazyLabel.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/LazyLabel.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/LazyPropertyKey.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/LazyPropertyKey.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/LazyType.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/LazyType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/LazyTypes.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/LazyTypes.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/LetSelectOrSemiApplyPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/LetSelectOrSemiApplyPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/LetSemiApplyPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/LetSemiApplyPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/LimitPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/LimitPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/LoadCSVPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/LoadCSVPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/LockNodesPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/LockNodesPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NestedPipeExpression.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NestedPipeExpression.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeByIdSeekPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeByIdSeekPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeByLabelScanPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeByLabelScanPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeCountFromCountStorePipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeCountFromCountStorePipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeHashJoinPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeHashJoinPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeIndexContainsScanPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeIndexContainsScanPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeIndexScanPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeIndexScanPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeIndexSeekPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeIndexSeekPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeIndexSeeker.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeIndexSeeker.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeLeftOuterHashJoinPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeLeftOuterHashJoinPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeOuterHashJoinPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeOuterHashJoinPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeRightOuterHashJoinPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeRightOuterHashJoinPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/OptionalExpandAllPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/OptionalExpandAllPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/OptionalExpandIntoPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/OptionalExpandIntoPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/OptionalPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/OptionalPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/Pipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/Pipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/PipeDecorator.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/PipeDecorator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ProcedureCallPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ProcedureCallPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ProduceResultsPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ProduceResultsPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ProjectEndpointsPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ProjectEndpointsPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ProjectionPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ProjectionPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/PruningVarLengthExpandPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/PruningVarLengthExpandPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/QueryState.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/QueryState.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/RelationshipCountFromCountStorePipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/RelationshipCountFromCountStorePipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/RemoveLabelsPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/RemoveLabelsPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/RollUpApplyPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/RollUpApplyPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/SeekRhs.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/SeekRhs.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/SelectOrSemiApplyPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/SelectOrSemiApplyPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/SemiApplyPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/SemiApplyPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/SetOperation.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/SetOperation.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/SetPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/SetPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ShortestPathPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ShortestPathPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/SkipPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/SkipPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/SortPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/SortPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/TopPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/TopPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/TriadicSelectionPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/TriadicSelectionPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/UndirectedRelationshipByIdSeekPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/UndirectedRelationshipByIdSeekPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/UnionIterator.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/UnionIterator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/UnionPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/UnionPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/UnwindPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/UnwindPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ValueHashJoinPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ValueHashJoinPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/VarLengthExpandPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/VarLengthExpandPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/aggregation/AggregationFunction.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/aggregation/AggregationFunction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/aggregation/AvgFunction.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/aggregation/AvgFunction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/aggregation/CollectFunction.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/aggregation/CollectFunction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/aggregation/CountFunction.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/aggregation/CountFunction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/aggregation/CountStarFunction.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/aggregation/CountStarFunction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/aggregation/DistinctFunction.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/aggregation/DistinctFunction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/aggregation/MaxFunction.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/aggregation/MaxFunction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/aggregation/NumericExpressionOnly.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/aggregation/NumericExpressionOnly.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/aggregation/PercentileFunction.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/aggregation/PercentileFunction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/aggregation/StdevFunction.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/aggregation/StdevFunction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/aggregation/SumFunction.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/aggregation/SumFunction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/matching/GraphRelationship.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/matching/GraphRelationship.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/matching/History.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/matching/History.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/matching/MatchingContext.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/matching/MatchingContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/matching/MatchingPair.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/matching/MatchingPair.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/matching/PatternElement.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/matching/PatternElement.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/matching/PatternGraph.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/matching/PatternGraph.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/matching/PatternMatcher.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/matching/PatternMatcher.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/matching/PatternMatchingBuilder.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/matching/PatternMatchingBuilder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/matching/PatternNode.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/matching/PatternNode.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/matching/PatternRelationship.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/matching/PatternRelationship.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/matching/TraversalMatcher.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/matching/TraversalMatcher.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/symbols/SymbolTable.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/symbols/SymbolTable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/package.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/CSVResourcesTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/CSVResourcesTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/CastSupportTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/CastSupportTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/GraphElementPropertyFunctionsTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/GraphElementPropertyFunctionsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/ImplicitDummyPos.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/ImplicitDummyPos.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/LastCommittedTxIdProviderTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/LastCommittedTxIdProviderTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/MakeValuesNeoSafeTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/MakeValuesNeoSafeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/MatchingContextTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/MatchingContextTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/QueryContextAdaptation.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/QueryContextAdaptation.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/QueryStateHelper.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/QueryStateHelper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/QueryStateTestSupport.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/QueryStateTestSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/ResourceManagerTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/ResourceManagerTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/SeekRangeTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/SeekRangeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/TestableIterator.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/TestableIterator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionBoundPlanContextTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionBoundPlanContextTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionBoundQueryContextTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionBoundQueryContextTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/UpdateCountingQueryContextTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/UpdateCountingQueryContextTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/ValueComparisonHelper.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/ValueComparisonHelper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/AddTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/AddTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/AllVariablesTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/AllVariablesTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/AndsTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/AndsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/CoalesceTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/CoalesceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/CoercedPredicateTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/CoercedPredicateTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/ComparablePredicateTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/ComparablePredicateTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/ExtractTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/ExtractTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/HasLabelTests.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/HasLabelTests.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/LengthFunctionTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/LengthFunctionTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/ListLiteralTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/ListLiteralTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/MathFunctionsTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/MathFunctionsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/OrsTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/OrsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/PatternComprehensionTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/PatternComprehensionTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/PropertyValueComparisonTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/PropertyValueComparisonTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/ReduceTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/ReduceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/RegularExpressionPredicateTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/RegularExpressionPredicateTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/SizeFunctionTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/SizeFunctionTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/SplittingPredicateTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/SplittingPredicateTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/SubtractTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/SubtractTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/convert/PathExpressionConversionTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/convert/PathExpressionConversionTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/CoerceToTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/CoerceToTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/ContainerIndexTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/ContainerIndexTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/DistanceFunctionTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/DistanceFunctionTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/DivideTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/DivideTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/ExpressionTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/ExpressionTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/FakeEntityTestSupport.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/FakeEntityTestSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/GenericCaseTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/GenericCaseTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/IndexedInclusiveLongRangeTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/IndexedInclusiveLongRangeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/KeysFunctionTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/KeysFunctionTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/LabelsFunctionTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/LabelsFunctionTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/ListSliceTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/ListSliceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/LiteralMapTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/LiteralMapTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/ModuloTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/ModuloTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/PathImplTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/PathImplTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/PathValueBuilderTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/PathValueBuilderTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/PropertiesFunctionTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/PropertiesFunctionTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/RangeFunctionTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/RangeFunctionTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/RelationshipTypeFunctionTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/RelationshipTypeFunctionTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/ShortestPathNoDuplicatesTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/ShortestPathNoDuplicatesTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/SimpleCaseTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/SimpleCaseTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/SplitFunctionTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/SplitFunctionTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/StringFunctionsTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/StringFunctionsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/ToBooleanFunctionTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/ToBooleanFunctionTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/ToFloatFunctionTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/ToFloatFunctionTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/ToIntegerFunctionTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/ToIntegerFunctionTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/ToStringFunctionTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/ToStringFunctionTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/TypeTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/TypeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/groupInequalityPredicatesForLegacyTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/groupInequalityPredicatesForLegacyTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/predicates/CheckerTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/predicates/CheckerTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/predicates/ConstantCachedInTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/predicates/ConstantCachedInTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/predicates/EquivalentTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/predicates/EquivalentTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/values/KeyTokenTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/values/KeyTokenTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/AllNodesScanPipeTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/AllNodesScanPipeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/AllShortestPathsPipeTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/AllShortestPathsPipeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ApplyPipeTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ApplyPipeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/DirectedDirectedRelationshipByIdSeekPipeTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/DirectedDirectedRelationshipByIdSeekPipeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/DistinctPipeTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/DistinctPipeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/EagerAggregationPipeTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/EagerAggregationPipeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/EagerPipeTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/EagerPipeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ErrorPipeTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ErrorPipeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ExpandAllPipeTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ExpandAllPipeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ExpandIntoPipeTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ExpandIntoPipeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/FakePipe.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/FakePipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/LazyGroupingIteratorTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/LazyGroupingIteratorTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/LazyIterator.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/LazyIterator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/LazyPropertyKeyTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/LazyPropertyKeyTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/LazyTypesTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/LazyTypesTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/LegacyPruningVarLengthExpandPipe.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/LegacyPruningVarLengthExpandPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/LetSelectOrSemiApplyPipeTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/LetSelectOrSemiApplyPipeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/LetSemiApplyPipeTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/LetSemiApplyPipeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/LimitPipeTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/LimitPipeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/LockNodesPipeTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/LockNodesPipeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeByIdSeekPipeTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeByIdSeekPipeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeByLabelScanPipeTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeByLabelScanPipeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeCountFromCountStorePipeTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeCountFromCountStorePipeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeHashJoinPipeTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeHashJoinPipeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeIndexScanPipeTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeIndexScanPipeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeIndexSeekPipeTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeIndexSeekPipeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeLeftOuterHashJoinPipeTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeLeftOuterHashJoinPipeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeRightOuterHashJoinPipeTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeRightOuterHashJoinPipeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/OptionalExpandAllPipeTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/OptionalExpandAllPipeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/OptionalExpandIntoPipeTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/OptionalExpandIntoPipeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/OptionalPipeTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/OptionalPipeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/PipeTestSupport.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/PipeTestSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ProcedureCallPipeTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ProcedureCallPipeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ProduceResultsPipeTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ProduceResultsPipeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ProjectEndpointsPipeTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ProjectEndpointsPipeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/PruningVarLengthExpandPipeTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/PruningVarLengthExpandPipeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/QueryStateTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/QueryStateTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/RelationshipCountFromCountStorePipeTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/RelationshipCountFromCountStorePipeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/RollUpApplyPipeTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/RollUpApplyPipeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/SelectOrSemiApplyPipeTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/SelectOrSemiApplyPipeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/SemiApplyPipeTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/SemiApplyPipeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/SetPropertyPipeTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/SetPropertyPipeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/SingleShortestPathPipeTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/SingleShortestPathPipeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/SkipPipeTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/SkipPipeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/SortPipeTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/SortPipeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/Top1WithTiesPipeTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/Top1WithTiesPipeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/TopPipeTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/TopPipeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/TriadicSelectionPipeTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/TriadicSelectionPipeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/UndirectedDirectedRelationshipByIdSeekPipeTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/UndirectedDirectedRelationshipByIdSeekPipeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/UnionIteratorTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/UnionIteratorTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/UnwindPipeTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/UnwindPipeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ValueHashJoinPipeTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ValueHashJoinPipeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/VarLengthExpandPipeTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/VarLengthExpandPipeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/aggregation/AggregateTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/aggregation/AggregateTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/aggregation/AvgFunctionTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/aggregation/AvgFunctionTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/aggregation/CollectFunctionTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/aggregation/CollectFunctionTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/aggregation/CountTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/aggregation/CountTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/aggregation/MaxFunctionTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/aggregation/MaxFunctionTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/aggregation/MinFunctionTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/aggregation/MinFunctionTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/aggregation/PercentileFunctionsTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/aggregation/PercentileFunctionsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/aggregation/StdevFunctionTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/aggregation/StdevFunctionTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/aggregation/SumFunctionTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/aggregation/SumFunctionTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/matching/HistoryTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/matching/HistoryTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/matching/PatternRelationshipTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/matching/PatternRelationshipTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/ir-3.4/NOTICE.txt
+++ b/community/cypher/ir-3.4/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/community/cypher/ir-3.4/src/main/scala/org/neo4j/cypher/internal/ir/v3_4/CSVFormat.scala
+++ b/community/cypher/ir-3.4/src/main/scala/org/neo4j/cypher/internal/ir/v3_4/CSVFormat.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/ir-3.4/src/main/scala/org/neo4j/cypher/internal/ir/v3_4/CreatesPropertyKeys.scala
+++ b/community/cypher/ir-3.4/src/main/scala/org/neo4j/cypher/internal/ir/v3_4/CreatesPropertyKeys.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/ir-3.4/src/main/scala/org/neo4j/cypher/internal/ir/v3_4/MutatingPattern.scala
+++ b/community/cypher/ir-3.4/src/main/scala/org/neo4j/cypher/internal/ir/v3_4/MutatingPattern.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/ir-3.4/src/main/scala/org/neo4j/cypher/internal/ir/v3_4/PatternRelationship.scala
+++ b/community/cypher/ir-3.4/src/main/scala/org/neo4j/cypher/internal/ir/v3_4/PatternRelationship.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/ir-3.4/src/main/scala/org/neo4j/cypher/internal/ir/v3_4/PeriodicCommit.scala
+++ b/community/cypher/ir-3.4/src/main/scala/org/neo4j/cypher/internal/ir/v3_4/PeriodicCommit.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/ir-3.4/src/main/scala/org/neo4j/cypher/internal/ir/v3_4/PlannerQuery.scala
+++ b/community/cypher/ir-3.4/src/main/scala/org/neo4j/cypher/internal/ir/v3_4/PlannerQuery.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/ir-3.4/src/main/scala/org/neo4j/cypher/internal/ir/v3_4/Predicate.scala
+++ b/community/cypher/ir-3.4/src/main/scala/org/neo4j/cypher/internal/ir/v3_4/Predicate.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/ir-3.4/src/main/scala/org/neo4j/cypher/internal/ir/v3_4/QueryGraph.scala
+++ b/community/cypher/ir-3.4/src/main/scala/org/neo4j/cypher/internal/ir/v3_4/QueryGraph.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/ir-3.4/src/main/scala/org/neo4j/cypher/internal/ir/v3_4/QueryHorizon.scala
+++ b/community/cypher/ir-3.4/src/main/scala/org/neo4j/cypher/internal/ir/v3_4/QueryHorizon.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/ir-3.4/src/main/scala/org/neo4j/cypher/internal/ir/v3_4/QueryShuffle.scala
+++ b/community/cypher/ir-3.4/src/main/scala/org/neo4j/cypher/internal/ir/v3_4/QueryShuffle.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/ir-3.4/src/main/scala/org/neo4j/cypher/internal/ir/v3_4/Selections.scala
+++ b/community/cypher/ir-3.4/src/main/scala/org/neo4j/cypher/internal/ir/v3_4/Selections.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/ir-3.4/src/main/scala/org/neo4j/cypher/internal/ir/v3_4/ShortestPathPattern.scala
+++ b/community/cypher/ir-3.4/src/main/scala/org/neo4j/cypher/internal/ir/v3_4/ShortestPathPattern.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/ir-3.4/src/main/scala/org/neo4j/cypher/internal/ir/v3_4/Strictness.scala
+++ b/community/cypher/ir-3.4/src/main/scala/org/neo4j/cypher/internal/ir/v3_4/Strictness.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/ir-3.4/src/main/scala/org/neo4j/cypher/internal/ir/v3_4/StrictnessMode.scala
+++ b/community/cypher/ir-3.4/src/main/scala/org/neo4j/cypher/internal/ir/v3_4/StrictnessMode.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/ir-3.4/src/main/scala/org/neo4j/cypher/internal/ir/v3_4/UpdateGraph.scala
+++ b/community/cypher/ir-3.4/src/main/scala/org/neo4j/cypher/internal/ir/v3_4/UpdateGraph.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/ir-3.4/src/main/scala/org/neo4j/cypher/internal/ir/v3_4/helpers/ExpressionConverters.scala
+++ b/community/cypher/ir-3.4/src/main/scala/org/neo4j/cypher/internal/ir/v3_4/helpers/ExpressionConverters.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/ir-3.4/src/main/scala/org/neo4j/cypher/internal/ir/v3_4/helpers/PatternConverters.scala
+++ b/community/cypher/ir-3.4/src/main/scala/org/neo4j/cypher/internal/ir/v3_4/helpers/PatternConverters.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/ir-3.4/src/test/scala/org/neo4j/cypher/internal/ir/v3_4/SelectivityTest.scala
+++ b/community/cypher/ir-3.4/src/test/scala/org/neo4j/cypher/internal/ir/v3_4/SelectivityTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/planner-spi-3.4/NOTICE.txt
+++ b/community/cypher/planner-spi-3.4/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/community/cypher/planner-spi-3.4/src/main/scala/org/neo4j/cypher/internal/planner/v3_4/spi/GraphStatistics.scala
+++ b/community/cypher/planner-spi-3.4/src/main/scala/org/neo4j/cypher/internal/planner/v3_4/spi/GraphStatistics.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/planner-spi-3.4/src/main/scala/org/neo4j/cypher/internal/planner/v3_4/spi/IdempotentResult.scala
+++ b/community/cypher/planner-spi-3.4/src/main/scala/org/neo4j/cypher/internal/planner/v3_4/spi/IdempotentResult.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/planner-spi-3.4/src/main/scala/org/neo4j/cypher/internal/planner/v3_4/spi/IndexDescriptor.scala
+++ b/community/cypher/planner-spi-3.4/src/main/scala/org/neo4j/cypher/internal/planner/v3_4/spi/IndexDescriptor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/planner-spi-3.4/src/main/scala/org/neo4j/cypher/internal/planner/v3_4/spi/InstrumentedGraphStatistics.scala
+++ b/community/cypher/planner-spi-3.4/src/main/scala/org/neo4j/cypher/internal/planner/v3_4/spi/InstrumentedGraphStatistics.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/planner-spi-3.4/src/main/scala/org/neo4j/cypher/internal/planner/v3_4/spi/KernelStatisticProvider.scala
+++ b/community/cypher/planner-spi-3.4/src/main/scala/org/neo4j/cypher/internal/planner/v3_4/spi/KernelStatisticProvider.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/planner-spi-3.4/src/main/scala/org/neo4j/cypher/internal/planner/v3_4/spi/PlanContext.scala
+++ b/community/cypher/planner-spi-3.4/src/main/scala/org/neo4j/cypher/internal/planner/v3_4/spi/PlanContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/planner-spi-3.4/src/main/scala/org/neo4j/cypher/internal/planner/v3_4/spi/PlannerName.scala
+++ b/community/cypher/planner-spi-3.4/src/main/scala/org/neo4j/cypher/internal/planner/v3_4/spi/PlannerName.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/planner-spi-3.4/src/main/scala/org/neo4j/cypher/internal/planner/v3_4/spi/PlanningAttributes.scala
+++ b/community/cypher/planner-spi-3.4/src/main/scala/org/neo4j/cypher/internal/planner/v3_4/spi/PlanningAttributes.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/planner-spi-3.4/src/main/scala/org/neo4j/cypher/internal/planner/v3_4/spi/TokenContext.scala
+++ b/community/cypher/planner-spi-3.4/src/main/scala/org/neo4j/cypher/internal/planner/v3_4/spi/TokenContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/runtime-util/NOTICE.txt
+++ b/community/cypher/runtime-util/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/community/cypher/runtime-util/src/main/java/org/neo4j/cypher/internal/DefaultComparatorTopTable.java
+++ b/community/cypher/runtime-util/src/main/java/org/neo4j/cypher/internal/DefaultComparatorTopTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/runtime-util/src/main/java/org/neo4j/cypher/internal/javacompat/GraphDatabaseCypherService.java
+++ b/community/cypher/runtime-util/src/main/java/org/neo4j/cypher/internal/javacompat/GraphDatabaseCypherService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/runtime-util/src/main/java/org/neo4j/cypher/internal/javacompat/ValueToObjectSerializer.java
+++ b/community/cypher/runtime-util/src/main/java/org/neo4j/cypher/internal/javacompat/ValueToObjectSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/runtime-util/src/main/java/org/neo4j/cypher/result/QueryResult.java
+++ b/community/cypher/runtime-util/src/main/java/org/neo4j/cypher/result/QueryResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/CypherException.scala
+++ b/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/CypherException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/SyntaxException.scala
+++ b/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/SyntaxException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/exceptionHandler.scala
+++ b/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/exceptionHandler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/ArrayBackedMap.scala
+++ b/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/ArrayBackedMap.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/Counter.scala
+++ b/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/Counter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/ExecutionMode.scala
+++ b/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/ExecutionMode.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/InternalExecutionResult.scala
+++ b/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/InternalExecutionResult.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/InternalQueryType.scala
+++ b/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/InternalQueryType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/JavaListWrapper.scala
+++ b/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/JavaListWrapper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/LenientCreateRelationship.scala
+++ b/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/LenientCreateRelationship.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/ProcedureCallMode.scala
+++ b/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/ProcedureCallMode.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/QueryContext.scala
+++ b/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/QueryContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/QueryStatistics.scala
+++ b/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/QueryStatistics.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/RuntimeJavaValueConverter.scala
+++ b/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/RuntimeJavaValueConverter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/RuntimeScalaValueConverter.scala
+++ b/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/RuntimeScalaValueConverter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/isGraphKernelResultValue.scala
+++ b/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/isGraphKernelResultValue.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/planDescription/InternalPlanDescription.scala
+++ b/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/planDescription/InternalPlanDescription.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/planDescription/LogicalPlan2PlanDescription.scala
+++ b/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/planDescription/LogicalPlan2PlanDescription.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/planDescription/PlanDescriptionArgumentSerializer.scala
+++ b/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/planDescription/PlanDescriptionArgumentSerializer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/planDescription/renderAsTreeTable.scala
+++ b/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/planDescription/renderAsTreeTable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/planDescription/renderSummary.scala
+++ b/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/planDescription/renderSummary.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/package.scala
+++ b/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/runtime-util/src/test/java/org/neo4j/cypher/internal/DefaultComparatorTopTableTest.java
+++ b/community/cypher/runtime-util/src/test/java/org/neo4j/cypher/internal/DefaultComparatorTopTableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/runtime-util/src/test/scala/org/neo4j/cypher/FakeClock.scala
+++ b/community/cypher/runtime-util/src/test/scala/org/neo4j/cypher/FakeClock.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/runtime-util/src/test/scala/org/neo4j/cypher/GraphDatabaseFunSuite.scala
+++ b/community/cypher/runtime-util/src/test/scala/org/neo4j/cypher/GraphDatabaseFunSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/runtime-util/src/test/scala/org/neo4j/cypher/GraphDatabaseTestSupport.scala
+++ b/community/cypher/runtime-util/src/test/scala/org/neo4j/cypher/GraphDatabaseTestSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/runtime-util/src/test/scala/org/neo4j/cypher/GraphIcing.scala
+++ b/community/cypher/runtime-util/src/test/scala/org/neo4j/cypher/GraphIcing.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/runtime-util/src/test/scala/org/neo4j/cypher/SyntaxExceptionTest.scala
+++ b/community/cypher/runtime-util/src/test/scala/org/neo4j/cypher/SyntaxExceptionTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/runtime-util/src/test/scala/org/neo4j/cypher/internal/runtime/ArrayBackedMapTest.scala
+++ b/community/cypher/runtime-util/src/test/scala/org/neo4j/cypher/internal/runtime/ArrayBackedMapTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/runtime-util/src/test/scala/org/neo4j/cypher/internal/runtime/CounterTest.scala
+++ b/community/cypher/runtime-util/src/test/scala/org/neo4j/cypher/internal/runtime/CounterTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/runtime-util/src/test/scala/org/neo4j/cypher/internal/runtime/CreateTempFileTestSupport.scala
+++ b/community/cypher/runtime-util/src/test/scala/org/neo4j/cypher/internal/runtime/CreateTempFileTestSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/runtime-util/src/test/scala/org/neo4j/cypher/internal/runtime/ImplicitValueConversion.scala
+++ b/community/cypher/runtime-util/src/test/scala/org/neo4j/cypher/internal/runtime/ImplicitValueConversion.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/runtime-util/src/test/scala/org/neo4j/cypher/internal/runtime/PathImpl.scala
+++ b/community/cypher/runtime-util/src/test/scala/org/neo4j/cypher/internal/runtime/PathImpl.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/runtime-util/src/test/scala/org/neo4j/cypher/internal/runtime/RuntimeJavaValueConverterTest.scala
+++ b/community/cypher/runtime-util/src/test/scala/org/neo4j/cypher/internal/runtime/RuntimeJavaValueConverterTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/runtime-util/src/test/scala/org/neo4j/cypher/internal/runtime/RuntimeScalaValueConverterTest.scala
+++ b/community/cypher/runtime-util/src/test/scala/org/neo4j/cypher/internal/runtime/RuntimeScalaValueConverterTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/runtime-util/src/test/scala/org/neo4j/cypher/internal/runtime/planDescription/CompactedPlanDescriptionTest.scala
+++ b/community/cypher/runtime-util/src/test/scala/org/neo4j/cypher/internal/runtime/planDescription/CompactedPlanDescriptionTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/runtime-util/src/test/scala/org/neo4j/cypher/internal/runtime/planDescription/InternalPlanDescriptionTest.scala
+++ b/community/cypher/runtime-util/src/test/scala/org/neo4j/cypher/internal/runtime/planDescription/InternalPlanDescriptionTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/runtime-util/src/test/scala/org/neo4j/cypher/internal/runtime/planDescription/LogicalPlan2PlanDescriptionTest.scala
+++ b/community/cypher/runtime-util/src/test/scala/org/neo4j/cypher/internal/runtime/planDescription/LogicalPlan2PlanDescriptionTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/runtime-util/src/test/scala/org/neo4j/cypher/internal/runtime/planDescription/PlanDescriptionArgumentSerializerTests.scala
+++ b/community/cypher/runtime-util/src/test/scala/org/neo4j/cypher/internal/runtime/planDescription/PlanDescriptionArgumentSerializerTests.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/runtime-util/src/test/scala/org/neo4j/cypher/internal/runtime/planDescription/RenderSummaryTest.scala
+++ b/community/cypher/runtime-util/src/test/scala/org/neo4j/cypher/internal/runtime/planDescription/RenderSummaryTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/runtime-util/src/test/scala/org/neo4j/cypher/internal/runtime/planDescription/RenderTreeTableTest.scala
+++ b/community/cypher/runtime-util/src/test/scala/org/neo4j/cypher/internal/runtime/planDescription/RenderTreeTableTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/cypher/util-3.4/NOTICE.txt
+++ b/community/cypher/util-3.4/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgBD
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/community/cypher/util-3.4/src/main/java/org/neo4j/cypher/internal/util/v3_4/AssertionRunner.java
+++ b/community/cypher/util-3.4/src/main/java/org/neo4j/cypher/internal/util/v3_4/AssertionRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/ASTNode.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/ASTNode.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/AssertionUtils.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/AssertionUtils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/Cardinality.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/Cardinality.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/CypherException.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/CypherException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/Eagerly.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/Eagerly.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/Foldable.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/Foldable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/InputPosition.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/InputPosition.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/NameId.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/NameId.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/NonEmptyList.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/NonEmptyList.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/PrefixNameGenerator.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/PrefixNameGenerator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/Ref.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/Ref.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/Rewritable.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/Rewritable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/Selectivity.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/Selectivity.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/TaskCloser.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/TaskCloser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/Unchangeable.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/Unchangeable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/ZeroOneOrMany.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/ZeroOneOrMany.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/attribution/Attribute.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/attribution/Attribute.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/attribution/Ids.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/attribution/Ids.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/package.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/spi/MapToPublicExceptions.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/spi/MapToPublicExceptions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/symbols/AnyType.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/symbols/AnyType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/symbols/BooleanType.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/symbols/BooleanType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/symbols/CypherType.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/symbols/CypherType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/symbols/FloatType.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/symbols/FloatType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/symbols/GeometryType.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/symbols/GeometryType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/symbols/GraphRefType.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/symbols/GraphRefType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/symbols/IntegerType.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/symbols/IntegerType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/symbols/ListType.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/symbols/ListType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/symbols/MapType.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/symbols/MapType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/symbols/NodeType.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/symbols/NodeType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/symbols/NumberType.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/symbols/NumberType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/symbols/PathType.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/symbols/PathType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/symbols/PointType.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/symbols/PointType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/symbols/RelationshipType.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/symbols/RelationshipType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/symbols/StringType.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/symbols/StringType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/symbols/TemporalTypes.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/symbols/TemporalTypes.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/symbols/TypeRange.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/symbols/TypeRange.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/symbols/TypeSpec.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/symbols/TypeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/symbols/package.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/symbols/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/util-3.4/src/test/scala/org/neo4j/cypher/internal/util/v3_4/DummyPosition.scala
+++ b/community/cypher/util-3.4/src/test/scala/org/neo4j/cypher/internal/util/v3_4/DummyPosition.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/util-3.4/src/test/scala/org/neo4j/cypher/internal/util/v3_4/EagerlyTest.scala
+++ b/community/cypher/util-3.4/src/test/scala/org/neo4j/cypher/internal/util/v3_4/EagerlyTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/util-3.4/src/test/scala/org/neo4j/cypher/internal/util/v3_4/RewritableTest.scala
+++ b/community/cypher/util-3.4/src/test/scala/org/neo4j/cypher/internal/util/v3_4/RewritableTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/util-3.4/src/test/scala/org/neo4j/cypher/internal/util/v3_4/TaskCloserTest.scala
+++ b/community/cypher/util-3.4/src/test/scala/org/neo4j/cypher/internal/util/v3_4/TaskCloserTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/util-3.4/src/test/scala/org/neo4j/cypher/internal/util/v3_4/ZeroOneOrManyTest.scala
+++ b/community/cypher/util-3.4/src/test/scala/org/neo4j/cypher/internal/util/v3_4/ZeroOneOrManyTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/util-3.4/src/test/scala/org/neo4j/cypher/internal/util/v3_4/attribution/AttributeTest.scala
+++ b/community/cypher/util-3.4/src/test/scala/org/neo4j/cypher/internal/util/v3_4/attribution/AttributeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/util-3.4/src/test/scala/org/neo4j/cypher/internal/util/v3_4/test_helpers/CypherFunSuite.scala
+++ b/community/cypher/util-3.4/src/test/scala/org/neo4j/cypher/internal/util/v3_4/test_helpers/CypherFunSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/util-3.4/src/test/scala/org/neo4j/cypher/internal/util/v3_4/test_helpers/CypherTestSupport.scala
+++ b/community/cypher/util-3.4/src/test/scala/org/neo4j/cypher/internal/util/v3_4/test_helpers/CypherTestSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/util-3.4/src/test/scala/org/neo4j/cypher/internal/util/v3_4/test_helpers/IgnoreAllTests.scala
+++ b/community/cypher/util-3.4/src/test/scala/org/neo4j/cypher/internal/util/v3_4/test_helpers/IgnoreAllTests.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/cypher/util-3.4/src/test/scala/org/neo4j/cypher/internal/util/v3_4/test_helpers/WindowsStringSafe.scala
+++ b/community/cypher/util-3.4/src/test/scala/org/neo4j/cypher/internal/util/v3_4/test_helpers/WindowsStringSafe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/dbms/NOTICE.txt
+++ b/community/dbms/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/CannotWriteException.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/CannotWriteException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/CsvImporter.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/CsvImporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/DatabaseImporter.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/DatabaseImporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/DiagnosticsReportCommand.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/DiagnosticsReportCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/DiagnosticsReportCommandProvider.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/DiagnosticsReportCommandProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/DumpCommand.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/DumpCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/DumpCommandProvider.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/DumpCommandProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/ImportCommand.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/ImportCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/ImportCommandProvider.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/ImportCommandProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/Importer.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/Importer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/ImporterFactory.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/ImporterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/LoadCommand.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/LoadCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/LoadCommandProvider.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/LoadCommandProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/MemoryRecommendationsCommand.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/MemoryRecommendationsCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/MemoryRecommendationsCommandProvider.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/MemoryRecommendationsCommandProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/OfflineBackupCommandSection.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/OfflineBackupCommandSection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/StoreInfoCommand.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/StoreInfoCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/StoreInfoCommandProvider.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/StoreInfoCommandProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/StoreLockChecker.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/StoreLockChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/config/WrappedBatchImporterConfigurationForNeo4jAdmin.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/config/WrappedBatchImporterConfigurationForNeo4jAdmin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/config/WrappedCsvInputConfigurationForNeo4jAdmin.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/config/WrappedCsvInputConfigurationForNeo4jAdmin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/dbms/src/main/java/org/neo4j/dbms/DatabaseManagementSystemSettings.java
+++ b/community/dbms/src/main/java/org/neo4j/dbms/DatabaseManagementSystemSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/dbms/src/main/java/org/neo4j/dbms/archive/Dumper.java
+++ b/community/dbms/src/main/java/org/neo4j/dbms/archive/Dumper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/dbms/src/main/java/org/neo4j/dbms/archive/IncorrectFormat.java
+++ b/community/dbms/src/main/java/org/neo4j/dbms/archive/IncorrectFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/dbms/src/main/java/org/neo4j/dbms/archive/InvalidDumpEntryException.java
+++ b/community/dbms/src/main/java/org/neo4j/dbms/archive/InvalidDumpEntryException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/dbms/src/main/java/org/neo4j/dbms/archive/Loader.java
+++ b/community/dbms/src/main/java/org/neo4j/dbms/archive/Loader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/dbms/src/main/java/org/neo4j/dbms/archive/Utils.java
+++ b/community/dbms/src/main/java/org/neo4j/dbms/archive/Utils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/dbms/src/main/java/org/neo4j/dbms/diagnostics/jmx/JMXDumper.java
+++ b/community/dbms/src/main/java/org/neo4j/dbms/diagnostics/jmx/JMXDumper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/dbms/src/main/java/org/neo4j/dbms/diagnostics/jmx/JmxDump.java
+++ b/community/dbms/src/main/java/org/neo4j/dbms/diagnostics/jmx/JmxDump.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/dbms/src/main/java/org/neo4j/dbms/diagnostics/jmx/LocalVirtualMachine.java
+++ b/community/dbms/src/main/java/org/neo4j/dbms/diagnostics/jmx/LocalVirtualMachine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/dbms/src/main/java/org/neo4j/dbms/diagnostics/jmx/Reports.java
+++ b/community/dbms/src/main/java/org/neo4j/dbms/diagnostics/jmx/Reports.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/dbms/src/main/java/org/neo4j/dbms/diagnostics/jmx/ReportsBean.java
+++ b/community/dbms/src/main/java/org/neo4j/dbms/diagnostics/jmx/ReportsBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/CsvImporterTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/CsvImporterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/DatabaseImporterTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/DatabaseImporterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/DiagnosticsReportCommandIT.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/DiagnosticsReportCommandIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/DiagnosticsReportCommandTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/DiagnosticsReportCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/DumpCommandTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/DumpCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/ImportCommandTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/ImportCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/LoadCommandTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/LoadCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/MemoryRecommendationsCommandTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/MemoryRecommendationsCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/StoreInfoCommandTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/StoreInfoCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/UtilTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/UtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/config/WrappedBatchImporterConfigurationForNeo4jAdminTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/config/WrappedBatchImporterConfigurationForNeo4jAdminTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/config/WrappedCsvInputConfigurationForNeo4jAdminTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/config/WrappedCsvInputConfigurationForNeo4jAdminTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/dbms/src/test/java/org/neo4j/dbms/DatabaseManagementSystemSettingsTest.java
+++ b/community/dbms/src/test/java/org/neo4j/dbms/DatabaseManagementSystemSettingsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/dbms/src/test/java/org/neo4j/dbms/archive/ArchiveTest.java
+++ b/community/dbms/src/test/java/org/neo4j/dbms/archive/ArchiveTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/dbms/src/test/java/org/neo4j/dbms/archive/DumperTest.java
+++ b/community/dbms/src/test/java/org/neo4j/dbms/archive/DumperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/dbms/src/test/java/org/neo4j/dbms/archive/LoaderTest.java
+++ b/community/dbms/src/test/java/org/neo4j/dbms/archive/LoaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/dbms/src/test/java/org/neo4j/dbms/archive/TestUtils.java
+++ b/community/dbms/src/test/java/org/neo4j/dbms/archive/TestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/NOTICE.txt
+++ b/community/graph-algo/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/CommonEvaluators.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/CommonEvaluators.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/CostAccumulator.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/CostAccumulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/CostEvaluator.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/CostEvaluator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/EstimateEvaluator.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/EstimateEvaluator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/GraphAlgoFactory.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/GraphAlgoFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/MaxCostEvaluator.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/MaxCostEvaluator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/PathFinder.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/PathFinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/WeightedPath.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/WeightedPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/ancestor/AncestorsUtil.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/ancestor/AncestorsUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/centrality/BetweennessCentrality.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/centrality/BetweennessCentrality.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/centrality/ClosenessCentrality.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/centrality/ClosenessCentrality.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/centrality/CostDivider.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/centrality/CostDivider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/centrality/Eccentricity.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/centrality/Eccentricity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/centrality/EigenvectorCentrality.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/centrality/EigenvectorCentrality.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/centrality/EigenvectorCentralityArnoldi.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/centrality/EigenvectorCentralityArnoldi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/centrality/EigenvectorCentralityBase.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/centrality/EigenvectorCentralityBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/centrality/EigenvectorCentralityPower.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/centrality/EigenvectorCentralityPower.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/centrality/NetworkDiameter.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/centrality/NetworkDiameter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/centrality/NetworkRadius.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/centrality/NetworkRadius.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/centrality/ParallellCentralityCalculation.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/centrality/ParallellCentralityCalculation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/centrality/ShortestPathBasedCentrality.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/centrality/ShortestPathBasedCentrality.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/centrality/StressCentrality.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/centrality/StressCentrality.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/centrality/package-info.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/centrality/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/path/AStar.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/path/AStar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/path/AllPaths.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/path/AllPaths.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/path/AllSimplePaths.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/path/AllSimplePaths.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/path/Dijkstra.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/path/Dijkstra.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/path/DijkstraBidirectional.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/path/DijkstraBidirectional.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/path/ExactDepthPathFinder.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/path/ExactDepthPathFinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/path/ShortestPath.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/path/ShortestPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/path/TraversalAStar.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/path/TraversalAStar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/path/TraversalPathFinder.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/path/TraversalPathFinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/path/TraversalShortestPath.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/path/TraversalShortestPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/shortestpath/Dijkstra.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/shortestpath/Dijkstra.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/shortestpath/DijkstraPriorityQueue.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/shortestpath/DijkstraPriorityQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/shortestpath/DijkstraPriorityQueueFibonacciImpl.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/shortestpath/DijkstraPriorityQueueFibonacciImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/shortestpath/DijkstraPriorityQueueImpl.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/shortestpath/DijkstraPriorityQueueImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/shortestpath/FloydWarshall.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/shortestpath/FloydWarshall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/shortestpath/SingleSourceShortestPath.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/shortestpath/SingleSourceShortestPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/shortestpath/SingleSourceShortestPathBFS.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/shortestpath/SingleSourceShortestPathBFS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/shortestpath/SingleSourceShortestPathDijkstra.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/shortestpath/SingleSourceShortestPathDijkstra.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/shortestpath/SingleSourceSingleSinkShortestPath.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/shortestpath/SingleSourceSingleSinkShortestPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/shortestpath/Util.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/shortestpath/Util.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/shortestpath/package-info.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/shortestpath/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/util/BestFirstSelectorFactory.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/util/BestFirstSelectorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/util/DijkstraBranchCollisionDetector.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/util/DijkstraBranchCollisionDetector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/util/DijkstraSelectorFactory.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/util/DijkstraSelectorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/util/DoubleAdder.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/util/DoubleAdder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/util/DoubleComparator.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/util/DoubleComparator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/util/DoubleEvaluator.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/util/DoubleEvaluator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/util/DoubleEvaluatorWithDefault.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/util/DoubleEvaluatorWithDefault.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/util/FibonacciHeap.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/util/FibonacciHeap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/util/GeoEstimateEvaluator.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/util/GeoEstimateEvaluator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/util/IntegerAdder.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/util/IntegerAdder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/util/IntegerComparator.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/util/IntegerComparator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/util/IntegerEvaluator.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/util/IntegerEvaluator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/util/LiteDepthFirstSelector.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/util/LiteDepthFirstSelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/util/MatrixUtil.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/util/MatrixUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/util/PathImpl.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/util/PathImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/util/PathInterest.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/util/PathInterest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/util/PathInterestFactory.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/util/PathInterestFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/util/PriorityMap.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/util/PriorityMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/util/TopFetchingWeightedPathIterator.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/util/TopFetchingWeightedPathIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/util/WeightedPathImpl.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/util/WeightedPathImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/util/WeightedPathIterator.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/util/WeightedPathIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/package-info.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/test/java/common/AbstractTestBase.java
+++ b/community/graph-algo/src/test/java/common/AbstractTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/test/java/common/GraphDefinition.java
+++ b/community/graph-algo/src/test/java/common/GraphDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/test/java/common/GraphDescription.java
+++ b/community/graph-algo/src/test/java/common/GraphDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/test/java/common/Neo4jAlgoTestCase.java
+++ b/community/graph-algo/src/test/java/common/Neo4jAlgoTestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/test/java/common/SimpleGraphBuilder.java
+++ b/community/graph-algo/src/test/java/common/SimpleGraphBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/test/java/common/StandardGraphs.java
+++ b/community/graph-algo/src/test/java/common/StandardGraphs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/test/java/org/neo4j/graphalgo/UtilTest.java
+++ b/community/graph-algo/src/test/java/org/neo4j/graphalgo/UtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/test/java/org/neo4j/graphalgo/centrality/BetweennessCentralityTest.java
+++ b/community/graph-algo/src/test/java/org/neo4j/graphalgo/centrality/BetweennessCentralityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/test/java/org/neo4j/graphalgo/centrality/ClosenessCentralityTest.java
+++ b/community/graph-algo/src/test/java/org/neo4j/graphalgo/centrality/ClosenessCentralityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/test/java/org/neo4j/graphalgo/centrality/EccentricityTest.java
+++ b/community/graph-algo/src/test/java/org/neo4j/graphalgo/centrality/EccentricityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/test/java/org/neo4j/graphalgo/centrality/EigenvectorCentralityArnoldiTest.java
+++ b/community/graph-algo/src/test/java/org/neo4j/graphalgo/centrality/EigenvectorCentralityArnoldiTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/test/java/org/neo4j/graphalgo/centrality/EigenvectorCentralityPowerTest.java
+++ b/community/graph-algo/src/test/java/org/neo4j/graphalgo/centrality/EigenvectorCentralityPowerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/test/java/org/neo4j/graphalgo/centrality/EigenvectorCentralityTest.java
+++ b/community/graph-algo/src/test/java/org/neo4j/graphalgo/centrality/EigenvectorCentralityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/test/java/org/neo4j/graphalgo/centrality/NetworkDiameterTest.java
+++ b/community/graph-algo/src/test/java/org/neo4j/graphalgo/centrality/NetworkDiameterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/test/java/org/neo4j/graphalgo/centrality/NetworkRadiusTest.java
+++ b/community/graph-algo/src/test/java/org/neo4j/graphalgo/centrality/NetworkRadiusTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/test/java/org/neo4j/graphalgo/centrality/ParallellCentralityCalculationTest.java
+++ b/community/graph-algo/src/test/java/org/neo4j/graphalgo/centrality/ParallellCentralityCalculationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/test/java/org/neo4j/graphalgo/centrality/StressCentralityTest.java
+++ b/community/graph-algo/src/test/java/org/neo4j/graphalgo/centrality/StressCentralityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/test/java/org/neo4j/graphalgo/impl/ancestor/AncestorTestCase.java
+++ b/community/graph-algo/src/test/java/org/neo4j/graphalgo/impl/ancestor/AncestorTestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/test/java/org/neo4j/graphalgo/impl/path/TestShortestPath.java
+++ b/community/graph-algo/src/test/java/org/neo4j/graphalgo/impl/path/TestShortestPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/test/java/org/neo4j/graphalgo/impl/util/PathImplTest.java
+++ b/community/graph-algo/src/test/java/org/neo4j/graphalgo/impl/util/PathImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/test/java/org/neo4j/graphalgo/impl/util/TestBestFirstSelectorFactory.java
+++ b/community/graph-algo/src/test/java/org/neo4j/graphalgo/impl/util/TestBestFirstSelectorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/test/java/org/neo4j/graphalgo/impl/util/TestPriorityMap.java
+++ b/community/graph-algo/src/test/java/org/neo4j/graphalgo/impl/util/TestPriorityMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/test/java/org/neo4j/graphalgo/impl/util/TestTopFetchingWeightedPathIterator.java
+++ b/community/graph-algo/src/test/java/org/neo4j/graphalgo/impl/util/TestTopFetchingWeightedPathIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/test/java/org/neo4j/graphalgo/path/DijkstraIncreasingWeightTest.java
+++ b/community/graph-algo/src/test/java/org/neo4j/graphalgo/path/DijkstraIncreasingWeightTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/test/java/org/neo4j/graphalgo/path/DijkstraTest.java
+++ b/community/graph-algo/src/test/java/org/neo4j/graphalgo/path/DijkstraTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/test/java/org/neo4j/graphalgo/path/TestAStar.java
+++ b/community/graph-algo/src/test/java/org/neo4j/graphalgo/path/TestAStar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/test/java/org/neo4j/graphalgo/path/TestAllPaths.java
+++ b/community/graph-algo/src/test/java/org/neo4j/graphalgo/path/TestAllPaths.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/test/java/org/neo4j/graphalgo/path/TestAllSimplePaths.java
+++ b/community/graph-algo/src/test/java/org/neo4j/graphalgo/path/TestAllSimplePaths.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/test/java/org/neo4j/graphalgo/path/TestExactDepthPathFinder.java
+++ b/community/graph-algo/src/test/java/org/neo4j/graphalgo/path/TestExactDepthPathFinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/test/java/org/neo4j/graphalgo/shortestpath/DijkstraDirectionTest.java
+++ b/community/graph-algo/src/test/java/org/neo4j/graphalgo/shortestpath/DijkstraDirectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/test/java/org/neo4j/graphalgo/shortestpath/DijkstraIteratorTest.java
+++ b/community/graph-algo/src/test/java/org/neo4j/graphalgo/shortestpath/DijkstraIteratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/test/java/org/neo4j/graphalgo/shortestpath/DijkstraMultiplePathsTest.java
+++ b/community/graph-algo/src/test/java/org/neo4j/graphalgo/shortestpath/DijkstraMultiplePathsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/test/java/org/neo4j/graphalgo/shortestpath/DijkstraMultipleRelationshipTypesTest.java
+++ b/community/graph-algo/src/test/java/org/neo4j/graphalgo/shortestpath/DijkstraMultipleRelationshipTypesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/test/java/org/neo4j/graphalgo/shortestpath/DijkstraTest.java
+++ b/community/graph-algo/src/test/java/org/neo4j/graphalgo/shortestpath/DijkstraTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/test/java/org/neo4j/graphalgo/shortestpath/FloydWarshallTest.java
+++ b/community/graph-algo/src/test/java/org/neo4j/graphalgo/shortestpath/FloydWarshallTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/test/java/org/neo4j/graphalgo/shortestpath/SingleSourceShortestPathBFSTest.java
+++ b/community/graph-algo/src/test/java/org/neo4j/graphalgo/shortestpath/SingleSourceShortestPathBFSTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/test/java/org/neo4j/graphalgo/shortestpath/SingleSourceShortestPathDijkstraTest.java
+++ b/community/graph-algo/src/test/java/org/neo4j/graphalgo/shortestpath/SingleSourceShortestPathDijkstraTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graph-algo/src/test/java/org/neo4j/graphalgo/shortestpath/SingleSourceShortestPathTest.java
+++ b/community/graph-algo/src/test/java/org/neo4j/graphalgo/shortestpath/SingleSourceShortestPathTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/NOTICE.txt
+++ b/community/graphdb-api/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/ConstraintViolationException.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/ConstraintViolationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/DatabaseShutdownException.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/DatabaseShutdownException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/DependencyResolver.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/DependencyResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/Direction.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/Direction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/DynamicLabel.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/DynamicLabel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/DynamicRelationshipType.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/DynamicRelationshipType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/Entity.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/Entity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/ExecutionPlanDescription.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/ExecutionPlanDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/GraphDatabaseService.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/GraphDatabaseService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/InputPosition.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/InputPosition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/InvalidTransactionTypeException.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/InvalidTransactionTypeException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/Label.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/Label.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/Lock.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/Lock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/MultipleFoundException.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/MultipleFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/Node.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/Node.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/NotFoundException.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/NotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/NotInTransactionException.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/NotInTransactionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/Notification.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/Notification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/Path.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/Path.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/PathExpander.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/PathExpander.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/PathExpanderBuilder.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/PathExpanderBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/PathExpanders.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/PathExpanders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/PropertyContainer.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/PropertyContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/QueryExecutionException.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/QueryExecutionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/QueryExecutionType.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/QueryExecutionType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/QueryStatistics.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/QueryStatistics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/Relationship.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/Relationship.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/RelationshipType.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/RelationshipType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/Result.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/Result.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/SeverityLevel.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/SeverityLevel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/StringSearchMode.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/StringSearchMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/Transaction.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/Transaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/TransactionFailureException.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/TransactionFailureException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/TransactionGuardException.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/TransactionGuardException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/TransactionTerminatedException.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/TransactionTerminatedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/TransientDatabaseFailureException.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/TransientDatabaseFailureException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/TransientFailureException.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/TransientFailureException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/TransientTransactionFailureException.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/TransientTransactionFailureException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/config/BaseSetting.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/config/BaseSetting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/config/Configuration.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/config/Configuration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/config/InvalidSettingException.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/config/InvalidSettingException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/config/ScopeAwareSetting.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/config/ScopeAwareSetting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/config/Setting.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/config/Setting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/config/SettingGroup.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/config/SettingGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/config/SettingValidator.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/config/SettingValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/config/package-info.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/config/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/event/ErrorState.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/event/ErrorState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/event/KernelEventHandler.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/event/KernelEventHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/event/LabelEntry.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/event/LabelEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/event/PropertyEntry.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/event/PropertyEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/event/TransactionData.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/event/TransactionData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/event/TransactionEventHandler.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/event/TransactionEventHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/event/package-info.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/event/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/impl/ExtendedPath.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/impl/ExtendedPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/impl/OrderedByTypeExpander.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/impl/OrderedByTypeExpander.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/impl/StandardExpander.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/impl/StandardExpander.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/impl/traversal/AbstractSelectorOrderer.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/impl/traversal/AbstractSelectorOrderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/impl/traversal/BidirectionalTraversalBranchPath.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/impl/traversal/BidirectionalTraversalBranchPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/impl/traversal/ShortestPathsBranchCollisionDetector.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/impl/traversal/ShortestPathsBranchCollisionDetector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/impl/traversal/StandardBranchCollisionDetector.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/impl/traversal/StandardBranchCollisionDetector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/index/AutoIndexer.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/index/AutoIndexer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/index/Index.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/index/Index.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/index/IndexHits.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/index/IndexHits.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/index/IndexManager.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/index/IndexManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/index/IndexPopulationProgress.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/index/IndexPopulationProgress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/index/ReadableIndex.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/index/ReadableIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/index/ReadableRelationshipIndex.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/index/ReadableRelationshipIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/index/RelationshipAutoIndexer.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/index/RelationshipAutoIndexer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/index/RelationshipIndex.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/index/RelationshipIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/index/UniqueFactory.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/index/UniqueFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/index/package-info.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/index/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/package-info.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/schema/ConstraintCreator.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/schema/ConstraintCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/schema/ConstraintDefinition.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/schema/ConstraintDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/schema/ConstraintType.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/schema/ConstraintType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/schema/IndexCreator.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/schema/IndexCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/schema/IndexDefinition.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/schema/IndexDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/schema/Schema.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/schema/Schema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/schema/package-info.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/schema/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/security/AuthProviderFailedException.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/security/AuthProviderFailedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/security/AuthProviderTimeoutException.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/security/AuthProviderTimeoutException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/security/AuthorizationExpiredException.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/security/AuthorizationExpiredException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/security/AuthorizationViolationException.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/security/AuthorizationViolationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/security/URLAccessRule.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/security/URLAccessRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/security/URLAccessValidationError.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/security/URLAccessValidationError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/security/WriteOperationsNotAllowedException.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/security/WriteOperationsNotAllowedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/spatial/CRS.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/spatial/CRS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/spatial/Coordinate.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/spatial/Coordinate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/spatial/Geometry.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/spatial/Geometry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/spatial/Point.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/spatial/Point.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/AbstractUniquenessFilter.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/AbstractUniquenessFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/AlternatingSelectorOrderer.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/AlternatingSelectorOrderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/BidirectionalTraversalDescription.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/BidirectionalTraversalDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/BidirectionalUniquenessFilter.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/BidirectionalUniquenessFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/BranchCollisionDetector.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/BranchCollisionDetector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/BranchCollisionPolicies.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/BranchCollisionPolicies.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/BranchCollisionPolicy.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/BranchCollisionPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/BranchOrderingPolicies.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/BranchOrderingPolicies.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/BranchOrderingPolicy.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/BranchOrderingPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/BranchSelector.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/BranchSelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/BranchState.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/BranchState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/Evaluation.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/Evaluation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/Evaluator.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/Evaluator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/Evaluators.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/Evaluators.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/GloballyUnique.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/GloballyUnique.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/InitialBranchState.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/InitialBranchState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/LevelSelectorOrderer.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/LevelSelectorOrderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/LevelUnique.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/LevelUnique.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/NotUnique.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/NotUnique.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/PathEvaluator.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/PathEvaluator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/PathUnique.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/PathUnique.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/Paths.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/Paths.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/PostorderBreadthFirstSelector.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/PostorderBreadthFirstSelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/PostorderDepthFirstSelector.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/PostorderDepthFirstSelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/PreorderBreadthFirstSelector.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/PreorderBreadthFirstSelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/PreorderDepthFirstSelector.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/PreorderDepthFirstSelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/PrimitiveTypeFetcher.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/PrimitiveTypeFetcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/RecentlyUnique.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/RecentlyUnique.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/SideSelector.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/SideSelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/SideSelectorPolicies.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/SideSelectorPolicies.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/SideSelectorPolicy.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/SideSelectorPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/Sorting.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/Sorting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/TraversalBranch.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/TraversalBranch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/TraversalContext.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/TraversalContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/TraversalDescription.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/TraversalDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/TraversalMetadata.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/TraversalMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/Traverser.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/Traverser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/Uniqueness.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/Uniqueness.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/UniquenessFactory.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/UniquenessFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/UniquenessFilter.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/UniquenessFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/package-info.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/test/java/org/neo4j/graphdb/impl/traversal/StandardBranchCollisionDetectorTest.java
+++ b/community/graphdb-api/src/test/java/org/neo4j/graphdb/impl/traversal/StandardBranchCollisionDetectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/graphdb-api/src/test/java/org/neo4j/graphdb/index/IndexPopulationProgressTest.java
+++ b/community/graphdb-api/src/test/java/org/neo4j/graphdb/index/IndexPopulationProgressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/import-tool/NOTICE.txt
+++ b/community/import-tool/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/community/import-tool/src/main/java/org/neo4j/tooling/CharacterConverter.java
+++ b/community/import-tool/src/main/java/org/neo4j/tooling/CharacterConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/import-tool/src/main/java/org/neo4j/tooling/ImportTool.java
+++ b/community/import-tool/src/main/java/org/neo4j/tooling/ImportTool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/import-tool/src/main/java/org/neo4j/tooling/PrintingImportLogicMonitor.java
+++ b/community/import-tool/src/main/java/org/neo4j/tooling/PrintingImportLogicMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/import-tool/src/test/java/org/neo4j/tooling/CharacterConverterTest.java
+++ b/community/import-tool/src/test/java/org/neo4j/tooling/CharacterConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/import-tool/src/test/java/org/neo4j/tooling/CsvOutput.java
+++ b/community/import-tool/src/test/java/org/neo4j/tooling/CsvOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/import-tool/src/test/java/org/neo4j/tooling/ImportToolNumericalFailureTest.java
+++ b/community/import-tool/src/test/java/org/neo4j/tooling/ImportToolNumericalFailureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/import-tool/src/test/java/org/neo4j/tooling/ImportToolTest.java
+++ b/community/import-tool/src/test/java/org/neo4j/tooling/ImportToolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/import-tool/src/test/java/org/neo4j/tooling/PrintingImportLogicMonitorTest.java
+++ b/community/import-tool/src/test/java/org/neo4j/tooling/PrintingImportLogicMonitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/import-tool/src/test/java/org/neo4j/tooling/QuickImport.java
+++ b/community/import-tool/src/test/java/org/neo4j/tooling/QuickImport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/NOTICE.txt
+++ b/community/index/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/CleanupJob.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/CleanupJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/ConsistencyChecker.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/ConsistencyChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/CrashGenerationCleaner.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/CrashGenerationCleaner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/DynamicSizeUtil.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/DynamicSizeUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/FreeListIdProvider.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/FreeListIdProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/FreelistNode.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/FreelistNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/GBPTree.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/GBPTree.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/GBPTreeCleanupJob.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/GBPTreeCleanupJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/GBPTreeLock.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/GBPTreeLock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/Generation.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/Generation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/GenerationSafePointer.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/GenerationSafePointer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/GenerationSafePointerPair.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/GenerationSafePointerPair.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/GroupingRecoveryCleanupWorkCollector.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/GroupingRecoveryCleanupWorkCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/Header.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/Header.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/Hit.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/Hit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/IdProvider.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/IdProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/IdSpace.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/IdSpace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/InternalTreeLogic.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/InternalTreeLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/KeySearch.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/KeySearch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/Layout.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/Layout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/Meta.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/Meta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/MetadataMismatchException.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/MetadataMismatchException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/PageCursorUtil.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/PageCursorUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/PointerChecking.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/PointerChecking.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/RecoveryCleanupWorkCollector.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/RecoveryCleanupWorkCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/RightmostInChain.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/RightmostInChain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/Root.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/Root.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/RootCatchup.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/RootCatchup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/SeekCursor.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/SeekCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/StructurePropagation.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/StructurePropagation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/TreeInconsistencyException.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/TreeInconsistencyException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/TreeNode.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/TreeNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/TreeNodeDynamicSize.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/TreeNodeDynamicSize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/TreeNodeFixedSize.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/TreeNodeFixedSize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/TreeNodeSelector.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/TreeNodeSelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/TreePrinter.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/TreePrinter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/TreeState.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/TreeState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/TreeStatePair.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/TreeStatePair.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/TripCountingRootCatchup.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/TripCountingRootCatchup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/ValueMerger.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/ValueMerger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/ValueMergers.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/ValueMergers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/Writer.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/Writer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/package-info.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/ConsistencyCheckerTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/ConsistencyCheckerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/CrashGenerationCleanerCrashTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/CrashGenerationCleanerCrashTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/CrashGenerationCleanerTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/CrashGenerationCleanerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/DynamicSizeUtilTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/DynamicSizeUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/FormatCompatibilityTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/FormatCompatibilityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/FreeListIdProviderTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/FreeListIdProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/FreelistNodeTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/FreelistNodeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeBuilder.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeConcurrencyDynamicSizeIT.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeConcurrencyDynamicSizeIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeConcurrencyFIxedSizeIT.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeConcurrencyFIxedSizeIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeConcurrencyITBase.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeConcurrencyITBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeDynamixSizeIT.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeDynamixSizeIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeFixedSizeIT.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeFixedSizeIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeITBase.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeITBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeLockTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeLockTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeMetaTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeMetaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreePartialCreateFuzzIT.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreePartialCreateFuzzIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeReadWriteDynamicSizeTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeReadWriteDynamicSizeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeReadWriteFixedSizeTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeReadWriteFixedSizeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeReadWriteTestBase.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeReadWriteTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeRecoveryDynamicSizeIT.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeRecoveryDynamicSizeIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeRecoveryFixedSizeIT.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeRecoveryFixedSizeIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeRecoveryITBase.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeRecoveryITBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeTestUtil.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeTestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GenerationSafePointerPairAdditionalTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GenerationSafePointerPairAdditionalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GenerationSafePointerPairTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GenerationSafePointerPairTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GenerationSafePointerTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GenerationSafePointerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GenerationTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GenerationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GroupingRecoveryCleanupWorkCollectorTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GroupingRecoveryCleanupWorkCollectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/InternalTreeLogicDynamicSizeTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/InternalTreeLogicDynamicSizeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/InternalTreeLogicFixedSizeTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/InternalTreeLogicFixedSizeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/InternalTreeLogicTestBase.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/InternalTreeLogicTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/KeySearchTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/KeySearchTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/KeyValueSeeder.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/KeyValueSeeder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/LargeDynamicKeysIT.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/LargeDynamicKeysIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/LayoutTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/LayoutTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/PageAwareByteArrayCursor.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/PageAwareByteArrayCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/PageCursorUtilTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/PageCursorUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/PointerCheckingTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/PointerCheckingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/RawBytes.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/RawBytes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/SeekCursorDynamicSizeTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/SeekCursorDynamicSizeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/SeekCursorFixedSizeTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/SeekCursorFixedSizeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/SeekCursorTestBase.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/SeekCursorTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/SimpleByteArrayLayout.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/SimpleByteArrayLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/SimpleCleanupMonitor.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/SimpleCleanupMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/SimpleIdProvider.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/SimpleIdProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/SimpleLongLayout.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/SimpleLongLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/TestLayout.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/TestLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/TestPageCursor.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/TestPageCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/ThrowingRunnable.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/ThrowingRunnable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/TreeNodeDynamicSizeTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/TreeNodeDynamicSizeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/TreeNodeFixedSizeTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/TreeNodeFixedSizeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/TreeNodeTestBase.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/TreeNodeTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/TreeStatePairTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/TreeStatePairTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/TreeStateTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/TreeStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/TripCountingRootCatchupTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/TripCountingRootCatchupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/NOTICE.txt
+++ b/community/io/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/community/io/src/main/java/org/neo4j/io/ByteUnit.java
+++ b/community/io/src/main/java/org/neo4j/io/ByteUnit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/IOUtils.java
+++ b/community/io/src/main/java/org/neo4j/io/IOUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/NullOutputStream.java
+++ b/community/io/src/main/java/org/neo4j/io/NullOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/compress/ZipUtils.java
+++ b/community/io/src/main/java/org/neo4j/io/compress/ZipUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/file/Files.java
+++ b/community/io/src/main/java/org/neo4j/io/file/Files.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/fs/DefaultFileSystemAbstraction.java
+++ b/community/io/src/main/java/org/neo4j/io/fs/DefaultFileSystemAbstraction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/fs/DelegateFileSystemAbstraction.java
+++ b/community/io/src/main/java/org/neo4j/io/fs/DelegateFileSystemAbstraction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/fs/DelegatingPath.java
+++ b/community/io/src/main/java/org/neo4j/io/fs/DelegatingPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/fs/FileHandle.java
+++ b/community/io/src/main/java/org/neo4j/io/fs/FileHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/fs/FileSystemAbstraction.java
+++ b/community/io/src/main/java/org/neo4j/io/fs/FileSystemAbstraction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/fs/FileSystemLifecycleAdapter.java
+++ b/community/io/src/main/java/org/neo4j/io/fs/FileSystemLifecycleAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/fs/FileUtils.java
+++ b/community/io/src/main/java/org/neo4j/io/fs/FileUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/fs/FileVisitors.java
+++ b/community/io/src/main/java/org/neo4j/io/fs/FileVisitors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/fs/OffsetChannel.java
+++ b/community/io/src/main/java/org/neo4j/io/fs/OffsetChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/fs/OpenMode.java
+++ b/community/io/src/main/java/org/neo4j/io/fs/OpenMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/fs/StoreChannel.java
+++ b/community/io/src/main/java/org/neo4j/io/fs/StoreChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/fs/StoreFileChannel.java
+++ b/community/io/src/main/java/org/neo4j/io/fs/StoreFileChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/fs/StoreFileChannelUnwrapper.java
+++ b/community/io/src/main/java/org/neo4j/io/fs/StoreFileChannelUnwrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/fs/StreamFilesRecursive.java
+++ b/community/io/src/main/java/org/neo4j/io/fs/StreamFilesRecursive.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/fs/WrappingFileHandle.java
+++ b/community/io/src/main/java/org/neo4j/io/fs/WrappingFileHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/fs/watcher/DefaultFileSystemWatcher.java
+++ b/community/io/src/main/java/org/neo4j/io/fs/watcher/DefaultFileSystemWatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/fs/watcher/FileWatchEventListener.java
+++ b/community/io/src/main/java/org/neo4j/io/fs/watcher/FileWatchEventListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/fs/watcher/FileWatcher.java
+++ b/community/io/src/main/java/org/neo4j/io/fs/watcher/FileWatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/fs/watcher/RestartableFileSystemWatcher.java
+++ b/community/io/src/main/java/org/neo4j/io/fs/watcher/RestartableFileSystemWatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/fs/watcher/SilentFileWatcher.java
+++ b/community/io/src/main/java/org/neo4j/io/fs/watcher/SilentFileWatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/fs/watcher/resource/WatchedFile.java
+++ b/community/io/src/main/java/org/neo4j/io/fs/watcher/resource/WatchedFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/fs/watcher/resource/WatchedResource.java
+++ b/community/io/src/main/java/org/neo4j/io/fs/watcher/resource/WatchedResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/mem/GrabAllocator.java
+++ b/community/io/src/main/java/org/neo4j/io/mem/GrabAllocator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/mem/MemoryAllocator.java
+++ b/community/io/src/main/java/org/neo4j/io/mem/MemoryAllocator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/CursorException.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/CursorException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/IOLimiter.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/IOLimiter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/PageCache.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/PageCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/PageCacheOpenOptions.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/PageCacheOpenOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/PageCursor.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/PageCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/PageEvictionCallback.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/PageEvictionCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/PageSwapper.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/PageSwapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/PageSwapperFactory.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/PageSwapperFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/PagedFile.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/PagedFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/CompositePageCursor.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/CompositePageCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/DelegatingPageCursor.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/DelegatingPageCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/FileIsMappedException.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/FileIsMappedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/FileIsNotMappedException.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/FileIsNotMappedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/FileLockException.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/FileLockException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/PagedReadableByteChannel.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/PagedReadableByteChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/PagedWritableByteChannel.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/PagedWritableByteChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/SingleFilePageSwapper.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/SingleFilePageSwapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/SingleFilePageSwapperFactory.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/SingleFilePageSwapperFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/BackgroundTask.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/BackgroundTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/BackgroundThreadExecutor.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/BackgroundThreadExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/CacheLiveLockException.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/CacheLiveLockException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/CursorExceptionWithPreciseStackTrace.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/CursorExceptionWithPreciseStackTrace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/CursorFactory.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/CursorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/DaemonThreadFactory.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/DaemonThreadFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/EvictionTask.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/EvictionTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/FileMapping.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/FileMapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/FreePage.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/FreePage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/LatchMap.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/LatchMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCache.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCursor.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPagedFile.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPagedFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnReadPageCursor.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnReadPageCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnWritePageCursor.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnWritePageCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/OffHeapPageLock.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/OffHeapPageLock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/PageList.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/PageList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/StandalonePageCacheFactory.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/StandalonePageCacheFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/SwapperSet.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/SwapperSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/VictimPageReference.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/VictimPageReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/monitoring/PageCacheCounters.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/monitoring/PageCacheCounters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/package-info.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/tracing/AutoCloseablePageCacheTracerEvent.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/tracing/AutoCloseablePageCacheTracerEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/tracing/DefaultPageCacheTracer.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/tracing/DefaultPageCacheTracer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/tracing/EvictionEvent.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/tracing/EvictionEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/tracing/EvictionEventOpportunity.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/tracing/EvictionEventOpportunity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/tracing/EvictionRunEvent.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/tracing/EvictionRunEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/tracing/FlushEvent.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/tracing/FlushEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/tracing/FlushEventOpportunity.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/tracing/FlushEventOpportunity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/tracing/MajorFlushEvent.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/tracing/MajorFlushEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/tracing/PageCacheTracer.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/tracing/PageCacheTracer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/tracing/PageFaultEvent.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/tracing/PageFaultEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/tracing/PinEvent.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/tracing/PinEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/tracing/cursor/DefaultPageCursorTracer.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/tracing/cursor/DefaultPageCursorTracer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/tracing/cursor/DefaultPageCursorTracerSupplier.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/tracing/cursor/DefaultPageCursorTracerSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/tracing/cursor/PageCursorCounters.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/tracing/cursor/PageCursorCounters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/tracing/cursor/PageCursorTracer.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/tracing/cursor/PageCursorTracer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/tracing/cursor/PageCursorTracerSupplier.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/tracing/cursor/PageCursorTracerSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/tracing/cursor/context/EmptyVersionContext.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/tracing/cursor/context/EmptyVersionContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/tracing/cursor/context/EmptyVersionContextSupplier.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/tracing/cursor/context/EmptyVersionContextSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/tracing/cursor/context/VersionContext.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/tracing/cursor/context/VersionContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/tracing/cursor/context/VersionContextSupplier.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/tracing/cursor/context/VersionContextSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/main/java/org/neo4j/io/proc/ProcessUtil.java
+++ b/community/io/src/main/java/org/neo4j/io/proc/ProcessUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/adversaries/AbstractAdversary.java
+++ b/community/io/src/test/java/org/neo4j/adversaries/AbstractAdversary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/adversaries/Adversary.java
+++ b/community/io/src/test/java/org/neo4j/adversaries/Adversary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/adversaries/ClassGuardedAdversary.java
+++ b/community/io/src/test/java/org/neo4j/adversaries/ClassGuardedAdversary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/adversaries/CountingAdversary.java
+++ b/community/io/src/test/java/org/neo4j/adversaries/CountingAdversary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/adversaries/MethodGuardedAdversary.java
+++ b/community/io/src/test/java/org/neo4j/adversaries/MethodGuardedAdversary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/adversaries/RandomAdversary.java
+++ b/community/io/src/test/java/org/neo4j/adversaries/RandomAdversary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/adversaries/StackTraceElementGuardedAdversary.java
+++ b/community/io/src/test/java/org/neo4j/adversaries/StackTraceElementGuardedAdversary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/adversaries/fs/AdversarialChannelDefaultFileSystemAbstraction.java
+++ b/community/io/src/test/java/org/neo4j/adversaries/fs/AdversarialChannelDefaultFileSystemAbstraction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/adversaries/fs/AdversarialFileChannel.java
+++ b/community/io/src/test/java/org/neo4j/adversaries/fs/AdversarialFileChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/adversaries/fs/AdversarialFileSystemAbstraction.java
+++ b/community/io/src/test/java/org/neo4j/adversaries/fs/AdversarialFileSystemAbstraction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/adversaries/fs/AdversarialInputStream.java
+++ b/community/io/src/test/java/org/neo4j/adversaries/fs/AdversarialInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/adversaries/fs/AdversarialOutputStream.java
+++ b/community/io/src/test/java/org/neo4j/adversaries/fs/AdversarialOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/adversaries/fs/AdversarialReader.java
+++ b/community/io/src/test/java/org/neo4j/adversaries/fs/AdversarialReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/adversaries/fs/AdversarialWriter.java
+++ b/community/io/src/test/java/org/neo4j/adversaries/fs/AdversarialWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/adversaries/package-info.java
+++ b/community/io/src/test/java/org/neo4j/adversaries/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/adversaries/pagecache/AdversarialPageCache.java
+++ b/community/io/src/test/java/org/neo4j/adversaries/pagecache/AdversarialPageCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/adversaries/pagecache/AdversarialPagedFile.java
+++ b/community/io/src/test/java/org/neo4j/adversaries/pagecache/AdversarialPagedFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/adversaries/pagecache/AdversarialReadPageCursor.java
+++ b/community/io/src/test/java/org/neo4j/adversaries/pagecache/AdversarialReadPageCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/adversaries/pagecache/AdversarialReadPageCursorTest.java
+++ b/community/io/src/test/java/org/neo4j/adversaries/pagecache/AdversarialReadPageCursorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/adversaries/pagecache/AdversarialWritePageCursor.java
+++ b/community/io/src/test/java/org/neo4j/adversaries/pagecache/AdversarialWritePageCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/adversaries/watcher/AdversarialFileWatcher.java
+++ b/community/io/src/test/java/org/neo4j/adversaries/watcher/AdversarialFileWatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/graphdb/mockfs/CloseTrackingFileSystem.java
+++ b/community/io/src/test/java/org/neo4j/graphdb/mockfs/CloseTrackingFileSystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/graphdb/mockfs/DelegatingFileSystemAbstraction.java
+++ b/community/io/src/test/java/org/neo4j/graphdb/mockfs/DelegatingFileSystemAbstraction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/graphdb/mockfs/DelegatingStoreChannel.java
+++ b/community/io/src/test/java/org/neo4j/graphdb/mockfs/DelegatingStoreChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/graphdb/mockfs/EphemeralFileSystemAbstraction.java
+++ b/community/io/src/test/java/org/neo4j/graphdb/mockfs/EphemeralFileSystemAbstraction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/graphdb/mockfs/EphemeralFileSystemAbstractionTest.java
+++ b/community/io/src/test/java/org/neo4j/graphdb/mockfs/EphemeralFileSystemAbstractionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/graphdb/mockfs/LimitedFileChannel.java
+++ b/community/io/src/test/java/org/neo4j/graphdb/mockfs/LimitedFileChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/graphdb/mockfs/LimitedFilesystemAbstraction.java
+++ b/community/io/src/test/java/org/neo4j/graphdb/mockfs/LimitedFilesystemAbstraction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/graphdb/mockfs/SelectiveFileSystemAbstraction.java
+++ b/community/io/src/test/java/org/neo4j/graphdb/mockfs/SelectiveFileSystemAbstraction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/graphdb/mockfs/SelectiveFileWatcher.java
+++ b/community/io/src/test/java/org/neo4j/graphdb/mockfs/SelectiveFileWatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/graphdb/mockfs/UncloseableDelegatingFileSystemAbstraction.java
+++ b/community/io/src/test/java/org/neo4j/graphdb/mockfs/UncloseableDelegatingFileSystemAbstraction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/ByteUnitTest.java
+++ b/community/io/src/test/java/org/neo4j/io/ByteUnitTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/IOUtilsTest.java
+++ b/community/io/src/test/java/org/neo4j/io/IOUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/compress/ZipUtilsTest.java
+++ b/community/io/src/test/java/org/neo4j/io/compress/ZipUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/fs/DefaultFileSystemAbstractionTest.java
+++ b/community/io/src/test/java/org/neo4j/io/fs/DefaultFileSystemAbstractionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/fs/DelegateFileSystemAbstractionTest.java
+++ b/community/io/src/test/java/org/neo4j/io/fs/DelegateFileSystemAbstractionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/fs/EphemeralFileSystemAbstractionTest.java
+++ b/community/io/src/test/java/org/neo4j/io/fs/EphemeralFileSystemAbstractionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/fs/FileSystemAbstractionInterruptionTest.java
+++ b/community/io/src/test/java/org/neo4j/io/fs/FileSystemAbstractionInterruptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/fs/FileSystemAbstractionTest.java
+++ b/community/io/src/test/java/org/neo4j/io/fs/FileSystemAbstractionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/fs/FileVisitorsDecoratorsTest.java
+++ b/community/io/src/test/java/org/neo4j/io/fs/FileVisitorsDecoratorsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/fs/JustContinueTest.java
+++ b/community/io/src/test/java/org/neo4j/io/fs/JustContinueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/fs/OffsetChannelTest.java
+++ b/community/io/src/test/java/org/neo4j/io/fs/OffsetChannelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/fs/OnDirectoryTest.java
+++ b/community/io/src/test/java/org/neo4j/io/fs/OnDirectoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/fs/OnFileTest.java
+++ b/community/io/src/test/java/org/neo4j/io/fs/OnFileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/fs/OnlyMatchingFileVisitorTest.java
+++ b/community/io/src/test/java/org/neo4j/io/fs/OnlyMatchingFileVisitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/fs/SelectiveFileSystemAbstractionTest.java
+++ b/community/io/src/test/java/org/neo4j/io/fs/SelectiveFileSystemAbstractionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/fs/StoreFileChannelTest.java
+++ b/community/io/src/test/java/org/neo4j/io/fs/StoreFileChannelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/fs/ThrowExceptionsFileVisitorTest.java
+++ b/community/io/src/test/java/org/neo4j/io/fs/ThrowExceptionsFileVisitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/fs/watcher/DefaultFileSystemWatcherTest.java
+++ b/community/io/src/test/java/org/neo4j/io/fs/watcher/DefaultFileSystemWatcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/fs/watcher/RestartableFileSystemWatcherTest.java
+++ b/community/io/src/test/java/org/neo4j/io/fs/watcher/RestartableFileSystemWatcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/mem/MemoryAllocatorTest.java
+++ b/community/io/src/test/java/org/neo4j/io/mem/MemoryAllocatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/ByteArrayPageCursor.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/ByteArrayPageCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/DelegatingPageCache.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/DelegatingPageCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/DelegatingPageSwapper.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/DelegatingPageSwapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/DelegatingPagedFile.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/DelegatingPagedFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheSlowTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheSlowTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTestSupport.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTestSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/PageSwapperTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/PageSwapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/StubPageCursor.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/StubPageCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/StubPagedFile.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/StubPagedFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/TinyLockManager.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/TinyLockManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/checking/AccessCheckingPageCache.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/checking/AccessCheckingPageCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/checking/AccessCheckingPageCacheTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/checking/AccessCheckingPageCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/checking/AccessCheckingPagedFile.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/checking/AccessCheckingPagedFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/checking/AccessCheckingReadPageCursor.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/checking/AccessCheckingReadPageCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/harness/MuninnPageCacheHarnessTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/harness/MuninnPageCacheHarnessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/harness/MuninnPageCacheHarnessWithRealFileSystemIT.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/harness/MuninnPageCacheHarnessWithRealFileSystemIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/harness/PageCacheHarnessTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/harness/PageCacheHarnessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/impl/CompositePageCursorTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/impl/CompositePageCursorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/impl/LockThisFileProgram.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/impl/LockThisFileProgram.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/impl/PagedByteChannelsTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/impl/PagedByteChannelsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/impl/SingleFilePageSwapperTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/impl/SingleFilePageSwapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/impl/SingleFilePageSwapperWithAdversarialFileChannelIT.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/impl/SingleFilePageSwapperWithAdversarialFileChannelIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/impl/SingleFilePageSwapperWithRealFileSystemIT.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/impl/SingleFilePageSwapperWithRealFileSystemIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/impl/muninn/LargePageListIT.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/impl/muninn/LargePageListIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/impl/muninn/LatchMapTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/impl/muninn/LatchMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCacheFixture.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCacheFixture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCacheSlowIT.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCacheSlowIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCacheSlowTestWithAdversarialChannel.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCacheSlowTestWithAdversarialChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCacheSlowTestWithRealFileSystemIT.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCacheSlowTestWithRealFileSystemIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCacheStressIT.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCacheStressIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCacheTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCacheWithRealFileSystemIT.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCacheWithRealFileSystemIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/impl/muninn/PageListTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/impl/muninn/PageListTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/impl/muninn/SequenceLockStressIT.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/impl/muninn/SequenceLockStressIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/impl/muninn/StubPageFaultEvent.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/impl/muninn/StubPageFaultEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/impl/muninn/SwapperSetTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/impl/muninn/SwapperSetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/randomharness/Action.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/randomharness/Action.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/randomharness/Command.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/randomharness/Command.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/randomharness/CommandPrimer.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/randomharness/CommandPrimer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/randomharness/PageCountRecordFormat.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/randomharness/PageCountRecordFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/randomharness/Phase.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/randomharness/Phase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/randomharness/Plan.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/randomharness/Plan.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/randomharness/PlanRunner.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/randomharness/PlanRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/randomharness/RandomPageCacheTestHarness.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/randomharness/RandomPageCacheTestHarness.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/randomharness/Record.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/randomharness/Record.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/randomharness/RecordFormat.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/randomharness/RecordFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/randomharness/StandardRecordFormat.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/randomharness/StandardRecordFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/stress/Condition.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/stress/Condition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/stress/Conditions.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/stress/Conditions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/stress/PageCacheStressTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/stress/PageCacheStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/stress/PageCacheStresser.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/stress/PageCacheStresser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/stress/RecordFormat.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/stress/RecordFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/stress/RecordStresser.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/stress/RecordStresser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/tracing/ConfigurablePageCursorTracerSupplier.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/tracing/ConfigurablePageCursorTracerSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/tracing/DefaultPageCacheTracerTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/tracing/DefaultPageCacheTracerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/tracing/DefaultPageCursorTracerTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/tracing/DefaultPageCursorTracerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/tracing/DelegatingPageCacheTracer.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/tracing/DelegatingPageCacheTracer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/tracing/DummyPageSwapper.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/tracing/DummyPageSwapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/tracing/linear/HEvents.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/tracing/linear/HEvents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/tracing/linear/LinearHistoryPageCacheTracer.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/tracing/linear/LinearHistoryPageCacheTracer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/tracing/linear/LinearHistoryPageCacheTracerTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/tracing/linear/LinearHistoryPageCacheTracerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/tracing/linear/LinearHistoryPageCursorTracer.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/tracing/linear/LinearHistoryPageCursorTracer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/tracing/linear/LinearHistoryTracer.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/tracing/linear/LinearHistoryTracer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/tracing/linear/LinearHistoryTracerFactory.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/tracing/linear/LinearHistoryTracerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/tracing/linear/LinearTracers.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/tracing/linear/LinearTracers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/tracing/recording/Event.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/tracing/recording/Event.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/tracing/recording/RecordingPageCacheTracer.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/tracing/recording/RecordingPageCacheTracer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/tracing/recording/RecordingPageCursorTracer.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/tracing/recording/RecordingPageCursorTracer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/tracing/recording/RecordingTracer.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/tracing/recording/RecordingTracer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/io/proc/ProcessUtilTest.java
+++ b/community/io/src/test/java/org/neo4j/io/proc/ProcessUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/test/AssumptionHelper.java
+++ b/community/io/src/test/java/org/neo4j/test/AssumptionHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/test/ThreadTestUtils.java
+++ b/community/io/src/test/java/org/neo4j/test/ThreadTestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/test/impl/ChannelInputStream.java
+++ b/community/io/src/test/java/org/neo4j/test/impl/ChannelInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/test/impl/ChannelOutputStream.java
+++ b/community/io/src/test/java/org/neo4j/test/impl/ChannelOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/test/impl/ChannelOutputStreamTest.java
+++ b/community/io/src/test/java/org/neo4j/test/impl/ChannelOutputStreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/test/rule/PageCacheAndDependenciesRule.java
+++ b/community/io/src/test/java/org/neo4j/test/rule/PageCacheAndDependenciesRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/test/rule/PageCacheRule.java
+++ b/community/io/src/test/java/org/neo4j/test/rule/PageCacheRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/test/rule/TestDirectory.java
+++ b/community/io/src/test/java/org/neo4j/test/rule/TestDirectory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/test/rule/fs/DefaultFileSystemRule.java
+++ b/community/io/src/test/java/org/neo4j/test/rule/fs/DefaultFileSystemRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/test/rule/fs/EphemeralFileSystemRule.java
+++ b/community/io/src/test/java/org/neo4j/test/rule/fs/EphemeralFileSystemRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/io/src/test/java/org/neo4j/test/rule/fs/FileSystemRule.java
+++ b/community/io/src/test/java/org/neo4j/test/rule/fs/FileSystemRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/jmx/NOTICE.txt
+++ b/community/jmx/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/community/jmx/src/main/java/org/neo4j/jmx/Description.java
+++ b/community/jmx/src/main/java/org/neo4j/jmx/Description.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/jmx/src/main/java/org/neo4j/jmx/JmxUtils.java
+++ b/community/jmx/src/main/java/org/neo4j/jmx/JmxUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/jmx/src/main/java/org/neo4j/jmx/Kernel.java
+++ b/community/jmx/src/main/java/org/neo4j/jmx/Kernel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/jmx/src/main/java/org/neo4j/jmx/ManagementInterface.java
+++ b/community/jmx/src/main/java/org/neo4j/jmx/ManagementInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/jmx/src/main/java/org/neo4j/jmx/Primitives.java
+++ b/community/jmx/src/main/java/org/neo4j/jmx/Primitives.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/jmx/src/main/java/org/neo4j/jmx/StoreFile.java
+++ b/community/jmx/src/main/java/org/neo4j/jmx/StoreFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/jmx/src/main/java/org/neo4j/jmx/StoreSize.java
+++ b/community/jmx/src/main/java/org/neo4j/jmx/StoreSize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/jmx/src/main/java/org/neo4j/jmx/impl/ConfigurationBean.java
+++ b/community/jmx/src/main/java/org/neo4j/jmx/impl/ConfigurationBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/jmx/src/main/java/org/neo4j/jmx/impl/JmxExtensionFactory.java
+++ b/community/jmx/src/main/java/org/neo4j/jmx/impl/JmxExtensionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/jmx/src/main/java/org/neo4j/jmx/impl/JmxKernelExtension.java
+++ b/community/jmx/src/main/java/org/neo4j/jmx/impl/JmxKernelExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/jmx/src/main/java/org/neo4j/jmx/impl/KernelBean.java
+++ b/community/jmx/src/main/java/org/neo4j/jmx/impl/KernelBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/jmx/src/main/java/org/neo4j/jmx/impl/ManagementBeanProvider.java
+++ b/community/jmx/src/main/java/org/neo4j/jmx/impl/ManagementBeanProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/jmx/src/main/java/org/neo4j/jmx/impl/ManagementData.java
+++ b/community/jmx/src/main/java/org/neo4j/jmx/impl/ManagementData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/jmx/src/main/java/org/neo4j/jmx/impl/ManagementSupport.java
+++ b/community/jmx/src/main/java/org/neo4j/jmx/impl/ManagementSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/jmx/src/main/java/org/neo4j/jmx/impl/Neo4jMBean.java
+++ b/community/jmx/src/main/java/org/neo4j/jmx/impl/Neo4jMBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/jmx/src/main/java/org/neo4j/jmx/impl/PrimitivesBean.java
+++ b/community/jmx/src/main/java/org/neo4j/jmx/impl/PrimitivesBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/jmx/src/main/java/org/neo4j/jmx/impl/StoreFileBean.java
+++ b/community/jmx/src/main/java/org/neo4j/jmx/impl/StoreFileBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/jmx/src/main/java/org/neo4j/jmx/impl/StoreSizeBean.java
+++ b/community/jmx/src/main/java/org/neo4j/jmx/impl/StoreSizeBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/jmx/src/main/java/org/neo4j/jmx/impl/ThrottlingBeanSnapshotProxy.java
+++ b/community/jmx/src/main/java/org/neo4j/jmx/impl/ThrottlingBeanSnapshotProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/jmx/src/main/java/org/neo4j/jmx/package-info.java
+++ b/community/jmx/src/main/java/org/neo4j/jmx/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/jmx/src/test/java/org/neo4j/jmx/DescriptionTest.java
+++ b/community/jmx/src/test/java/org/neo4j/jmx/DescriptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/jmx/src/test/java/org/neo4j/jmx/impl/ConfigurationBeanIT.java
+++ b/community/jmx/src/test/java/org/neo4j/jmx/impl/ConfigurationBeanIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/jmx/src/test/java/org/neo4j/jmx/impl/StoreSizeBeanTest.java
+++ b/community/jmx/src/test/java/org/neo4j/jmx/impl/StoreSizeBeanTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/jmx/src/test/java/org/neo4j/jmx/impl/TestJmxExtension.java
+++ b/community/jmx/src/test/java/org/neo4j/jmx/impl/TestJmxExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/jmx/src/test/java/org/neo4j/jmx/impl/ThrottlingBeanSnapshotProxyTest.java
+++ b/community/jmx/src/test/java/org/neo4j/jmx/impl/ThrottlingBeanSnapshotProxyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/NOTICE.txt
+++ b/community/kernel-api/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/AutoCloseablePlus.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/AutoCloseablePlus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/CapableIndexReference.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/CapableIndexReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/Cursor.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/Cursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/CursorFactory.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/CursorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/CursorPosition.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/CursorPosition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/ExecutionStatistics.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/ExecutionStatistics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/ExplicitIndexRead.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/ExplicitIndexRead.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/ExplicitIndexSearchResult.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/ExplicitIndexSearchResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/ExplicitIndexWrite.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/ExplicitIndexWrite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/IndexCapability.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/IndexCapability.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/IndexLimitation.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/IndexLimitation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/IndexOrder.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/IndexOrder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/IndexQuery.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/IndexQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/IndexReference.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/IndexReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/IndexValueCapability.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/IndexValueCapability.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/InternalIndexState.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/InternalIndexState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/Kernel.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/Kernel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/LabelSet.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/LabelSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/Locks.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/Locks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/Modes.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/Modes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/NamedToken.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/NamedToken.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/NodeCursor.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/NodeCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/NodeExplicitIndexCursor.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/NodeExplicitIndexCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/NodeIndexCursor.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/NodeIndexCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/NodeLabelIndexCursor.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/NodeLabelIndexCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/NodeValueIndexCursor.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/NodeValueIndexCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/Permissions.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/Permissions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/Procedures.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/Procedures.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/PropertyCursor.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/PropertyCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/PropertyPredicate.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/PropertyPredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/Read.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/Read.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/RelationshipDataAccessor.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/RelationshipDataAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/RelationshipExplicitIndexCursor.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/RelationshipExplicitIndexCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/RelationshipGroupCursor.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/RelationshipGroupCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/RelationshipIndexCursor.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/RelationshipIndexCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/RelationshipScanCursor.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/RelationshipScanCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/RelationshipTraversalCursor.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/RelationshipTraversalCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/Scan.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/Scan.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/SchemaRead.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/SchemaRead.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/SchemaWrite.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/SchemaWrite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/Session.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/Session.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/SuspendableCursor.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/SuspendableCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/Token.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/Token.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/TokenNameLookup.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/TokenNameLookup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/TokenRead.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/TokenRead.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/TokenWrite.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/TokenWrite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/Transaction.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/Transaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/Write.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/Write.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/exceptions/EntityNotFoundException.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/exceptions/EntityNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/exceptions/InvalidTransactionTypeKernelException.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/exceptions/InvalidTransactionTypeKernelException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/exceptions/KernelException.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/exceptions/KernelException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/exceptions/LabelNotFoundKernelException.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/exceptions/LabelNotFoundKernelException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/exceptions/ProcedureException.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/exceptions/ProcedureException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/exceptions/PropertyKeyIdNotFoundKernelException.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/exceptions/PropertyKeyIdNotFoundKernelException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/exceptions/TransactionFailureException.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/exceptions/TransactionFailureException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/exceptions/explicitindex/AutoIndexingKernelException.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/exceptions/explicitindex/AutoIndexingKernelException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/exceptions/explicitindex/ExplicitIndexNotFoundKernelException.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/exceptions/explicitindex/ExplicitIndexNotFoundKernelException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/exceptions/schema/ConstraintValidationException.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/exceptions/schema/ConstraintValidationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/exceptions/schema/IllegalTokenNameException.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/exceptions/schema/IllegalTokenNameException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/exceptions/schema/SchemaKernelException.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/exceptions/schema/SchemaKernelException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/exceptions/schema/TooManyLabelsException.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/exceptions/schema/TooManyLabelsException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/Nodes.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/Nodes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipDenseSelection.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipDenseSelection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipDenseSelectionCursor.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipDenseSelectionCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipDenseSelectionIterator.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipDenseSelectionIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipFactory.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipSelectionCursor.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipSelectionCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipSelections.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipSelections.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipSparseSelection.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipSparseSelection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipSparseSelectionCursor.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipSparseSelectionCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipSparseSelectionIterator.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipSparseSelectionIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/procs/DefaultParameterValue.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/procs/DefaultParameterValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/procs/FieldSignature.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/procs/FieldSignature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/procs/Neo4jTypes.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/procs/Neo4jTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/procs/ProcedureHandle.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/procs/ProcedureHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/procs/ProcedureSignature.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/procs/ProcedureSignature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/procs/QualifiedName.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/procs/QualifiedName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/procs/UserAggregator.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/procs/UserAggregator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/procs/UserFunctionHandle.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/procs/UserFunctionHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/procs/UserFunctionSignature.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/procs/UserFunctionSignature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/schema/LabelSchemaDescriptor.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/schema/LabelSchemaDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/schema/LabelSchemaSupplier.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/schema/LabelSchemaSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/schema/RelationTypeSchemaDescriptor.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/schema/RelationTypeSchemaDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/schema/SchemaComputer.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/schema/SchemaComputer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/schema/SchemaDescriptor.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/schema/SchemaDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/schema/SchemaDescriptorPredicates.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/schema/SchemaDescriptorPredicates.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/schema/SchemaDescriptorSupplier.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/schema/SchemaDescriptorSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/schema/SchemaProcessor.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/schema/SchemaProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/schema/SchemaUtil.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/schema/SchemaUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/schema/constraints/ConstraintDescriptor.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/schema/constraints/ConstraintDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/security/AccessMode.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/security/AccessMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/security/AuthSubject.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/security/AuthSubject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/security/AuthenticationResult.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/security/AuthenticationResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/security/LoginContext.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/security/LoginContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/security/SecurityContext.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/security/SecurityContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/kernel/api/exceptions/index/IndexNotFoundKernelException.java
+++ b/community/kernel-api/src/main/java/org/neo4j/kernel/api/exceptions/index/IndexNotFoundKernelException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/storageengine/api/EntityType.java
+++ b/community/kernel-api/src/main/java/org/neo4j/storageengine/api/EntityType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/storageengine/api/lock/ResourceType.java
+++ b/community/kernel-api/src/main/java/org/neo4j/storageengine/api/lock/ResourceType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/storageengine/api/lock/WaitStrategy.java
+++ b/community/kernel-api/src/main/java/org/neo4j/storageengine/api/lock/WaitStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/main/java/org/neo4j/storageengine/api/schema/PopulationProgress.java
+++ b/community/kernel-api/src/main/java/org/neo4j/storageengine/api/schema/PopulationProgress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/ConstraintTestBase.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/ConstraintTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/CursorsClosedPostCondition.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/CursorsClosedPostCondition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/DeepRelationshipTraversalCursorTestBase.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/DeepRelationshipTraversalCursorTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/ExplicitIndexCursorTestBase.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/ExplicitIndexCursorTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/ExplicitIndexCursorWritesTestBase.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/ExplicitIndexCursorWritesTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/GraphPropertiesTestBase.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/GraphPropertiesTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/IndexQueryTest.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/IndexQueryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/IndexReadAsserts.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/IndexReadAsserts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/KernelAPIReadTestBase.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/KernelAPIReadTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/KernelAPIReadTestSupport.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/KernelAPIReadTestSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/KernelAPIWriteTestBase.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/KernelAPIWriteTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/KernelAPIWriteTestSupport.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/KernelAPIWriteTestSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/LargeNodeCursorTestBase.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/LargeNodeCursorTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/LockingTestBase.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/LockingTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/ManagedTestCursors.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/ManagedTestCursors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/NodeCursorTestBase.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/NodeCursorTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/NodeIndexTransactionStateTestBase.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/NodeIndexTransactionStateTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/NodeLabelIndexCursorTestBase.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/NodeLabelIndexCursorTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/NodeTransactionStateTestBase.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/NodeTransactionStateTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/NodeValueIndexCursorTestBase.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/NodeValueIndexCursorTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/NodeWriteTestBase.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/NodeWriteTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/PermissionsFixture.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/PermissionsFixture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/PropertyCursorTestBase.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/PropertyCursorTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/RandomRelationshipTraversalCursorTestBase.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/RandomRelationshipTraversalCursorTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/RelationshipScanCursorTestBase.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/RelationshipScanCursorTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/RelationshipTestSupport.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/RelationshipTestSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/RelationshipTransactionStateTestBase.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/RelationshipTransactionStateTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/RelationshipTraversalCursorTestBase.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/RelationshipTraversalCursorTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/RelationshipWriteTestBase.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/RelationshipWriteTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/SchemaReadWriteTestBase.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/SchemaReadWriteTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/TransactionTestBase.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/TransactionTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/TwoLayerTxStateTestBase.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/TwoLayerTxStateTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/helpers/NodeData.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/helpers/NodeData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/helpers/NodesTest.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/helpers/NodesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/helpers/RelationshipDenseSelectionTestBase.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/helpers/RelationshipDenseSelectionTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/helpers/RelationshipSelectionTestBase.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/helpers/RelationshipSelectionTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/helpers/RelationshipSparseSelectionTestBase.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/helpers/RelationshipSparseSelectionTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/helpers/StubCursorFactory.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/helpers/StubCursorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/helpers/StubGroupCursor.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/helpers/StubGroupCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/helpers/StubNodeCursor.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/helpers/StubNodeCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/helpers/StubNodeLabelIndexCursor.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/helpers/StubNodeLabelIndexCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/helpers/StubPropertyCursor.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/helpers/StubPropertyCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/helpers/StubRead.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/helpers/StubRead.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/helpers/StubRelationshipCursor.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/helpers/StubRelationshipCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/helpers/TestRelationshipChain.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/helpers/TestRelationshipChain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/NOTICE.txt
+++ b/community/kernel/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/community/kernel/src/main/java/org/neo4j/diagnostics/DiagnosticsOfflineReportProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/diagnostics/DiagnosticsOfflineReportProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/diagnostics/DiagnosticsReportSource.java
+++ b/community/kernel/src/main/java/org/neo4j/diagnostics/DiagnosticsReportSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/diagnostics/DiagnosticsReportSources.java
+++ b/community/kernel/src/main/java/org/neo4j/diagnostics/DiagnosticsReportSources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/diagnostics/DiagnosticsReporter.java
+++ b/community/kernel/src/main/java/org/neo4j/diagnostics/DiagnosticsReporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/diagnostics/DiagnosticsReporterProgress.java
+++ b/community/kernel/src/main/java/org/neo4j/diagnostics/DiagnosticsReporterProgress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/diagnostics/InteractiveProgress.java
+++ b/community/kernel/src/main/java/org/neo4j/diagnostics/InteractiveProgress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/diagnostics/KernelDiagnosticsOfflineReportProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/diagnostics/KernelDiagnosticsOfflineReportProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/diagnostics/NonInteractiveProgress.java
+++ b/community/kernel/src/main/java/org/neo4j/diagnostics/NonInteractiveProgress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/diagnostics/ProgressAwareInputStream.java
+++ b/community/kernel/src/main/java/org/neo4j/diagnostics/ProgressAwareInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/Description.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/Description.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseBuilder.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseFactoryState.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseFactoryState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/package-info.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/graphdb/impl/notification/NotificationCode.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/impl/notification/NotificationCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/graphdb/impl/notification/NotificationDetail.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/impl/notification/NotificationDetail.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/helpers/AdvertisedSocketAddress.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/AdvertisedSocketAddress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/helpers/Args.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/Args.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/helpers/ArrayUtil.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/ArrayUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/helpers/Assertion.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/Assertion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/helpers/Cancelable.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/Cancelable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/helpers/CancellationRequest.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/CancellationRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/helpers/Clock.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/Clock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/helpers/CloneableInPublic.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/CloneableInPublic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/helpers/Format.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/Format.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/helpers/FutureAdapter.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/FutureAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/helpers/HostnamePort.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/HostnamePort.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/helpers/ListenSocketAddress.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/ListenSocketAddress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/helpers/Listeners.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/Listeners.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/helpers/NamedThreadFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/NamedThreadFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/helpers/PortBindException.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/PortBindException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/helpers/ProcessFailureException.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/ProcessFailureException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/helpers/Reference.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/Reference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/helpers/RunCarefully.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/RunCarefully.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/helpers/Service.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/Service.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/helpers/SocketAddress.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/SocketAddress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/helpers/SocketAddressParser.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/SocketAddressParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/helpers/Strings.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/Strings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/helpers/TaskControl.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/TaskControl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/helpers/TaskCoordinator.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/TaskCoordinator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/helpers/ThisShouldNotHappenError.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/ThisShouldNotHappenError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/helpers/TimeUtil.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/TimeUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/helpers/TransactionTemplate.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/TransactionTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/helpers/Uris.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/Uris.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/helpers/collection/BoundedIterable.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/collection/BoundedIterable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/helpers/package-info.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/helpers/progress/Aggregator.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/progress/Aggregator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/helpers/progress/Indicator.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/progress/Indicator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/helpers/progress/ProgressListener.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/progress/ProgressListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/helpers/progress/ProgressMonitorFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/progress/ProgressMonitorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/helpers/progress/package-info.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/progress/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/AvailabilityGuard.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/AvailabilityGuard.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/DatabaseAvailability.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/DatabaseAvailability.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/DeadlockDetectedException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/DeadlockDetectedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/GraphDatabaseDependencies.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/GraphDatabaseDependencies.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/GraphDatabaseQueryService.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/GraphDatabaseQueryService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreKernelModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreKernelModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreTransactionLogModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreTransactionLogModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/NeoStoresDiagnostics.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/NeoStoresDiagnostics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/StoreLockException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/StoreLockException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/AssertOpen.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/AssertOpen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/ExplicitIndex.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/ExplicitIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/ExplicitIndexHits.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/ExplicitIndexHits.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/InwardKernel.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/InwardKernel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/KernelTransaction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/KernelTransaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/KernelTransactionHandle.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/KernelTransactionHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/QueryRegistryOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/QueryRegistryOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/ResourceManager.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/ResourceManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/ResourceTracker.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/ResourceTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/SilentTokenNameLookup.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/SilentTokenNameLookup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/Statement.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/Statement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/StatementConstants.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/StatementConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/TransactionHook.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/TransactionHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/bolt/BoltConnectionTracker.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/bolt/BoltConnectionTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/bolt/ManagedBoltStateMachine.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/bolt/ManagedBoltStateMachine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/dbms/DbmsOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/dbms/DbmsOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/direct/DirectStoreAccess.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/direct/DirectStoreAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/ComponentInjectionException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/ComponentInjectionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/ConstraintViolationTransactionFailureException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/ConstraintViolationTransactionFailureException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/InvalidArgumentsException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/InvalidArgumentsException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/PropertyKeyNotFoundException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/PropertyKeyNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/PropertyNotFoundException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/PropertyNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/ReadOnlyDbException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/ReadOnlyDbException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/RelationshipTypeIdNotFoundKernelException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/RelationshipTypeIdNotFoundKernelException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/RelationshipTypeNotFoundException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/RelationshipTypeNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/ResourceCloseFailureException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/ResourceCloseFailureException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/TransactionApplyKernelException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/TransactionApplyKernelException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/index/ExceptionDuringFlipKernelException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/index/ExceptionDuringFlipKernelException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/index/FlipFailedKernelException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/index/FlipFailedKernelException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/index/IndexActivationFailedKernelException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/index/IndexActivationFailedKernelException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/index/IndexEntryConflictException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/index/IndexEntryConflictException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/index/IndexNotApplicableKernelException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/index/IndexNotApplicableKernelException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/index/IndexPopulationFailedKernelException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/index/IndexPopulationFailedKernelException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/index/IndexProxyAlreadyClosedKernelException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/index/IndexProxyAlreadyClosedKernelException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/AlreadyConstrainedException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/AlreadyConstrainedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/AlreadyIndexedException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/AlreadyIndexedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/CreateConstraintFailureException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/CreateConstraintFailureException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/DropConstraintFailureException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/DropConstraintFailureException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/DropIndexFailureException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/DropIndexFailureException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/DuplicateSchemaRuleException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/DuplicateSchemaRuleException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/IndexBelongsToConstraintException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/IndexBelongsToConstraintException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/IndexBrokenKernelException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/IndexBrokenKernelException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/MalformedSchemaRuleException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/MalformedSchemaRuleException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/NoSuchConstraintException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/NoSuchConstraintException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/NoSuchIndexException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/NoSuchIndexException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/NodePropertyExistenceException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/NodePropertyExistenceException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/RelationshipPropertyExistenceException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/RelationshipPropertyExistenceException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/RepeatedPropertyInCompositeSchemaException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/RepeatedPropertyInCompositeSchemaException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/SchemaRuleException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/SchemaRuleException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/SchemaRuleNotFoundException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/SchemaRuleNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/UnableToValidateConstraintException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/UnableToValidateConstraintException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/UniquePropertyValueValidationException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/UniquePropertyValueValidationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/explicitindex/AutoIndexOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/explicitindex/AutoIndexOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/explicitindex/AutoIndexing.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/explicitindex/AutoIndexing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/index/ArrayEncoder.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/index/ArrayEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/index/IndexAccessor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/index/IndexAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/index/IndexDirectoryStructure.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/index/IndexDirectoryStructure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/index/IndexEntryUpdate.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/index/IndexEntryUpdate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/index/IndexPopulator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/index/IndexPopulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/index/IndexProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/index/IndexProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/index/IndexUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/index/IndexUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/index/LoggingMonitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/index/LoggingMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/index/PropertyAccessor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/index/PropertyAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/labelscan/AllEntriesLabelScanReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/labelscan/AllEntriesLabelScanReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/labelscan/LabelScanStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/labelscan/LabelScanStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/labelscan/LabelScanWriter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/labelscan/LabelScanWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/labelscan/LoggingMonitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/labelscan/LoggingMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/labelscan/NodeLabelRange.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/labelscan/NodeLabelRange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/labelscan/NodeLabelUpdate.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/labelscan/NodeLabelUpdate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/proc/BasicContext.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/proc/BasicContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/proc/CallableProcedure.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/proc/CallableProcedure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/proc/CallableUserAggregationFunction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/proc/CallableUserAggregationFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/proc/CallableUserFunction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/proc/CallableUserFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/proc/Context.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/proc/Context.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/proc/FailedLoadAggregatedFunction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/proc/FailedLoadAggregatedFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/proc/FailedLoadFunction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/proc/FailedLoadFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/proc/FailedLoadProcedure.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/proc/FailedLoadProcedure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/proc/Key.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/proc/Key.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/properties/PropertyKeyIdIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/properties/PropertyKeyIdIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/properties/PropertyKeyValue.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/properties/PropertyKeyValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/query/ExecutingQuery.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/query/ExecutingQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/query/ExecutingQueryStatus.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/query/ExecutingQueryStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/query/ExplicitIndexUsage.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/query/ExplicitIndexUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/query/IndexUsage.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/query/IndexUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/query/PageCounterValues.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/query/PageCounterValues.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/query/PlannerInfo.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/query/PlannerInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/query/QuerySnapshot.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/query/QuerySnapshot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/query/SchemaIndexUsage.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/query/SchemaIndexUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/query/SimpleState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/query/SimpleState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/query/WaitingOnLock.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/query/WaitingOnLock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/query/WaitingOnLockEvent.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/query/WaitingOnLockEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/query/WaitingOnQuery.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/query/WaitingOnQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema/LabelSchemaDescriptor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema/LabelSchemaDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema/RelationTypeSchemaDescriptor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema/RelationTypeSchemaDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema/SchemaDescriptorFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema/SchemaDescriptorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema/constaints/ConstraintDescriptor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema/constaints/ConstraintDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema/constaints/ConstraintDescriptorFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema/constaints/ConstraintDescriptorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema/constaints/IndexBackedConstraintDescriptor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema/constaints/IndexBackedConstraintDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema/constaints/NodeExistenceConstraintDescriptor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema/constaints/NodeExistenceConstraintDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema/constaints/NodeKeyConstraintDescriptor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema/constaints/NodeKeyConstraintDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema/constaints/RelExistenceConstraintDescriptor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema/constaints/RelExistenceConstraintDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema/constaints/UniquenessConstraintDescriptor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema/constaints/UniquenessConstraintDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema/index/SchemaIndexDescriptor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema/index/SchemaIndexDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema/index/SchemaIndexDescriptorFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema/index/SchemaIndexDescriptorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/security/AnonymousContext.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/security/AnonymousContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/security/AuthManager.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/security/AuthManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/security/AuthToken.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/security/AuthToken.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/security/PasswordPolicy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/security/PasswordPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/security/SecurityModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/security/SecurityModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/security/UserManager.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/security/UserManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/security/UserManagerSupplier.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/security/UserManagerSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/security/exception/InvalidAuthTokenException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/security/exception/InvalidAuthTokenException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/txstate/ExplicitIndexTransactionState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/txstate/ExplicitIndexTransactionState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/txstate/RelationshipChangeVisitorAdapter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/txstate/RelationshipChangeVisitorAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/txstate/TransactionCountingStateVisitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/txstate/TransactionCountingStateVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/txstate/TransactionState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/txstate/TransactionState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/txstate/TxStateHolder.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/txstate/TxStateHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/txtracking/TransactionIdTracker.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/txtracking/TransactionIdTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/BuiltInDbmsProcedures.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/BuiltInDbmsProcedures.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/BuiltInFunctions.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/BuiltInFunctions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/BuiltInProcedures.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/BuiltInProcedures.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/ConfigResult.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/ConfigResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/IndexProcedures.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/IndexProcedures.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/IndexSpecifier.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/IndexSpecifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/JmxQueryProcedure.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/JmxQueryProcedure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/ListComponentsProcedure.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/ListComponentsProcedure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/NodePropertySchemaInfoResult.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/NodePropertySchemaInfoResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/RelationshipPropertySchemaInfoResult.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/RelationshipPropertySchemaInfoResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/SchemaCalculator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/SchemaCalculator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/SchemaProcedure.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/SchemaProcedure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/SortedLabels.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/SortedLabels.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/SpecialBuiltInProcedures.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/SpecialBuiltInProcedures.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/TokenProcedures.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/TokenProcedures.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/AnnotationBasedConfigurationMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/AnnotationBasedConfigurationMigrator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/BaseConfigurationMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/BaseConfigurationMigrator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/BoltConnector.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/BoltConnector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/BoltConnectorValidator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/BoltConnectorValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/Config.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/Config.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/ConfigValues.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/ConfigValues.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/ConfigurationMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/ConfigurationMigrator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/ConfigurationValidator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/ConfigurationValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/Connector.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/Connector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/ConnectorPortRegister.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/ConnectorPortRegister.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/ConnectorValidator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/ConnectorValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/GraphDatabaseConfigurationMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/GraphDatabaseConfigurationMigrator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/Group.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/Group.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/GroupSettingSupport.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/GroupSettingSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/HttpConnector.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/HttpConnector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/HttpConnectorValidator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/HttpConnectorValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/IndividualSettingsValidator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/IndividualSettingsValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/Migrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/Migrator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/ServerConfigurationValidator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/ServerConfigurationValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/Settings.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/Settings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/Title.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/Title.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/ssl/LegacySslPolicyConfig.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/ssl/LegacySslPolicyConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/ssl/SslPolicyConfig.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/ssl/SslPolicyConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/ssl/SslPolicyConfigValidator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/ssl/SslPolicyConfigValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/ssl/SslPolicyLoader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/ssl/SslPolicyLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/ssl/SslSystemSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/ssl/SslSystemSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/extension/KernelExtensionFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/extension/KernelExtensionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/extension/KernelExtensionUtil.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/extension/KernelExtensionUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/extension/KernelExtensions.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/extension/KernelExtensions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/extension/UnsatisfiedDependencyStrategies.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/extension/UnsatisfiedDependencyStrategies.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/extension/UnsatisfiedDependencyStrategy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/extension/UnsatisfiedDependencyStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/extension/dependency/AllByPrioritySelectionStrategy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/extension/dependency/AllByPrioritySelectionStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/extension/dependency/HighestSelectionStrategy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/extension/dependency/HighestSelectionStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/guard/Guard.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/guard/Guard.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/guard/TerminationGuard.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/guard/TerminationGuard.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/annotations/AnnotationProcessor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/annotations/AnnotationProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/annotations/DocumentationProcessor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/annotations/DocumentationProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/annotations/Documented.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/annotations/Documented.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/annotations/ServiceProcessor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/annotations/ServiceProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/AbstractIndexKeyLengthValidator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/AbstractIndexKeyLengthValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/BatchTransactionApplier.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/BatchTransactionApplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/BatchTransactionApplierFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/BatchTransactionApplierFacade.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CachingExplicitIndexTransactionState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CachingExplicitIndexTransactionState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ClockContext.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ClockContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CloseableResourceManager.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CloseableResourceManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CommandVisitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CommandVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CommitProcessFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CommitProcessFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CountsAccessor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CountsAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CountsRecordState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CountsRecordState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CountsStoreBatchTransactionApplier.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CountsStoreBatchTransactionApplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CountsStoreTransactionApplier.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CountsStoreTransactionApplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CountsVisitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CountsVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/DatabaseSchemaState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/DatabaseSchemaState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/DefaultTransactionTracer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/DefaultTransactionTracer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/DegreeVisitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/DegreeVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ExecutingQueryList.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ExecutingQueryList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ExplicitBatchIndexApplier.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ExplicitBatchIndexApplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ExplicitIndexApplierLookup.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ExplicitIndexApplierLookup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ExplicitIndexProviderLookup.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ExplicitIndexProviderLookup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ExplicitIndexTransactionApplier.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ExplicitIndexTransactionApplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/IndexReaderFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/IndexReaderFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/IndexTextValueLengthValidator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/IndexTextValueLengthValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelStatement.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelStatement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementationHandle.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementationHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionMonitorScheduler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionMonitorScheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionTimeoutMonitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionTimeoutMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactions.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionsSnapshot.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionsSnapshot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LogRotationMonitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LogRotationMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LookupFilter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LookupFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/NonTransactionalTokenNameLookup.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/NonTransactionalTokenNameLookup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/PropertyValueComparator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/PropertyValueComparator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/PropertyValueComparison.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/PropertyValueComparison.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ReadOnlyTransactionCommitProcess.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ReadOnlyTransactionCommitProcess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/RelationshipDataExtractor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/RelationshipDataExtractor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/RelationshipVisitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/RelationshipVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/SchemaState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/SchemaState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/SchemaWriteGuard.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/SchemaWriteGuard.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StackingQueryRegistrationOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StackingQueryRegistrationOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StatementOperationParts.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StatementOperationParts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TokenAccess.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TokenAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TransactionApplier.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TransactionApplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TransactionApplierFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TransactionApplierFacade.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TransactionCommitProcess.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TransactionCommitProcess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TransactionExecutionStatistic.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TransactionExecutionStatistic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TransactionHeaderInformation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TransactionHeaderInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TransactionHooks.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TransactionHooks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TransactionQueue.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TransactionQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TransactionRepresentationCommitProcess.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TransactionRepresentationCommitProcess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TransactionToApply.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TransactionToApply.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/cursor/TxAbstractPropertyCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/cursor/TxAbstractPropertyCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/cursor/TxAbstractRelationshipCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/cursor/TxAbstractRelationshipCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/cursor/TxAllPropertyCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/cursor/TxAllPropertyCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/cursor/TxIteratorRelationshipCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/cursor/TxIteratorRelationshipCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/cursor/TxSingleNodeCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/cursor/TxSingleNodeCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/cursor/TxSinglePropertyCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/cursor/TxSinglePropertyCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/cursor/TxSingleRelationshipCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/cursor/TxSingleRelationshipCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/dbms/NonTransactionalDbmsOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/dbms/NonTransactionalDbmsOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/explicitindex/AbstractIndexHits.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/explicitindex/AbstractIndexHits.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/explicitindex/InternalAutoIndexOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/explicitindex/InternalAutoIndexOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/explicitindex/InternalAutoIndexing.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/explicitindex/InternalAutoIndexing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/AbstractDelegatingIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/AbstractDelegatingIndexProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/AbstractSwallowingIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/AbstractSwallowingIndexProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/BatchingMultipleIndexPopulator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/BatchingMultipleIndexPopulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/ContractCheckingIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/ContractCheckingIndexProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/DelegatingIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/DelegatingIndexProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/FailedIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/FailedIndexProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/FailedIndexProxyFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/FailedIndexProxyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/FailedPopulatingIndexProxyFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/FailedPopulatingIndexProxyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/FlippableIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/FlippableIndexProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexCountsRemover.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexCountsRemover.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexMap.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexMapReference.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexMapReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexMapSnapshotProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexMapSnapshotProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexMeta.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexPopulationFailure.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexPopulationFailure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexPopulationJob.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexPopulationJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexPopulationJobController.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexPopulationJobController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexProviderMap.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexProviderMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexProviderNotFoundException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexProviderNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexProxyCreator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexProxyCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexProxyFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexProxyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexStoreView.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexStoreView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexUpdateMode.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexUpdateMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexUpdaterMap.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexUpdaterMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingService.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingServiceFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingServiceFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingUpdateService.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingUpdateService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/MultiPopulatorFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/MultiPopulatorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/MultipleIndexPopulator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/MultipleIndexPopulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/NodePropertyCommandsExtractor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/NodePropertyCommandsExtractor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/NodeUpdates.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/NodeUpdates.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/NodeUpdatesIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/NodeUpdatesIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/OnlineIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/OnlineIndexProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/PopulatingIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/PopulatingIndexProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/PropertyLoader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/PropertyLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/PropertyPhysicalToLogicalConverter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/PropertyPhysicalToLogicalConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/RebuildingIndexDescriptor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/RebuildingIndexDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/RecoveringIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/RecoveringIndexProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/StoreScan.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/StoreScan.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/TentativeConstraintIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/TentativeConstraintIndexProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/UpdateMode.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/UpdateMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/sampling/DefaultNonUniqueIndexSampler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/sampling/DefaultNonUniqueIndexSampler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/sampling/IndexSamplingConfig.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/sampling/IndexSamplingConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/sampling/IndexSamplingController.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/sampling/IndexSamplingController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/sampling/IndexSamplingControllerFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/sampling/IndexSamplingControllerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/sampling/IndexSamplingJob.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/sampling/IndexSamplingJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/sampling/IndexSamplingJobFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/sampling/IndexSamplingJobFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/sampling/IndexSamplingJobQueue.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/sampling/IndexSamplingJobQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/sampling/IndexSamplingJobTracker.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/sampling/IndexSamplingJobTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/sampling/IndexSamplingMode.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/sampling/IndexSamplingMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/sampling/NonUniqueIndexSampler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/sampling/NonUniqueIndexSampler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/sampling/OnlineIndexSamplingJob.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/sampling/OnlineIndexSamplingJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/sampling/OnlineIndexSamplingJobFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/sampling/OnlineIndexSamplingJobFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/sampling/UniqueIndexSampler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/sampling/UniqueIndexSampler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/updater/DelegatingIndexUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/updater/DelegatingIndexUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/updater/SwallowingIndexUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/updater/SwallowingIndexUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/updater/UniquePropertyIndexUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/updater/UniquePropertyIndexUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/updater/UpdateCountingIndexUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/updater/UpdateCountingIndexUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/operations/QueryRegistrationOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/operations/QueryRegistrationOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/scan/FullLabelStream.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/scan/FullLabelStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/scan/FullStoreChangeStream.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/scan/FullStoreChangeStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/schema/BridgingIndexProgressor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/schema/BridgingIndexProgressor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/security/OverriddenAccessMode.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/security/OverriddenAccessMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/security/RestrictedAccessMode.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/security/RestrictedAccessMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/security/WrappedAccessMode.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/security/WrappedAccessMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/ConstraintIndexCreator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/ConstraintIndexCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/ExplicitIndexTransactionStateImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/ExplicitIndexTransactionStateImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/GraphState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/GraphState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/NodeStateImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/NodeStateImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/PropertyContainerStateImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/PropertyContainerStateImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/RelationshipChangesForNode.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/RelationshipChangesForNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/RelationshipStateImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/RelationshipStateImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/TxState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/TxState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/AllIdIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/AllIdIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/AllNodeIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/AllNodeIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/AllRelationshipIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/AllRelationshipIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/CursorRelationshipIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/CursorRelationshipIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/DefaultCapableIndexReference.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/DefaultCapableIndexReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/DefaultIndexReference.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/DefaultIndexReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/DegreeCounter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/DegreeCounter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/HighIdAwareIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/HighIdAwareIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/NodeLoadingIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/NodeLoadingIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/PropertyUtil.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/PropertyUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/RelationshipIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/RelationshipIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/SchemaCache.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/SchemaCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StorageLayer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StorageLayer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreAbstractRelationshipCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreAbstractRelationshipCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreIteratorRelationshipCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreIteratorRelationshipCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreNodeRelationshipCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreNodeRelationshipCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StorePropertyCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StorePropertyCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StorePropertyPayloadCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StorePropertyPayloadCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreSingleNodeCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreSingleNodeCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreSinglePropertyCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreSinglePropertyCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreSingleRelationshipCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreSingleRelationshipCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/cache/BridgingCacheAccess.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/cache/BridgingCacheAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/cache/ClockCache.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/cache/ClockCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/cache/VmPauseMonitorComponent.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/cache/VmPauseMonitorComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/constraints/ConstraintSemantics.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/constraints/ConstraintSemantics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/constraints/StandardConstraintSemantics.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/constraints/StandardConstraintSemantics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/context/TransactionVersionContext.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/context/TransactionVersionContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/context/TransactionVersionContextSupplier.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/context/TransactionVersionContextSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/CacheAccessBackDoor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/CacheAccessBackDoor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/DatabasePanicEventGenerator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/DatabasePanicEventGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/DefaultLabelIdCreator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/DefaultLabelIdCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/DefaultPropertyTokenCreator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/DefaultPropertyTokenCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/DefaultRelationshipTypeCreator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/DefaultRelationshipTypeCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/DelegatingLabelTokenHolder.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/DelegatingLabelTokenHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/DelegatingPropertyKeyTokenHolder.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/DelegatingPropertyKeyTokenHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/DelegatingRelationshipTypeTokenHolder.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/DelegatingRelationshipTypeTokenHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/DelegatingTokenHolder.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/DelegatingTokenHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/EmbeddedProxySPI.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/EmbeddedProxySPI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/GraphProperties.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/GraphProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/GraphPropertiesProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/GraphPropertiesProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/InMemoryTokenCache.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/InMemoryTokenCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/IsolatedTransactionTokenCreator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/IsolatedTransactionTokenCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/IteratingPropertyReceiver.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/IteratingPropertyReceiver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/LabelTokenHolder.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/LabelTokenHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/LastTxIdGetter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/LastTxIdGetter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NonUniqueTokenException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NonUniqueTokenException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/PathProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/PathProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/PropertyKeyTokenHolder.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/PropertyKeyTokenHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/ReadOnlyTokenCreator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/ReadOnlyTokenCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/RelationshipProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/RelationshipProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/RelationshipTypeToken.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/RelationshipTypeToken.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/RelationshipTypeTokenHolder.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/RelationshipTypeTokenHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/StartupStatistics.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/StartupStatistics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/StartupStatisticsProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/StartupStatisticsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/ThreadToStatementContextBridge.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/ThreadToStatementContextBridge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/TokenCreator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/TokenCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/TokenHolder.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/TokenHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/TokenNotFoundException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/TokenNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/AutoIndexerFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/AutoIndexerFacade.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/CoreAPIAvailabilityGuard.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/CoreAPIAvailabilityGuard.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/ExplicitIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/ExplicitIndexProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/IndexManagerImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/IndexManagerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/IndexProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/IndexProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/IndexProviderImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/IndexProviderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/InternalTransaction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/InternalTransaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/PlaceboTransaction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/PlaceboTransaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/PropertyContainerLocker.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/PropertyContainerLocker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/ReadOnlyIndexFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/ReadOnlyIndexFacade.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/ReadOnlyRelationshipIndexFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/ReadOnlyRelationshipIndexFacade.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/RelationshipAutoIndexerFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/RelationshipAutoIndexerFacade.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/RelationshipExplicitIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/RelationshipExplicitIndexProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/RelationshipReadOnlyIndexFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/RelationshipReadOnlyIndexFacade.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/TopLevelTransaction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/TopLevelTransaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/TxStateTransactionDataSnapshot.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/TxStateTransactionDataSnapshot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/AbstractConstraintCreator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/AbstractConstraintCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/BaseNodeConstraintCreator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/BaseNodeConstraintCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/IndexCreatorImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/IndexCreatorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/IndexDefinitionImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/IndexDefinitionImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/InternalSchemaActions.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/InternalSchemaActions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/MultiPropertyConstraintDefinition.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/MultiPropertyConstraintDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/NodeConstraintDefinition.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/NodeConstraintDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/NodeKeyConstraintDefinition.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/NodeKeyConstraintDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/NodePropertyExistenceConstraintDefinition.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/NodePropertyExistenceConstraintDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/NodePropertyUniqueConstraintCreator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/NodePropertyUniqueConstraintCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/PropertyConstraintDefinition.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/PropertyConstraintDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/PropertyNameUtils.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/PropertyNameUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/RelationshipConstraintDefinition.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/RelationshipConstraintDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/RelationshipPropertyExistenceConstraintDefinition.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/RelationshipPropertyExistenceConstraintDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/SchemaImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/SchemaImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/SinglePropertyConstraintDefinition.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/SinglePropertyConstraintDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/UniquenessConstraintDefinition.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/UniquenessConstraintDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/AccessCapability.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/AccessCapability.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/CanWrite.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/CanWrite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/ClassicCoreSPI.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/ClassicCoreSPI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/CommunityCommitProcessFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/CommunityCommitProcessFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/CommunityEditionModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/CommunityEditionModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/DataSourceModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/DataSourceModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/DatabaseInfo.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/DatabaseInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/Edition.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/Edition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/EditionModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/EditionModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacade.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacadeFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacadeFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/OperationalMode.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/OperationalMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/PlatformModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/PlatformModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/ReadOnly.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/ReadOnly.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/StatementLocksFactorySelector.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/StatementLocksFactorySelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/ExplicitIndexStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/ExplicitIndexStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/GBPTreeFileUtil.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/GBPTreeFileUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/IndexCommand.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/IndexCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/IndexConfigStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/IndexConfigStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/IndexDefineCommand.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/IndexDefineCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/IndexEntityType.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/IndexEntityType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/IndexProviderStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/IndexProviderStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/CompositeLabelScanValueIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/CompositeLabelScanValueIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/GBPTreePageCacheFileUtil.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/GBPTreePageCacheFileUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/LabelScanKey.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/LabelScanKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/LabelScanLayout.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/LabelScanLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/LabelScanValue.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/LabelScanValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/LabelScanValueIndexAccessor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/LabelScanValueIndexAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/LabelScanValueIndexProgressor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/LabelScanValueIndexProgressor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/LabelScanValueIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/LabelScanValueIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/LabelScanWriteMonitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/LabelScanWriteMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/NativeAllEntriesLabelScanReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/NativeAllEntriesLabelScanReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanWriter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/PhysicalToLogicalLabelChanges.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/PhysicalToLogicalLabelChanges.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/CapabilityValidator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/CapabilityValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/ConflictDetectingValueMerger.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/ConflictDetectingValueMerger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/DateLayout.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/DateLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/DateSchemaKey.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/DateSchemaKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/DeferredConflictCheckingIndexUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/DeferredConflictCheckingIndexUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/DurationLayout.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/DurationLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/DurationSchemaKey.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/DurationSchemaKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/FailureHeaderWriter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/FailureHeaderWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/FilteringNativeHitIndexProgressor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/FilteringNativeHitIndexProgressor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/FilteringNativeHitIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/FilteringNativeHitIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/FullScanNonUniqueIndexSampler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/FullScanNonUniqueIndexSampler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/GBPTreeFileSystemFileUtil.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/GBPTreeFileSystemFileUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/IndexPartsCache.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/IndexPartsCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/LocalDateTimeLayout.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/LocalDateTimeLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/LocalDateTimeSchemaKey.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/LocalDateTimeSchemaKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/LocalTimeLayout.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/LocalTimeLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/LocalTimeSchemaKey.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/LocalTimeSchemaKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeAllEntriesReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeAllEntriesReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeDistinctValuesProgressor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeDistinctValuesProgressor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeHitIndexProgressor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeHitIndexProgressor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeHitIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeHitIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeIndexKeyLengthValidator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeIndexKeyLengthValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeIndexProgressor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeIndexProgressor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeIndexProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeIndexProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaIndex.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaIndexAccessor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaIndexAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaIndexHeaderReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaIndexHeaderReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaIndexHeaderWriter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaIndexHeaderWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaIndexPopulator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaIndexPopulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaIndexReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaIndexReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaIndexUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaIndexUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaIndexes.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaIndexes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaKey.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaValue.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NodeValueIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NodeValueIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NumberIndexProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NumberIndexProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NumberLayout.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NumberLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NumberLayoutNonUnique.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NumberLayoutNonUnique.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NumberLayoutUnique.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NumberLayoutUnique.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NumberSchemaIndexAccessor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NumberSchemaIndexAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NumberSchemaIndexPopulator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NumberSchemaIndexPopulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NumberSchemaIndexReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NumberSchemaIndexReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NumberSchemaKey.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NumberSchemaKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/PropertyLookupFallbackComparator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/PropertyLookupFallbackComparator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/RawBits.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/RawBits.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SamplingUtil.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SamplingUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SchemaLayout.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SchemaLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialHitIndexProgressor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialHitIndexProgressor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialIndexAccessor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialIndexAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialIndexCache.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialIndexCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialIndexFiles.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialIndexFiles.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialIndexPartReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialIndexPartReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialIndexPopulatingUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialIndexPopulatingUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialIndexPopulator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialIndexPopulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialIndexProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialIndexProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialIndexReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialIndexReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialIndexUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialIndexUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialLayout.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialSchemaKey.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialSchemaKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialVerifyDeferredConstraint.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialVerifyDeferredConstraint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/StringIndexProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/StringIndexProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/StringLayout.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/StringLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/StringSchemaIndexAccessor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/StringSchemaIndexAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/StringSchemaIndexPopulator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/StringSchemaIndexPopulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/StringSchemaIndexReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/StringSchemaIndexReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/StringSchemaKey.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/StringSchemaKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexAccessor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexCache.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexFiles.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexFiles.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexPartReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexPartReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexPopulatingUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexPopulatingUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexPopulator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexPopulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/ZonedDateTimeLayout.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/ZonedDateTimeLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/ZonedDateTimeSchemaKey.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/ZonedDateTimeSchemaKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/ZonedTimeLayout.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/ZonedTimeLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/ZonedTimeSchemaKey.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/ZonedTimeSchemaKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/config/SpaceFillingCurveSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/config/SpaceFillingCurveSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/config/SpaceFillingCurveSettingsFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/config/SpaceFillingCurveSettingsFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/config/SpatialIndexSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/config/SpatialIndexSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/BridgingIndexProgressor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/BridgingIndexProgressor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexAccessor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexBase.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexPopulator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexPopulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexSampler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexSampler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionSlotSelector00.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionSlotSelector00.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionSlotSelector10.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionSlotSelector10.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionSlotSelector20.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionSlotSelector20.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/InstanceSelector.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/InstanceSelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/LazyInstanceSelector.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/LazyInstanceSelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/SlotSelector.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/SlotSelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/AbstractLockService.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/AbstractLockService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/ActiveLock.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/ActiveLock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/CombinedTracer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/CombinedTracer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/DumpLocksVisitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/DumpLocksVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/Lock.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/Lock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/LockAcquisitionTimeoutException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/LockAcquisitionTimeoutException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/LockClientStateHolder.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/LockClientStateHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/LockClientStoppedException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/LockClientStoppedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/LockCountVisitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/LockCountVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/LockGroup.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/LockGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/LockService.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/LockService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/LockTracer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/LockTracer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/LockType.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/LockType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/LockWaitEvent.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/LockWaitEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/Locks.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/Locks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/NoOpClient.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/NoOpClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/ReadOnlyLocks.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/ReadOnlyLocks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/ReentrantLockService.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/ReentrantLockService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/ResourceTypes.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/ResourceTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/SimpleStatementLocks.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/SimpleStatementLocks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/SimpleStatementLocksFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/SimpleStatementLocksFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/StatementLocks.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/StatementLocks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/StatementLocksFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/StatementLocksFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/community/CommunityLockClient.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/community/CommunityLockClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/community/CommunityLockManger.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/community/CommunityLockManger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/community/LockException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/community/LockException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/community/LockManagerImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/community/LockManagerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/community/LockNotFoundException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/community/LockNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/community/LockResource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/community/LockResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/community/LockTransaction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/community/LockTransaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/community/RWLock.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/community/RWLock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/community/RagManager.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/community/RagManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/logging/AbstractLogService.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/logging/AbstractLogService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/logging/LogService.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/logging/LogService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/logging/NullLogService.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/logging/NullLogService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/logging/SimpleLogService.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/logging/SimpleLogService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/logging/StoreLogService.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/logging/StoreLogService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/AllStoreHolder.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/AllStoreHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/CursorPropertyAccessor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/CursorPropertyAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultCursors.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultCursors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultNodeCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultNodeCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultNodeExplicitIndexCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultNodeExplicitIndexCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultNodeLabelIndexCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultNodeLabelIndexCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultNodeValueIndexCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultNodeValueIndexCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultPropertyCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultPropertyCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipExplicitIndexCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipExplicitIndexCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipGroupCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipGroupCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipScanCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipScanCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipTraversalCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipTraversalCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/ExplicitIndexProgressor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/ExplicitIndexProgressor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/GroupReferenceEncoding.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/GroupReferenceEncoding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/HasChanges.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/HasChanges.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/IndexCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/IndexCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/IndexReaders.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/IndexReaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/IndexTxStateUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/IndexTxStateUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/KernelSession.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/KernelSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/KernelToken.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/KernelToken.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/Labels.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/Labels.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/NewKernel.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/NewKernel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/NodeLabelIndexProgressor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/NodeLabelIndexProgressor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/NodeSchemaMatcher.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/NodeSchemaMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/NodeValueClientFilter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/NodeValueClientFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/Operations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/Operations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/Read.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/Read.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/References.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/References.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/RelationshipCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/RelationshipCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/RelationshipDirection.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/RelationshipDirection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/RelationshipReferenceEncoding.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/RelationshipReferenceEncoding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/TwoPhaseNodeForRelationshipLocking.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/TwoPhaseNodeForRelationshipLocking.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/UnionIndexCapability.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/UnionIndexCapability.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/ConfigurableStandalonePageCacheFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/ConfigurableStandalonePageCacheFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/ConfiguringPageCacheFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/ConfiguringPageCacheFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/PageCacheLifecycle.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/PageCacheLifecycle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/PublishPageCacheTracerMetricsAfterStart.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/PublishPageCacheTracerMetricsAfterStart.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ByteArrayConverter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ByteArrayConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ComponentRegistry.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ComponentRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/FieldInjections.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/FieldInjections.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ListConverter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ListConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/MapConverter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/MapConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/MethodSignatureCompiler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/MethodSignatureCompiler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/NamingRestrictions.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/NamingRestrictions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/OutputMappers.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/OutputMappers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ParseUtil.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ParseUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ProcedureConfig.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ProcedureConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ProcedureGDBFacadeSPI.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ProcedureGDBFacadeSPI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ProcedureGDSFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ProcedureGDSFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ProcedureHolder.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ProcedureHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ProcedureJarLoader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ProcedureJarLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ProcedureRegistry.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ProcedureRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ProcedureTransactionProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ProcedureTransactionProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/Procedures.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/Procedures.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureCompiler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureCompiler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/TerminationGuardProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/TerminationGuardProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/TypeMappers.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/TypeMappers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/temporal/DateFunction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/temporal/DateFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/temporal/DateTimeFunction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/temporal/DateTimeFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/temporal/DurationFunction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/temporal/DurationFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/temporal/LocalDateTimeFunction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/temporal/LocalDateTimeFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/temporal/LocalTimeFunction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/temporal/LocalTimeFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/temporal/TemporalFunction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/temporal/TemporalFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/temporal/TimeFunction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/temporal/TimeFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/query/Neo4jTransactionalContext.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/query/Neo4jTransactionalContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/query/Neo4jTransactionalContextFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/query/Neo4jTransactionalContextFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/query/NoQueryEngine.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/query/NoQueryEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/query/QueryEngineProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/query/QueryEngineProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/query/QueryExecutionEngine.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/query/QueryExecutionEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/query/QueryExecutionKernelException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/query/QueryExecutionKernelException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/query/QueryExecutionMonitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/query/QueryExecutionMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/query/TransactionalContext.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/query/TransactionalContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/query/TransactionalContextFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/query/TransactionalContextFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/query/clientconnection/BoltConnectionInfo.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/query/clientconnection/BoltConnectionInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/query/clientconnection/ClientConnectionInfo.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/query/clientconnection/ClientConnectionInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/query/clientconnection/HttpConnectionInfo.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/query/clientconnection/HttpConnectionInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/query/clientconnection/ShellConnectionInfo.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/query/clientconnection/ShellConnectionInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/query/statistic/StatisticProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/query/statistic/StatisticProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/recovery/RecoveryRequiredChecker.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/recovery/RecoveryRequiredChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/scheduler/CentralJobScheduler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/scheduler/CentralJobScheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/scheduler/GroupedDaemonThreadFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/scheduler/GroupedDaemonThreadFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/scheduler/PooledJobHandle.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/scheduler/PooledJobHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/scheduler/ScheduledJobHandle.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/scheduler/ScheduledJobHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/scheduler/ThreadPool.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/scheduler/ThreadPool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/scheduler/ThreadPoolManager.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/scheduler/ThreadPoolManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/scheduler/TimeBasedTaskScheduler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/scheduler/TimeBasedTaskScheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/security/Credential.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/security/Credential.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/security/FileURLAccessRule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/security/FileURLAccessRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/security/URLAccessRules.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/security/URLAccessRules.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/security/User.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/security/User.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/spi/KernelContext.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/spi/KernelContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/spi/SimpleKernelContext.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/spi/SimpleKernelContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/RecordStorageCommandCreationContext.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/RecordStorageCommandCreationContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/RecordStorageCommandReaderFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/RecordStorageCommandReaderFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/RecordStorageEngine.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/RecordStorageEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/StoreStatement.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/StoreStatement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/TransactionToRecordStateVisitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/TransactionToRecordStateVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/id/BufferedIdController.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/id/BufferedIdController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/id/DefaultIdController.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/id/DefaultIdController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/id/IdController.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/id/IdController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/AbstractDynamicStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/AbstractDynamicStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/CommonAbstractStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/CommonAbstractStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/CountsComputer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/CountsComputer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/DataInconsistencyError.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/DataInconsistencyError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/DynamicArrayStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/DynamicArrayStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/DynamicNodeLabels.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/DynamicNodeLabels.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/DynamicRecordAllocator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/DynamicRecordAllocator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/DynamicStringStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/DynamicStringStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/GeometryType.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/GeometryType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/HighestTransactionId.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/HighestTransactionId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/InlineNodeLabels.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/InlineNodeLabels.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/IntStoreHeader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/IntStoreHeader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/IntStoreHeaderFormat.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/IntStoreHeaderFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/InvalidIdGeneratorException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/InvalidIdGeneratorException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/InvalidRecordException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/InvalidRecordException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/LabelIdArray.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/LabelIdArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/LabelTokenStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/LabelTokenStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/LongerShortString.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/LongerShortString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/MetaDataStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/MetaDataStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/MismatchingStoreIdException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/MismatchingStoreIdException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/MultipleUnderlyingStorageExceptions.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/MultipleUnderlyingStorageExceptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/NeoStores.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/NeoStores.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/NoStoreHeader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/NoStoreHeader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/NoStoreHeaderFormat.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/NoStoreHeaderFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/NodeLabels.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/NodeLabels.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/NodeLabelsField.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/NodeLabelsField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/NodeStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/NodeStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/NotCurrentStoreVersionException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/NotCurrentStoreVersionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/PropertyKeyTokenStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/PropertyKeyTokenStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/PropertyStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/PropertyStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/PropertyType.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/PropertyType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/PropertyValueRecordSizeCalculator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/PropertyValueRecordSizeCalculator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/RecordCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/RecordCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/RecordCursors.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/RecordCursors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/RecordPageLocationCalculator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/RecordPageLocationCalculator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/RecordStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/RecordStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/RelationshipGroupStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/RelationshipGroupStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/RelationshipStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/RelationshipStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/RelationshipTypeTokenStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/RelationshipTypeTokenStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/Scanner.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/Scanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/SchemaRuleAccess.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/SchemaRuleAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/SchemaStorage.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/SchemaStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/SchemaStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/SchemaStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/ShortArray.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/ShortArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StandardDynamicRecordAllocator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StandardDynamicRecordAllocator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreAccess.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreFailureException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreFailureException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreFile.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreHeader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreHeader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreHeaderFormat.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreHeaderFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreId.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreIdIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreIdIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreNotFoundException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreRecordCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreRecordCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreType.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/TemporalType.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/TemporalType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/TemporalValueWriterAdapter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/TemporalValueWriterAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/TokenStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/TokenStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/TransactionId.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/TransactionId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/UnderlyingStorageException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/UnderlyingStorageException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/UnexpectedStoreVersionException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/UnexpectedStoreVersionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/allocator/ReusableRecordsAllocator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/allocator/ReusableRecordsAllocator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/allocator/ReusableRecordsCompositeAllocator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/allocator/ReusableRecordsCompositeAllocator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/CountsTracker.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/CountsTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/CountsUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/CountsUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/FileVersion.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/FileVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/KeyFormat.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/KeyFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/ReadOnlyCountsTracker.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/ReadOnlyCountsTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/ValueRegister.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/ValueRegister.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/keys/CountsKey.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/keys/CountsKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/keys/CountsKeyFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/keys/CountsKeyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/keys/CountsKeyType.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/keys/CountsKeyType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/keys/IndexKey.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/keys/IndexKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/keys/IndexSampleKey.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/keys/IndexSampleKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/keys/IndexStatisticsKey.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/keys/IndexStatisticsKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/keys/NodeKey.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/keys/NodeKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/keys/RelationshipKey.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/keys/RelationshipKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/BaseOneByteHeaderRecordFormat.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/BaseOneByteHeaderRecordFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/BaseRecordFormat.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/BaseRecordFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/BaseRecordFormats.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/BaseRecordFormats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/Capability.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/Capability.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/CapabilityType.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/CapabilityType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/FormatFamily.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/FormatFamily.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/RecordFormat.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/RecordFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/RecordFormatPropertyConfigurator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/RecordFormatPropertyConfigurator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/RecordFormatSelector.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/RecordFormatSelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/RecordFormats.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/RecordFormats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/StoreVersion.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/StoreVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/UnsupportedFormatCapabilityException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/UnsupportedFormatCapabilityException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/DynamicRecordFormat.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/DynamicRecordFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/LabelTokenRecordFormat.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/LabelTokenRecordFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/MetaDataRecordFormat.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/MetaDataRecordFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/NoRecordFormat.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/NoRecordFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/NodeRecordFormat.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/NodeRecordFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/PropertyKeyTokenRecordFormat.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/PropertyKeyTokenRecordFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/PropertyRecordFormat.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/PropertyRecordFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/RelationshipGroupRecordFormat.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/RelationshipGroupRecordFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/RelationshipRecordFormat.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/RelationshipRecordFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/RelationshipTypeTokenRecordFormat.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/RelationshipTypeTokenRecordFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/Standard.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/Standard.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/StandardFormatFamily.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/StandardFormatFamily.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/StandardFormatSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/StandardFormatSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/StandardV2_3.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/StandardV2_3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/StandardV3_0.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/StandardV3_0.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/StandardV3_2.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/StandardV3_2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/StandardV3_4.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/StandardV3_4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/TokenRecordFormat.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/TokenRecordFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/BatchingIdSequence.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/BatchingIdSequence.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/BufferingIdGenerator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/BufferingIdGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/BufferingIdGeneratorFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/BufferingIdGeneratorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/DefaultIdGeneratorFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/DefaultIdGeneratorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/DelayedBuffer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/DelayedBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/FreeIdKeeper.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/FreeIdKeeper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/IdContainer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/IdContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/IdGenerator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/IdGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/IdGeneratorFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/IdGeneratorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/IdGeneratorImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/IdGeneratorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/IdRange.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/IdRange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/IdRangeIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/IdRangeIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/IdReuseEligibility.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/IdReuseEligibility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/IdSequence.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/IdSequence.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/IdType.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/IdType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/ReadOnlyIdGeneratorFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/ReadOnlyIdGeneratorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/RenewableBatchIdSequence.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/RenewableBatchIdSequence.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/RenewableBatchIdSequences.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/RenewableBatchIdSequences.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/configuration/CommunityIdTypeConfigurationProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/configuration/CommunityIdTypeConfigurationProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/configuration/IdTypeConfiguration.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/configuration/IdTypeConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/configuration/IdTypeConfigurationProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/configuration/IdTypeConfigurationProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/validation/IdCapacityExceededException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/validation/IdCapacityExceededException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/validation/IdValidator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/validation/IdValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/validation/NegativeIdException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/validation/NegativeIdException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/validation/ReservedIdException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/validation/ReservedIdException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/AbstractKeyValueStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/AbstractKeyValueStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/ActiveState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/ActiveState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/BigEndianByteArrayBuffer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/BigEndianByteArrayBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/ConcurrentMapState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/ConcurrentMapState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/DataInitializer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/DataInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/DataProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/DataProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/DeadState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/DeadState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/EntryUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/EntryUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/EntryVisitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/EntryVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/HeaderField.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/HeaderField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/Headers.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/Headers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/KeyFormat.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/KeyFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/KeyValueMerger.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/KeyValueMerger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/KeyValueStoreFile.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/KeyValueStoreFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/KeyValueStoreFileFormat.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/KeyValueStoreFileFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/KeyValueVisitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/KeyValueVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/KeyValueWriter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/KeyValueWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/LockWrapper.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/LockWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/Metadata.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/Metadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/MetadataCollector.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/MetadataCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/MetadataVisitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/MetadataVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/PreparedRotation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/PreparedRotation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/ProgressiveFormat.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/ProgressiveFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/ProgressiveState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/ProgressiveState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/PrototypeState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/PrototypeState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/ReadableBuffer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/ReadableBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/ReadableState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/ReadableState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/Rotation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/Rotation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/RotationMonitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/RotationMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/RotationState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/RotationState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/RotationStrategy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/RotationStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/RotationTimeoutException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/RotationTimeoutException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/RotationTimerFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/RotationTimerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/SearchKey.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/SearchKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/State.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/State.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/UnknownKey.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/UnknownKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/UpdateLock.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/UpdateLock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/ValueLookup.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/ValueLookup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/ValueSink.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/ValueSink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/ValueUpdate.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/ValueUpdate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/WritableBuffer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/WritableBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/WritableState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/WritableState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/AbstractBaseRecord.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/AbstractBaseRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/ConstraintRule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/ConstraintRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/DynamicRecord.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/DynamicRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/IndexRule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/IndexRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/LabelTokenRecord.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/LabelTokenRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/MetaDataRecord.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/MetaDataRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/NeoStoreRecord.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/NeoStoreRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/NodeRecord.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/NodeRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/PrimitiveRecord.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/PrimitiveRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/PropertyBlock.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/PropertyBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/PropertyKeyTokenRecord.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/PropertyKeyTokenRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/PropertyRecord.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/PropertyRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/Record.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/Record.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/RecordLoad.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/RecordLoad.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/RelationshipGroupRecord.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/RelationshipGroupRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/RelationshipRecord.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/RelationshipRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/RelationshipTypeTokenRecord.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/RelationshipTypeTokenRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/SchemaRecord.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/SchemaRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/SchemaRuleDeserializer2_0to3_1.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/SchemaRuleDeserializer2_0to3_1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/SchemaRuleSerialization.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/SchemaRuleSerialization.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/TokenRecord.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/TokenRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/stats/IdBasedStoreEntityCounters.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/stats/IdBasedStoreEntityCounters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/stats/StoreEntityCounters.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/stats/StoreEntityCounters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/DatabaseMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/DatabaseMigrator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/DirectRecordStoreMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/DirectRecordStoreMigrator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/ExistingTargetStrategy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/ExistingTargetStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/FileOperation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/FileOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/MigrationStatus.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/MigrationStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreFileType.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreFileType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreMigrationParticipant.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreMigrationParticipant.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreUpgrader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreUpgrader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreVersionCheck.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreVersionCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/UpgradableDatabase.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/UpgradableDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/UpgradeNotAllowedByConfigurationException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/UpgradeNotAllowedByConfigurationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/UpgradeNotAllowedException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/UpgradeNotAllowedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/monitoring/MigrationProgressMonitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/monitoring/MigrationProgressMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/monitoring/SilentMigrationProgressMonitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/monitoring/SilentMigrationProgressMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/monitoring/VisibleMigrationProgressMonitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/monitoring/VisibleMigrationProgressMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/AbstractStoreMigrationParticipant.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/AbstractStoreMigrationParticipant.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/CountsMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/CountsMigrator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/ExplicitIndexMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/ExplicitIndexMigrator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/NativeLabelScanStoreMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/NativeLabelScanStoreMigrator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/SchemaIndexMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/SchemaIndexMigrator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/StoreMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/StoreMigrator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/StoreScanAsInputIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/StoreScanAsInputIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/StoreScanChunk.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/StoreScanChunk.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/CommittedTransactionRepresentation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/CommittedTransactionRepresentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/IllegalResourceException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/IllegalResourceException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/TransactionCounters.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/TransactionCounters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/TransactionHeaderInformationFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/TransactionHeaderInformationFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/TransactionMonitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/TransactionMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/TransactionRepresentation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/TransactionRepresentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/TransactionStats.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/TransactionStats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/BaseCommandReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/BaseCommandReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/CacheInvalidationBatchTransactionApplier.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/CacheInvalidationBatchTransactionApplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/CacheInvalidationTransactionApplier.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/CacheInvalidationTransactionApplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/Command.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/Command.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/CommandReading.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/CommandReading.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/HighIdBatchTransactionApplier.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/HighIdBatchTransactionApplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/HighIdTransactionApplier.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/HighIdTransactionApplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/IndexActivator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/IndexActivator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/IndexBatchTransactionApplier.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/IndexBatchTransactionApplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/IndexUpdatesWork.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/IndexUpdatesWork.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/LabelUpdateWork.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/LabelUpdateWork.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/NeoCommandType.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/NeoCommandType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/NeoStoreBatchTransactionApplier.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/NeoStoreBatchTransactionApplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/NeoStoreTransactionApplier.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/NeoStoreTransactionApplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/PhysicalLogCommandReaderV2_2_10.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/PhysicalLogCommandReaderV2_2_10.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/PhysicalLogCommandReaderV2_2_4.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/PhysicalLogCommandReaderV2_2_4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/PhysicalLogCommandReaderV3_0.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/PhysicalLogCommandReaderV3_0.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/PhysicalLogCommandReaderV3_0_2.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/PhysicalLogCommandReaderV3_0_2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/BatchingTransactionAppender.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/BatchingTransactionAppender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/Commitment.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/Commitment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/FilteringIOCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/FilteringIOCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/FlushableChannel.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/FlushableChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/FlushablePositionAwareChannel.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/FlushablePositionAwareChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/IndexCommandDetector.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/IndexCommandDetector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/LogEntryCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/LogEntryCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/LogFileInformation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/LogFileInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/LogHeaderCache.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/LogHeaderCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/LogPosition.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/LogPosition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/LogPositionMarker.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/LogPositionMarker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/LogVersionBridge.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/LogVersionBridge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/LogVersionRepository.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/LogVersionRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/LogVersionUpgradeChecker.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/LogVersionUpgradeChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/LogVersionedStoreChannel.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/LogVersionedStoreChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/LoggingLogFileMonitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/LoggingLogFileMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/LogicalTransactionStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/LogicalTransactionStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/MissingLogDataException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/MissingLogDataException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/NoSuchTransactionException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/NoSuchTransactionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/PhysicalFlushableChannel.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/PhysicalFlushableChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/PhysicalLogVersionedStoreChannel.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/PhysicalLogVersionedStoreChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/PhysicalLogicalTransactionStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/PhysicalLogicalTransactionStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/PhysicalTransactionCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/PhysicalTransactionCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/PhysicalTransactionRepresentation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/PhysicalTransactionRepresentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/PositionAwareChannel.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/PositionAwareChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/PositionAwarePhysicalFlushableChannel.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/PositionAwarePhysicalFlushableChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/PositionableChannel.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/PositionableChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/ReadAheadChannel.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/ReadAheadChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/ReadAheadLogChannel.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/ReadAheadLogChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/ReadOnlyLogVersionRepository.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/ReadOnlyLogVersionRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/ReadOnlyTransactionIdStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/ReadOnlyTransactionIdStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/ReadOnlyTransactionStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/ReadOnlyTransactionStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/ReadableClosableChannel.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/ReadableClosableChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/ReadableClosablePositionAwareChannel.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/ReadableClosablePositionAwareChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/ReadableLogChannel.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/ReadableLogChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/ReaderLogVersionBridge.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/ReaderLogVersionBridge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/ThreadLink.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/ThreadLink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/TransactionAppender.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/TransactionAppender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/TransactionCommitment.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/TransactionCommitment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/TransactionCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/TransactionCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/TransactionIdStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/TransactionIdStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/TransactionLogWriter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/TransactionLogWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/TransactionMetadataCache.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/TransactionMetadataCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/VersionableLog.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/VersionableLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/checkpoint/AbstractCheckPointThreshold.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/checkpoint/AbstractCheckPointThreshold.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CheckPointScheduler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CheckPointScheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CheckPointThreshold.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CheckPointThreshold.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CheckPointThresholdPolicy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CheckPointThresholdPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CheckPointer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CheckPointer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CheckPointerImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CheckPointerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CheckPointerMonitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CheckPointerMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CountCommittedTransactionThreshold.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CountCommittedTransactionThreshold.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/checkpoint/DefaultCheckPointerTracer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/checkpoint/DefaultCheckPointerTracer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/checkpoint/PeriodicThresholdPolicy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/checkpoint/PeriodicThresholdPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/checkpoint/SimpleTriggerInfo.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/checkpoint/SimpleTriggerInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/checkpoint/StoreCopyCheckPointMutex.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/checkpoint/StoreCopyCheckPointMutex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/checkpoint/TimeCheckPointThreshold.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/checkpoint/TimeCheckPointThreshold.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/checkpoint/TriggerInfo.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/checkpoint/TriggerInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/AbstractLogEntry.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/AbstractLogEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/CheckPoint.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/CheckPoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/IncompleteLogHeaderException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/IncompleteLogHeaderException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/InvalidLogEntryHandler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/InvalidLogEntryHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/LogEntry.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/LogEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/LogEntryByteCodes.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/LogEntryByteCodes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/LogEntryCommand.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/LogEntryCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/LogEntryCommit.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/LogEntryCommit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/LogEntryParser.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/LogEntryParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/LogEntryParsersV2_3.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/LogEntryParsersV2_3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/LogEntryReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/LogEntryReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/LogEntrySanity.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/LogEntrySanity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/LogEntryStart.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/LogEntryStart.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/LogEntryVersion.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/LogEntryVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/LogEntryWriter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/LogEntryWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/LogHeader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/LogHeader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/LogHeaderReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/LogHeaderReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/LogHeaderWriter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/LogHeaderWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/LogVersions.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/LogVersions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/UnsupportedLogVersionException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/UnsupportedLogVersionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/VersionAwareLogEntryReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/VersionAwareLogEntryReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/files/LogFile.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/files/LogFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/files/LogFileCreationMonitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/files/LogFileCreationMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/files/LogFiles.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/files/LogFiles.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/files/LogFilesBuilder.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/files/LogFilesBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/files/LogHeaderVisitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/files/LogHeaderVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/files/LogVersionVisitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/files/LogVersionVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/files/TransactionLogFile.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/files/TransactionLogFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/files/TransactionLogFileInformation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/files/TransactionLogFileInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/files/TransactionLogFiles.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/files/TransactionLogFiles.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/files/TransactionLogFilesContext.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/files/TransactionLogFilesContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/files/TransactionLogFilesHelper.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/files/TransactionLogFilesHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/pruning/EntryCountThreshold.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/pruning/EntryCountThreshold.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/pruning/EntryTimespanThreshold.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/pruning/EntryTimespanThreshold.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/pruning/FileCountThreshold.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/pruning/FileCountThreshold.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/pruning/FileSizeThreshold.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/pruning/FileSizeThreshold.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/pruning/LogPruneStrategy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/pruning/LogPruneStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/pruning/LogPruneStrategyFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/pruning/LogPruneStrategyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/pruning/LogPruning.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/pruning/LogPruning.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/pruning/LogPruningImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/pruning/LogPruningImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/pruning/Threshold.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/pruning/Threshold.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/pruning/ThresholdBasedPruneStrategy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/pruning/ThresholdBasedPruneStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/pruning/ThresholdConfigParser.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/pruning/ThresholdConfigParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/reverse/EagerlyReversedTransactionCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/reverse/EagerlyReversedTransactionCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/reverse/ReverseTransactionCursorLoggingMonitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/reverse/ReverseTransactionCursorLoggingMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/reverse/ReversedMultiFileTransactionCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/reverse/ReversedMultiFileTransactionCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/reverse/ReversedSingleFileTransactionCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/reverse/ReversedSingleFileTransactionCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/reverse/ReversedTransactionCursorMonitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/reverse/ReversedTransactionCursorMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/rotation/LogRotation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/rotation/LogRotation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/rotation/LogRotationImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/rotation/LogRotationImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/DataSourceManager.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/DataSourceManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/DefaultIndexProviderMap.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/DefaultIndexProviderMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/DirectIndexUpdates.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/DirectIndexUpdates.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/DirectionIdentifier.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/DirectionIdentifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/IndexUpdates.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/IndexUpdates.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/IntegrityValidator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/IntegrityValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/Loaders.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/Loaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/NeoStoreFileIndexListing.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/NeoStoreFileIndexListing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/NeoStoreFileListing.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/NeoStoreFileListing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/OnlineIndexUpdates.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/OnlineIndexUpdates.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/PropertyCreator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/PropertyCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/PropertyDeleter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/PropertyDeleter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/PropertyLoader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/PropertyLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/PropertyRecordChange.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/PropertyRecordChange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/PropertyTraverser.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/PropertyTraverser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/RecordAccess.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/RecordAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/RecordAccessSet.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/RecordAccessSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/RecordChangeSet.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/RecordChangeSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/RecordChanges.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/RecordChanges.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/RecordState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/RecordState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/RelationshipConnection.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/RelationshipConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/RelationshipCreator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/RelationshipCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/RelationshipDeleter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/RelationshipDeleter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/RelationshipGroupGetter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/RelationshipGroupGetter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/TokenCreator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/TokenCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/TransactionRecordState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/TransactionRecordState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/storeview/DynamicIndexStoreView.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/storeview/DynamicIndexStoreView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/storeview/LabelScanViewIdIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/storeview/LabelScanViewIdIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/storeview/LabelScanViewNodeStoreScan.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/storeview/LabelScanViewNodeStoreScan.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/storeview/NeoStoreIndexStoreView.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/storeview/NeoStoreIndexStoreView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/storeview/NodeStoreScan.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/storeview/NodeStoreScan.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/storeview/StoreViewNodeStoreScan.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/storeview/StoreViewNodeStoreScan.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/tracing/CheckPointTracer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/tracing/CheckPointTracer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/tracing/CommitEvent.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/tracing/CommitEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/tracing/LogAppendEvent.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/tracing/LogAppendEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/tracing/LogCheckPointEvent.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/tracing/LogCheckPointEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/tracing/LogForceEvent.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/tracing/LogForceEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/tracing/LogForceEvents.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/tracing/LogForceEvents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/tracing/LogForceWaitEvent.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/tracing/LogForceWaitEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/tracing/LogRotateEvent.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/tracing/LogRotateEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/tracing/SerializeTransactionEvent.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/tracing/SerializeTransactionEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/tracing/StoreApplyEvent.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/tracing/StoreApplyEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/tracing/TransactionEvent.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/tracing/TransactionEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/tracing/TransactionTracer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/tracing/TransactionTracer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/traversal/AbstractTraverserIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/traversal/AbstractTraverserIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/traversal/AsOneStartBranch.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/traversal/AsOneStartBranch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/traversal/BidirectionalTraversalDescriptionImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/traversal/BidirectionalTraversalDescriptionImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/traversal/BidirectionalTraverserIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/traversal/BidirectionalTraverserIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/traversal/DefaultTraverser.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/traversal/DefaultTraverser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/traversal/MonoDirectionalTraversalDescription.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/traversal/MonoDirectionalTraversalDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/traversal/MonoDirectionalTraverserIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/traversal/MonoDirectionalTraverserIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/traversal/MultiEvaluator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/traversal/MultiEvaluator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/traversal/SortingTraverserIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/traversal/SortingTraverserIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/traversal/StartNodeTraversalBranch.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/traversal/StartNodeTraversalBranch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/traversal/TraversalBranchImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/traversal/TraversalBranchImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/traversal/TraversalBranchWithState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/traversal/TraversalBranchWithState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/traversal/TraverserIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/traversal/TraverserIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/ArrayQueueOutOfOrderSequence.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/ArrayQueueOutOfOrderSequence.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/BaseToObjectValueWriter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/BaseToObjectValueWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/Bits.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/Bits.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/CappedLogger.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/CappedLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/Converters.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/Converters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/CopyOnWriteHashMap.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/CopyOnWriteHashMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/Cursors.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/Cursors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/CustomIOConfigValidator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/CustomIOConfigValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/DebugUtil.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/DebugUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/DefaultValueMapper.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/DefaultValueMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/Dependencies.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/Dependencies.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/DependenciesProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/DependenciesProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/DependencySatisfier.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/DependencySatisfier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/DirectionWrapper.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/DirectionWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/DurationLogger.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/DurationLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/HexPrinter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/HexPrinter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/IdOrderingQueue.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/IdOrderingQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/IdPrettyPrinter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/IdPrettyPrinter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/InstanceCache.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/InstanceCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/IoPrimitiveUtils.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/IoPrimitiveUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/LazySingleReference.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/LazySingleReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/Listener.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/Listener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/MonotonicCounter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/MonotonicCounter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/MovingAverage.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/MovingAverage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/MultiResource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/MultiResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/NodeProxyWrappingNodeValue.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/NodeProxyWrappingNodeValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/NoneStrictMath.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/NoneStrictMath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/NumberAwareStringComparator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/NumberAwareStringComparator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/OptionalHostnamePort.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/OptionalHostnamePort.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/OutOfOrderSequence.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/OutOfOrderSequence.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/PathWrappingPathValue.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/PathWrappingPathValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/RelationshipProxyWrappingValue.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/RelationshipProxyWrappingValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/SequenceArray.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/SequenceArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/SynchronizedArrayIdOrderingQueue.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/SynchronizedArrayIdOrderingQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/TraceLog.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/TraceLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/UnsatisfiedDependencyException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/UnsatisfiedDependencyException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/Validator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/Validator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/Validators.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/Validators.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/ValueUtils.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/ValueUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/VersionedHashMap.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/VersionedHashMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/collection/ArrayCollection.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/collection/ArrayCollection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/collection/CollectionsFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/collection/CollectionsFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/collection/CollectionsFactorySupplier.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/collection/CollectionsFactorySupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/collection/ConcurrentAccessException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/collection/ConcurrentAccessException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/collection/ContinuableArrayCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/collection/ContinuableArrayCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/collection/NoSuchEntryException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/collection/NoSuchEntryException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/collection/OffHeapCollectionsFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/collection/OffHeapCollectionsFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/collection/OnHeapCollectionsFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/collection/OnHeapCollectionsFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/collection/SimpleBitSet.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/collection/SimpleBitSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/collection/TimedRepository.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/collection/TimedRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/concurrent/LockWaitStrategies.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/concurrent/LockWaitStrategies.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/dbstructure/ArgumentFormatter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/dbstructure/ArgumentFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/dbstructure/DbStructureArgumentFormatter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/dbstructure/DbStructureArgumentFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/dbstructure/DbStructureCollector.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/dbstructure/DbStructureCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/dbstructure/DbStructureLookup.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/dbstructure/DbStructureLookup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/dbstructure/DbStructureTool.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/dbstructure/DbStructureTool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/dbstructure/DbStructureVisitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/dbstructure/DbStructureVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/dbstructure/GraphDbStructureGuide.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/dbstructure/GraphDbStructureGuide.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/dbstructure/InvocationTracer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/dbstructure/InvocationTracer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/diffsets/DiffApplyingLongIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/diffsets/DiffApplyingLongIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/diffsets/DiffApplyingPrimitiveLongIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/diffsets/DiffApplyingPrimitiveLongIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/diffsets/DiffApplyingRelationshipIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/diffsets/DiffApplyingRelationshipIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/diffsets/DiffSets.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/diffsets/DiffSets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/diffsets/PrimitiveLongDiffSets.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/diffsets/PrimitiveLongDiffSets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/diffsets/RelationshipDiffSets.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/diffsets/RelationshipDiffSets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/diffsets/SuperDiffSets.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/diffsets/SuperDiffSets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/monitoring/LogProgressReporter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/monitoring/LogProgressReporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/monitoring/ProgressReporter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/monitoring/ProgressReporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/monitoring/SilentProgressReporter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/monitoring/SilentProgressReporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/statistics/IntCounter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/statistics/IntCounter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/statistics/LocalIntCounter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/statistics/LocalIntCounter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/watcher/DefaultFileDeletionEventListener.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/watcher/DefaultFileDeletionEventListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/watcher/DefaultFileSystemWatcherService.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/watcher/DefaultFileSystemWatcherService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/watcher/FileSystemWatcherService.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/watcher/FileSystemWatcherService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/info/DiagnosticsExtractor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/info/DiagnosticsExtractor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/info/DiagnosticsManager.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/info/DiagnosticsManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/info/DiagnosticsPhase.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/info/DiagnosticsPhase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/info/DiagnosticsProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/info/DiagnosticsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/info/JvmChecker.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/info/JvmChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/info/JvmMetadataRepository.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/info/JvmMetadataRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/info/LockInfo.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/info/LockInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/info/SystemDiagnostics.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/info/SystemDiagnostics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/internal/DatabaseHealth.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/internal/DatabaseHealth.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/internal/DefaultKernelData.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/internal/DefaultKernelData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/internal/EmbeddedGraphDatabase.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/internal/EmbeddedGraphDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/internal/GraphDatabaseAPI.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/internal/GraphDatabaseAPI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/internal/KernelData.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/internal/KernelData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/internal/KernelDiagnostics.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/internal/KernelDiagnostics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/internal/KernelEventHandlers.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/internal/KernelEventHandlers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/internal/NativeIndexFileFilter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/internal/NativeIndexFileFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/internal/TransactionEventHandlers.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/internal/TransactionEventHandlers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/internal/Version.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/internal/Version.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/internal/locker/GlobalStoreLocker.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/internal/locker/GlobalStoreLocker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/internal/locker/StoreLocker.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/internal/locker/StoreLocker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/internal/locker/StoreLockerLifecycleAdapter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/internal/locker/StoreLockerLifecycleAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/monitoring/ByteCounterMonitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/monitoring/ByteCounterMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/monitoring/Monitors.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/monitoring/Monitors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/monitoring/VmPauseMonitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/monitoring/VmPauseMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/monitoring/tracing/DefaultTracerFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/monitoring/tracing/DefaultTracerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/monitoring/tracing/TracerFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/monitoring/tracing/TracerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/monitoring/tracing/Tracers.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/monitoring/tracing/Tracers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/package-info.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/recovery/CorruptedLogsTruncator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/recovery/CorruptedLogsTruncator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/recovery/DefaultRecoveryService.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/recovery/DefaultRecoveryService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/recovery/LogTailScanner.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/recovery/LogTailScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/recovery/LogTailScannerMonitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/recovery/LogTailScannerMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/recovery/LoggingLogTailScannerMonitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/recovery/LoggingLogTailScannerMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/recovery/Recovery.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/recovery/Recovery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/recovery/RecoveryApplier.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/recovery/RecoveryApplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/recovery/RecoveryMonitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/recovery/RecoveryMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/recovery/RecoveryService.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/recovery/RecoveryService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/recovery/RecoveryStartInformation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/recovery/RecoveryStartInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/recovery/RecoveryStartInformationProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/recovery/RecoveryStartInformationProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/spi/explicitindex/ExplicitIndexProviderTransaction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/spi/explicitindex/ExplicitIndexProviderTransaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/spi/explicitindex/IndexCommandFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/spi/explicitindex/IndexCommandFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/spi/explicitindex/IndexImplementation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/spi/explicitindex/IndexImplementation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/kernel/spi/explicitindex/IndexProviders.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/spi/explicitindex/IndexProviders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/CommandCreationContext.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/CommandCreationContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/CommandReader.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/CommandReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/CommandReaderFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/CommandReaderFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/CommandStream.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/CommandStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/CommandsToApply.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/CommandsToApply.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/DegreeItem.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/DegreeItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/Direction.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/Direction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/NodeItem.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/NodeItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/PropertyItem.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/PropertyItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/ReadPastEndException.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/ReadPastEndException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/ReadableChannel.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/ReadableChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/RelationshipItem.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/RelationshipItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/StorageCommand.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/StorageCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/StorageEngine.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/StorageEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/StorageProperty.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/StorageProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/StorageStatement.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/StorageStatement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/StoreFileMetadata.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/StoreFileMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/StoreReadLayer.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/StoreReadLayer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/Token.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/Token.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/TokenFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/TokenFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/TransactionApplicationMode.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/TransactionApplicationMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/WritableChannel.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/WritableChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/lock/AcquireLockTimeoutException.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/lock/AcquireLockTimeoutException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/lock/ResourceLocker.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/lock/ResourceLocker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/schema/AbstractIndexReader.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/schema/AbstractIndexReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/schema/IndexProgressor.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/schema/IndexProgressor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/schema/IndexReader.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/schema/IndexReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/schema/IndexSample.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/schema/IndexSample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/schema/IndexSampler.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/schema/IndexSampler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/schema/LabelScanReader.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/schema/LabelScanReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/schema/NodeValueIndexProgressor.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/schema/NodeValueIndexProgressor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/schema/SchemaRule.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/schema/SchemaRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/txstate/DiffSetsVisitor.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/txstate/DiffSetsVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/txstate/NodeState.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/txstate/NodeState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/txstate/PrimitiveLongDiffSetsVisitor.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/txstate/PrimitiveLongDiffSetsVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/txstate/PrimitiveLongReadableDiffSets.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/txstate/PrimitiveLongReadableDiffSets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/txstate/PropertyContainerState.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/txstate/PropertyContainerState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/txstate/ReadableDiffSets.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/txstate/ReadableDiffSets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/txstate/ReadableRelationshipDiffSets.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/txstate/ReadableRelationshipDiffSets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/txstate/ReadableTransactionState.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/txstate/ReadableTransactionState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/txstate/RelationshipState.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/txstate/RelationshipState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/txstate/SuperReadableDiffSets.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/txstate/SuperReadableDiffSets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/txstate/TxStateVisitor.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/txstate/TxStateVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/udc/UsageData.java
+++ b/community/kernel/src/main/java/org/neo4j/udc/UsageData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/udc/UsageDataKey.java
+++ b/community/kernel/src/main/java/org/neo4j/udc/UsageDataKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/udc/UsageDataKeys.java
+++ b/community/kernel/src/main/java/org/neo4j/udc/UsageDataKeys.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchInserter.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchInserter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchInserterIndex.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchInserterIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchInserterIndexProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchInserterIndexProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchInserters.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchInserters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchRelationship.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchRelationship.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/BatchInserterImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/BatchInserterImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/BatchRelationshipIterable.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/BatchRelationshipIterable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/BatchTokenHolder.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/BatchTokenHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/DirectRecordAccess.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/DirectRecordAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/DirectRecordAccessSet.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/DirectRecordAccessSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/FileSystemClosingBatchInserter.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/FileSystemClosingBatchInserter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/IndexConfigStoreProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/IndexConfigStoreProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/package-info.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/AdditionalInitialIds.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/AdditionalInitialIds.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/BatchImporter.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/BatchImporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/BatchImporterFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/BatchImporterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/BatchingIdGetter.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/BatchingIdGetter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/CacheGroupsStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/CacheGroupsStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/CalculateDenseNodesStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/CalculateDenseNodesStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/Configuration.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/Configuration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/CountGroupsStage.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/CountGroupsStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/CountGroupsStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/CountGroupsStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/DataImporter.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/DataImporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/DataStatistics.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/DataStatistics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/DeleteDuplicateNodesStage.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/DeleteDuplicateNodesStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/DeleteDuplicateNodesStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/DeleteDuplicateNodesStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/EncodeGroupsStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/EncodeGroupsStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/EntityImporter.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/EntityImporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ExhaustingEntityImporterRunnable.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ExhaustingEntityImporterRunnable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/HeapSizeSanityChecker.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/HeapSizeSanityChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/HighestId.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/HighestId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/IdMapperPreparationStage.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/IdMapperPreparationStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/IdMapperPreparationStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/IdMapperPreparationStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/IdRangeInput.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/IdRangeInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ImportLogic.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ImportLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ImportMemoryCalculator.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ImportMemoryCalculator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/InputIterable.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/InputIterable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/InputIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/InputIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/IoThroughputStat.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/IoThroughputStat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/LabelIndexWriterStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/LabelIndexWriterStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/MemoryUsageStatsProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/MemoryUsageStatsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/NodeCountsAndLabelIndexBuildStage.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/NodeCountsAndLabelIndexBuildStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/NodeCountsProcessor.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/NodeCountsProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/NodeCountsStage.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/NodeCountsStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/NodeDegreeCountStage.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/NodeDegreeCountStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/NodeFirstGroupStage.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/NodeFirstGroupStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/NodeImporter.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/NodeImporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/NodeInputIdPropertyLookup.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/NodeInputIdPropertyLookup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/NodeSetFirstGroupStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/NodeSetFirstGroupStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporter.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/Parallelizable.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/Parallelizable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ProcessRelationshipCountsDataStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ProcessRelationshipCountsDataStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ReadGroupRecordsByCacheStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ReadGroupRecordsByCacheStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ReadGroupsFromCacheStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ReadGroupsFromCacheStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ReadNodeIdsByCacheStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ReadNodeIdsByCacheStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RecordIdIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RecordIdIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RecordProcessor.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RecordProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RecordProcessorStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RecordProcessorStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipCountsProcessor.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipCountsProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipCountsStage.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipCountsStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipGroupCache.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipGroupCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipGroupDefragmenter.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipGroupDefragmenter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipGroupStage.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipGroupStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipImporter.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipImporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipLinkStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipLinkStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipLinkbackStage.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipLinkbackStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipLinkbackStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipLinkbackStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipLinkforwardStage.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipLinkforwardStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipLinkforwardStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipLinkforwardStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipLinkingProgress.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipLinkingProgress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ScanAndCacheGroupsStage.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ScanAndCacheGroupsStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/SparseNodeFirstRelationshipProcessor.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/SparseNodeFirstRelationshipProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/SparseNodeFirstRelationshipStage.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/SparseNodeFirstRelationshipStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/StandardBatchImporterFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/StandardBatchImporterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/UpdateRecordsStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/UpdateRecordsStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/Utils.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/Utils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/WriteGroupsStage.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/WriteGroupsStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/BaseNumberArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/BaseNumberArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/ByteArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/ByteArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/ChunkedNumberArrayFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/ChunkedNumberArrayFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/DynamicByteArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/DynamicByteArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/DynamicIntArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/DynamicIntArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/DynamicLongArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/DynamicLongArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/DynamicNumberArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/DynamicNumberArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/GatheringMemoryStatsVisitor.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/GatheringMemoryStatsVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/HeapByteArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/HeapByteArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/HeapIntArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/HeapIntArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/HeapLongArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/HeapLongArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/HeapNumberArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/HeapNumberArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/IntArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/IntArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/LongArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/LongArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/LongBitsManipulator.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/LongBitsManipulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/MemoryStatsVisitor.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/MemoryStatsVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/NodeLabelsCache.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/NodeLabelsCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/NodeRelationshipCache.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/NodeRelationshipCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/NodeType.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/NodeType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/NumberArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/NumberArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/NumberArrayFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/NumberArrayFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/OffHeapByteArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/OffHeapByteArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/OffHeapIntArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/OffHeapIntArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/OffHeapLongArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/OffHeapLongArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/OffHeapNumberArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/OffHeapNumberArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/OffHeapRegularNumberArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/OffHeapRegularNumberArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/PageCacheArrayFactoryMonitor.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/PageCacheArrayFactoryMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/PageCacheByteArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/PageCacheByteArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/PageCacheIntArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/PageCacheIntArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/PageCacheLongArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/PageCacheLongArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/PageCacheNumberArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/PageCacheNumberArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/PageCachedNumberArrayFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/PageCachedNumberArrayFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/IdMapper.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/IdMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/IdMappers.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/IdMappers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/AbstractTracker.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/AbstractTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/BigIdTracker.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/BigIdTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/CollisionValues.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/CollisionValues.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/DuplicateInputIdException.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/DuplicateInputIdException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/Encoder.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/Encoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/EncodingIdMapper.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/EncodingIdMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/GroupCache.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/GroupCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/IntTracker.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/IntTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/LongCollisionValues.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/LongCollisionValues.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/LongEncoder.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/LongEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/ParallelSort.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/ParallelSort.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/Radix.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/Radix.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/RadixCalculator.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/RadixCalculator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/SameGroupDetector.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/SameGroupDetector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/StringCollisionValues.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/StringCollisionValues.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/StringEncoder.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/StringEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/Tracker.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/Tracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/TrackerFactories.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/TrackerFactories.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/TrackerFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/TrackerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/Workers.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/Workers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/executor/DynamicTaskExecutor.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/executor/DynamicTaskExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/executor/ParkStrategy.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/executor/ParkStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/executor/Task.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/executor/Task.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/executor/TaskExecutionPanicException.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/executor/TaskExecutionPanicException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/executor/TaskExecutor.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/executor/TaskExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/BadCollector.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/BadCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/ByteBufferFlushableChannel.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/ByteBufferFlushableChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/ByteBufferReadableChannel.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/ByteBufferReadableChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/CachedInput.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/CachedInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/CachingInputChunk.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/CachingInputChunk.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/CachingInputIterable.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/CachingInputIterable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/CachingInputIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/CachingInputIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/Collector.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/Collector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/Collectors.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/Collectors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/DataException.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/DataException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/DuplicateHeaderException.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/DuplicateHeaderException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/EstimationSanityChecker.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/EstimationSanityChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/Group.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/Group.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/Groups.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/Groups.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/HeaderException.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/HeaderException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/Input.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/Input.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputCache.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputCacher.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputCacher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputChunk.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputChunk.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputEntity.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputEntityCacheReader.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputEntityCacheReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputEntityCacheWriter.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputEntityCacheWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputEntityDecorators.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputEntityDecorators.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputEntityVisitor.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputEntityVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputException.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputNodeCacheReader.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputNodeCacheReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputNodeCacheWriter.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputNodeCacheWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputRelationshipCacheReader.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputRelationshipCacheReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputRelationshipCacheWriter.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputRelationshipCacheWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/Inputs.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/Inputs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/MissingHeaderException.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/MissingHeaderException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/MissingRelationshipDataException.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/MissingRelationshipDataException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/UnexpectedEndOfInputException.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/UnexpectedEndOfInputException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/UpdateBehaviour.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/UpdateBehaviour.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/ValueType.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/ValueType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/Configuration.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/Configuration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvGroupInputIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvGroupInputIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInput.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInputChunk.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInputChunk.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInputChunkProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInputChunkProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInputIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInputIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInputParser.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInputParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/Data.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/DataFactories.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/DataFactories.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/DataFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/DataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/Decorator.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/Decorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/Deserialization.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/Deserialization.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/EagerCsvInputChunk.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/EagerCsvInputChunk.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/EagerParserChunker.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/EagerParserChunker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/Header.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/Header.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/IdType.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/IdType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputEntityArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputEntityArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/LazyCsvInputChunk.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/LazyCsvInputChunk.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/Type.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/Type.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/AbstractStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/AbstractStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/BatchFeedStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/BatchFeedStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/BatchSender.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/BatchSender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/CoarseBoundedProgressExecutionMonitor.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/CoarseBoundedProgressExecutionMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/Downstream.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/Downstream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/DynamicProcessorAssigner.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/DynamicProcessorAssigner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/ExecutionMonitor.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/ExecutionMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/ExecutionMonitors.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/ExecutionMonitors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/ExecutionSupervisor.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/ExecutionSupervisor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/ExecutionSupervisors.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/ExecutionSupervisors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/ForkedProcessorStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/ForkedProcessorStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/HumanUnderstandableExecutionMonitor.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/HumanUnderstandableExecutionMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/LonelyProcessingStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/LonelyProcessingStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/MultiExecutionMonitor.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/MultiExecutionMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/OnDemandDetailsExecutionMonitor.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/OnDemandDetailsExecutionMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/Panicable.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/Panicable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/ProcessorStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/ProcessorStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/ProducerStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/ProducerStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/ProgressRestoringMonitor.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/ProgressRestoringMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/PullingProducerStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/PullingProducerStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/QuantizedProjection.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/QuantizedProjection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/ReadRecordsStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/ReadRecordsStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/RecordDataAssembler.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/RecordDataAssembler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/SendDownstream.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/SendDownstream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/SpectrumExecutionMonitor.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/SpectrumExecutionMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/Stage.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/Stage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/StageControl.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/StageControl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/StageExecution.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/StageExecution.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/Step.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/Step.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/TicketedBatch.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/TicketedBatch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/TicketedProcessing.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/TicketedProcessing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/package-info.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/stats/DetailLevel.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/stats/DetailLevel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/stats/GenericStatsProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/stats/GenericStatsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/stats/Key.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/stats/Key.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/stats/Keys.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/stats/Keys.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/stats/ProcessingStats.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/stats/ProcessingStats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/stats/Stat.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/stats/Stat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/stats/Stats.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/stats/Stats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/stats/StatsProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/stats/StatsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/stats/StepStats.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/stats/StepStats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingNeoStores.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingNeoStores.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingTokenRepository.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingTokenRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/PageCacheFlusher.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/PageCacheFlusher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/PrepareIdSequence.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/PrepareIdSequence.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/SecondaryUnitPrepareIdSequence.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/SecondaryUnitPrepareIdSequence.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/StorePrepareIdSequence.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/StorePrepareIdSequence.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/io/IoMonitor.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/io/IoMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/io/IoTracer.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/io/IoTracer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/package-info.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/diagnostics/DiagnosticsReporterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/diagnostics/DiagnosticsReporterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/graphdb/AbstractMandatoryTransactionsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/AbstractMandatoryTransactionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/graphdb/ConsistentPropertyReadsIT.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/ConsistentPropertyReadsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/graphdb/ConstraintCreatorFacadeMethods.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/ConstraintCreatorFacadeMethods.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/graphdb/ConstraintDefinitionFacadeMethods.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/ConstraintDefinitionFacadeMethods.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/graphdb/CreateAndDeleteNodesIT.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/CreateAndDeleteNodesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/graphdb/DeleteNodeWithRelsIT.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/DeleteNodeWithRelsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/graphdb/DenseNodeIT.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/DenseNodeIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/graphdb/FacadeMethod.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/FacadeMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/graphdb/FirstStartupIT.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/FirstStartupIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/graphdb/GraphDatabaseInternalLogIT.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/GraphDatabaseInternalLogIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/graphdb/GraphDatabaseServiceFacadeMethods.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/GraphDatabaseServiceFacadeMethods.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/graphdb/GraphDatabaseServiceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/GraphDatabaseServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/graphdb/GraphDatabaseShutdownTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/GraphDatabaseShutdownTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/graphdb/IndexCreatorFacadeMethods.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/IndexCreatorFacadeMethods.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/graphdb/IndexDefinitionFacadeMethods.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/IndexDefinitionFacadeMethods.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/graphdb/IndexManagerFacadeMethods.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/IndexManagerFacadeMethods.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/graphdb/IndexingAcceptanceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/IndexingAcceptanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/graphdb/IndexingCompositeQueryAcceptanceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/IndexingCompositeQueryAcceptanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/graphdb/IndexingStringQueryAcceptanceTestBase.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/IndexingStringQueryAcceptanceTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/graphdb/LabelsAcceptanceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/LabelsAcceptanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/graphdb/MandatoryTransactionsForConstraintCreatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/MandatoryTransactionsForConstraintCreatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/graphdb/MandatoryTransactionsForConstraintDefinitionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/MandatoryTransactionsForConstraintDefinitionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/graphdb/MandatoryTransactionsForGraphDatabaseServiceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/MandatoryTransactionsForGraphDatabaseServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/graphdb/MandatoryTransactionsForIndexCreatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/MandatoryTransactionsForIndexCreatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/graphdb/MandatoryTransactionsForIndexDefinitionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/MandatoryTransactionsForIndexDefinitionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/graphdb/MandatoryTransactionsForIndexManagerFacadeTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/MandatoryTransactionsForIndexManagerFacadeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/graphdb/MandatoryTransactionsForNodeTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/MandatoryTransactionsForNodeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/graphdb/MandatoryTransactionsForRelationshipTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/MandatoryTransactionsForRelationshipTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/graphdb/MandatoryTransactionsForSchemaTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/MandatoryTransactionsForSchemaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/graphdb/MandatoryTransactionsForUniquenessConstraintDefinitionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/MandatoryTransactionsForUniquenessConstraintDefinitionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/graphdb/NativeLabelScanStoreChaosIT.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/NativeLabelScanStoreChaosIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/graphdb/NativeLabelScanStoreStartupIT.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/NativeLabelScanStoreStartupIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/graphdb/NativeLabelScanStoreUpdateIT.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/NativeLabelScanStoreUpdateIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/graphdb/NodeFacadeMethods.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/NodeFacadeMethods.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/graphdb/QueryExecutionTypeTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/QueryExecutionTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/graphdb/RelationshipFacadeMethods.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/RelationshipFacadeMethods.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/graphdb/ResourceIterableTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/ResourceIterableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/graphdb/RunOutOfDiskSpaceIT.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/RunOutOfDiskSpaceIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/graphdb/SchemaAcceptanceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/SchemaAcceptanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/graphdb/SchemaFacadeMethods.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/SchemaFacadeMethods.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/graphdb/SchemaIndexWaitingAcceptanceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/SchemaIndexWaitingAcceptanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/graphdb/SpatialMocks.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/SpatialMocks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/graphdb/TransactionLogsInSeparateLocationIT.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/TransactionLogsInSeparateLocationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/graphdb/factory/GraphDatabaseBuilderTestTools.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/factory/GraphDatabaseBuilderTestTools.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/graphdb/factory/GraphDatabaseFactoryStateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/factory/GraphDatabaseFactoryStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/graphdb/factory/GraphDatabaseSettingsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/factory/GraphDatabaseSettingsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/graphdb/impl/notification/NotificationCodeTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/impl/notification/NotificationCodeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/graphdb/impl/notification/NotificationDetailTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/impl/notification/NotificationDetailTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/graphdb/index/UniqueFactoryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/index/UniqueFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/graphdb/schema/ConcurrentCreateDropIndexIT.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/schema/ConcurrentCreateDropIndexIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/graphdb/schema/DropBrokenUniquenessConstraintIT.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/schema/DropBrokenUniquenessConstraintIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/graphdb/schema/UpdateDeletedIndexIT.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/schema/UpdateDeletedIndexIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/helpers/ArgsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/helpers/ArgsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/helpers/ArrayUtilTest.java
+++ b/community/kernel/src/test/java/org/neo4j/helpers/ArrayUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/helpers/BarService.java
+++ b/community/kernel/src/test/java/org/neo4j/helpers/BarService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/helpers/BazService.java
+++ b/community/kernel/src/test/java/org/neo4j/helpers/BazService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/helpers/Configuration.java
+++ b/community/kernel/src/test/java/org/neo4j/helpers/Configuration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/helpers/FooService.java
+++ b/community/kernel/src/test/java/org/neo4j/helpers/FooService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/helpers/FormatTest.java
+++ b/community/kernel/src/test/java/org/neo4j/helpers/FormatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/helpers/HostnamePortTest.java
+++ b/community/kernel/src/test/java/org/neo4j/helpers/HostnamePortTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/helpers/ListenersTest.java
+++ b/community/kernel/src/test/java/org/neo4j/helpers/ListenersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/helpers/MathUtilTest.java
+++ b/community/kernel/src/test/java/org/neo4j/helpers/MathUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/helpers/ServiceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/helpers/ServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/helpers/SocketAddressParserTest.java
+++ b/community/kernel/src/test/java/org/neo4j/helpers/SocketAddressParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/helpers/SocketAddressTest.java
+++ b/community/kernel/src/test/java/org/neo4j/helpers/SocketAddressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/helpers/StringsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/helpers/StringsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/helpers/TaskCoordinatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/helpers/TaskCoordinatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/helpers/TestArgs.java
+++ b/community/kernel/src/test/java/org/neo4j/helpers/TestArgs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/helpers/TestExceptions.java
+++ b/community/kernel/src/test/java/org/neo4j/helpers/TestExceptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/helpers/TestFormat.java
+++ b/community/kernel/src/test/java/org/neo4j/helpers/TestFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/helpers/TimeUtilTest.java
+++ b/community/kernel/src/test/java/org/neo4j/helpers/TimeUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/helpers/TransactionTemplateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/helpers/TransactionTemplateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/helpers/UrisTest.java
+++ b/community/kernel/src/test/java/org/neo4j/helpers/UrisTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/helpers/ValueUtilsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/helpers/ValueUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/helpers/progress/ProgressMonitorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/helpers/progress/ProgressMonitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/AvailabilityGuardTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/AvailabilityGuardTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/DiagnosticsLoggingTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/DiagnosticsLoggingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/DummyExtension.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/DummyExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/DummyExtensionFactory.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/DummyExtensionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/GraphDatabaseFacadeFactoryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/GraphDatabaseFacadeFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/NeoStoreDataSourceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/NeoStoreDataSourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/RecoveryCorruptedTransactionLogIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/RecoveryCorruptedTransactionLogIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/RecoveryIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/RecoveryIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/RecoveryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/RecoveryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/TestKernelExtension.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/TestKernelExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/TestPlaceboTransaction.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/TestPlaceboTransaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/TestTransactionEventDeadlocks.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/TestTransactionEventDeadlocks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/TestTraversal.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/TestTraversal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/TokenCreationIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/TokenCreationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/TopLevelTransactionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/TopLevelTransactionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/CompositeIndexingIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/CompositeIndexingIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/KernelTransactionFactory.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/KernelTransactionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/StubResourceManager.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/StubResourceManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/TransactionStatementSequenceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/TransactionStatementSequenceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/exception/StatusTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/exception/StatusTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/exceptions/index/IndexEntryConflictExceptionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/exceptions/index/IndexEntryConflictExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/exceptions/index/IndexPopulationFailedKernelExceptionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/exceptions/index/IndexPopulationFailedKernelExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/impl/labelscan/LabelScanStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/impl/labelscan/LabelScanStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/index/ArrayEncoderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/index/ArrayEncoderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/index/CompositeIndexAccessorCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/index/CompositeIndexAccessorCompatibility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/index/CompositeIndexPopulatorCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/index/CompositeIndexPopulatorCompatibility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/index/InMemoryIndexConstraintProviderApprovalTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/index/InMemoryIndexConstraintProviderApprovalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/index/InMemoryIndexProviderApprovalTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/index/InMemoryIndexProviderApprovalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/index/IndexAccessorCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/index/IndexAccessorCompatibility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/index/IndexDirectoryStructureTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/index/IndexDirectoryStructureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/index/IndexEntryUpdateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/index/IndexEntryUpdateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/index/IndexProviderApprovalTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/index/IndexProviderApprovalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/index/IndexProviderCompatibilityTestSuite.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/index/IndexProviderCompatibilityTestSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/index/IndexQueryHelper.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/index/IndexQueryHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/index/NodePropertyAccessor.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/index/NodePropertyAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/index/NodeUpdatesTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/index/NodeUpdatesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/index/SchemaConstraintProviderApprovalTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/index/SchemaConstraintProviderApprovalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/index/SimpleIndexAccessorCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/index/SimpleIndexAccessorCompatibility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/index/SimpleIndexPopulatorCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/index/SimpleIndexPopulatorCompatibility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/index/UniqueConstraintCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/index/UniqueConstraintCompatibility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/labelscan/NodeLabelRangeTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/labelscan/NodeLabelRangeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/proc/FieldSignatureTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/proc/FieldSignatureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/query/ExecutingQueryStatusTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/query/ExecutingQueryStatusTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/query/ExecutingQueryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/query/ExecutingQueryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/query/PlannerInfoTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/query/PlannerInfoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/schema/SchemaDescriptorFactoryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/schema/SchemaDescriptorFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/schema/SchemaProcessorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/schema/SchemaProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/schema/SchemaTestUtil.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/schema/SchemaTestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/schema/constaints/ConstraintDescriptorFactoryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/schema/constaints/ConstraintDescriptorFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/schema/index/SchemaIndexDescriptorFactoryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/schema/index/SchemaIndexDescriptorFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/security/AuthTokenTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/security/AuthTokenTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/txtracking/TransactionIdTrackerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/txtracking/TransactionIdTrackerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/AwaitIndexProcedureTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/AwaitIndexProcedureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/BuiltInDbmsProceduresIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/BuiltInDbmsProceduresIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/BuiltInProceduresTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/BuiltInProceduresTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/BuiltInSchemaProceduresIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/BuiltInSchemaProceduresIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/IndexProceduresTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/IndexProceduresTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/IndexSpecifierTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/IndexSpecifierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/JmxQueryProcedureTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/JmxQueryProcedureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/ResampleIndexProcedureTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/ResampleIndexProcedureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/ResampleOutdatedIndexesProcedureTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/ResampleOutdatedIndexesProcedureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/SchemaProcedureIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/SchemaProcedureIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/SortedLabelsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/SortedLabelsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/StubKernelTransaction.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/StubKernelTransaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/StubStatement.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/StubStatement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/configuration/AdvertisedAddressSettingsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/configuration/AdvertisedAddressSettingsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/configuration/AnnotationBasedConfigurationMigratorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/configuration/AnnotationBasedConfigurationMigratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/configuration/BoltConnectorValidatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/configuration/BoltConnectorValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/configuration/ConfigTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/configuration/ConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/configuration/GroupConfigTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/configuration/GroupConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/configuration/HttpConnectorValidatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/configuration/HttpConnectorValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/configuration/IndividualSettingsValidatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/configuration/IndividualSettingsValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/configuration/ListenAddressSettingsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/configuration/ListenAddressSettingsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/configuration/ServerConfigurationValidatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/configuration/ServerConfigurationValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/configuration/SettingsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/configuration/SettingsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/configuration/SystemTimeZoneLoggingIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/configuration/SystemTimeZoneLoggingIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/configuration/TestGraphDatabaseConfigurationMigrator.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/configuration/TestGraphDatabaseConfigurationMigrator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/configuration/ssl/LegacySslPolicyConfigTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/configuration/ssl/LegacySslPolicyConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/configuration/ssl/SslPolicyConfigTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/configuration/ssl/SslPolicyConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/configuration/ssl/SslPolicyConfigValidatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/configuration/ssl/SslPolicyConfigValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/configuration/ssl/SslPolicyLoaderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/configuration/ssl/SslPolicyLoaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/counts/CompositeCountsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/counts/CompositeCountsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/counts/LabelCountsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/counts/LabelCountsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/counts/NodeCountsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/counts/NodeCountsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/counts/RelationshipCountsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/counts/RelationshipCountsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/extension/KernelExtensionFactoryContractTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/extension/KernelExtensionFactoryContractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/extension/KernelExtensionsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/extension/KernelExtensionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/guard/TerminationGuardTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/guard/TerminationGuardTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/AbstractNeo4jTestCase.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/AbstractNeo4jTestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/MyRelTypes.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/MyRelTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/AutoIndexOperationsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/AutoIndexOperationsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/BatchTransactionApplierFacadeTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/BatchTransactionApplierFacadeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/CountsKeyTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/CountsKeyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/CountsRecordStateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/CountsRecordStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/CountsStoreTransactionApplierTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/CountsStoreTransactionApplierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/DataAndSchemaTransactionSeparationIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/DataAndSchemaTransactionSeparationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/DatabaseSchemaStateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/DatabaseSchemaStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/DefaultTransactionTracerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/DefaultTransactionTracerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/DiffSetsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/DiffSetsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/ExecutingQueryListTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/ExecutingQueryListTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/ExplicitBatchIndexApplierTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/ExplicitBatchIndexApplierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/IndexTextValueLengthValidatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/IndexTextValueLengthValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelSchemaStateFlushingTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelSchemaStateFlushingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelStatementTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelStatementTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionAssertOpenTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionAssertOpenTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionImplementationHandleTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionImplementationHandleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionImplementationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionImplementationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionMonitorSchedulerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionMonitorSchedulerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionSecurityContextTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionSecurityContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionTerminationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionTerminationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionTestBase.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionTimeoutMonitorIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionTimeoutMonitorIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionTimeoutMonitorSchedulerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionTimeoutMonitorSchedulerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionTimeoutMonitorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionTimeoutMonitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/LabelRecoveryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/LabelRecoveryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/LongDiffSetsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/LongDiffSetsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/PropertyTransactionStateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/PropertyTransactionStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/SchemaLoggingIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/SchemaLoggingIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/StatementLifecycleTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/StatementLifecycleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/StatementOperationsTestHelper.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/StatementOperationsTestHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TestKernelTransactionHandle.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TestKernelTransactionHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TransactionApplierFacadeTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TransactionApplierFacadeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TransactionQueueTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TransactionQueueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TransactionRepresentationCommitProcessIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TransactionRepresentationCommitProcessIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TransactionRepresentationCommitProcessTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TransactionRepresentationCommitProcessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintIndexCreatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintIndexCreatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/cursor/TxSingleNodeCursorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/cursor/TxSingleNodeCursorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/BatchingMultipleIndexPopulatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/BatchingMultipleIndexPopulatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/CollectingIndexUpdater.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/CollectingIndexUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/ContractCheckingIndexProxyTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/ContractCheckingIndexProxyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/ControlledPopulationIndexProvider.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/ControlledPopulationIndexProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/FailedIndexProxyTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/FailedIndexProxyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/FlippableIndexProxyTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/FlippableIndexProxyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexCRUDIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexCRUDIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexMapReferenceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexMapReferenceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexMapTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexPopulationJobControllerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexPopulationJobControllerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexPopulationJobTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexPopulationJobTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexPopulationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexPopulationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexProxyAdapter.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexProxyAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexRecoveryIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexRecoveryIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexRestartIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexRestartIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexStatisticsIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexStatisticsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexStatisticsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexStatisticsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexUpdaterMapTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexUpdaterMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexingServiceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexingServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/MultipleIndexPopulatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/MultipleIndexPopulatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/MultipleIndexPopulatorUpdatesTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/MultipleIndexPopulatorUpdatesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/NodeUpdatesIteratorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/NodeUpdatesIteratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/OnlineIndexProxyTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/OnlineIndexProxyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/PopulatingIndexProxyTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/PopulatingIndexProxyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/PropertyPhysicalToLogicalConverterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/PropertyPhysicalToLogicalConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/SchemaIndexTestHelper.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/SchemaIndexTestHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/TestIndexProviderDescriptor.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/TestIndexProviderDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/UpdatesTracker.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/UpdatesTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/HashBasedIndex.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/HashBasedIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/HashBasedIndexSampler.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/HashBasedIndexSampler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/InMemoryIndex.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/InMemoryIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/InMemoryIndexImplementation.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/InMemoryIndexImplementation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/InMemoryIndexProvider.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/InMemoryIndexProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/InMemoryIndexProviderFactory.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/InMemoryIndexProviderFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/InMemoryIndexProviderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/InMemoryIndexProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/UniqueInMemoryIndex.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/UniqueInMemoryIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/UpdateCapturingIndexAccessor.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/UpdateCapturingIndexAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/UpdateCapturingIndexProvider.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/UpdateCapturingIndexProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/UpdateCapturingIndexUpdater.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/UpdateCapturingIndexUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/sampling/DefaultNonUniqueIndexSamplerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/sampling/DefaultNonUniqueIndexSamplerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/sampling/IndexSamplingControllerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/sampling/IndexSamplingControllerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/sampling/IndexSamplingJobQueueTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/sampling/IndexSamplingJobQueueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/sampling/IndexSamplingJobTrackerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/sampling/IndexSamplingJobTrackerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/sampling/OnlineIndexSamplingJobTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/sampling/OnlineIndexSamplingJobTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/BuiltInProceduresIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/BuiltInProceduresIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/CompositeUniquenessConstraintValidationIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/CompositeUniquenessConstraintValidationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/KernelIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/KernelIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/KernelIntegrationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/KernelIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/LabelIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/LabelIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/NodeGetUniqueFromIndexSeekIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/NodeGetUniqueFromIndexSeekIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/ProceduresKernelIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/ProceduresKernelIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/PropertyIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/PropertyIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/RelationshipIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/RelationshipIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/SchemaRecoveryIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/SchemaRecoveryIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/TransactionHookIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/TransactionHookIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/UniquenessConstraintValidationConcurrencyIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/UniquenessConstraintValidationConcurrencyIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/UniquenessConstraintValidationIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/UniquenessConstraintValidationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/ExplicitIndexTransactionStateImplTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/ExplicitIndexTransactionStateImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/NoChangeWriteTransactionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/NoChangeWriteTransactionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/PropertyContainerStateImplTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/PropertyContainerStateImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/RelationshipChangesForNodeTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/RelationshipChangesForNodeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/StubCursors.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/StubCursors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/TxStateCompositeIndexTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/TxStateCompositeIndexTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/TxStateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/TxStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/TxStateVisitorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/TxStateVisitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/CursorRelationshipIteratorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/CursorRelationshipIteratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/IndexReferenceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/IndexReferenceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/NodeLoadingIteratorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/NodeLoadingIteratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/SchemaCacheTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/SchemaCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StorageLayerLabelTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StorageLayerLabelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StorageLayerNodeAndRelTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StorageLayerNodeAndRelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StorageLayerPropertyTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StorageLayerPropertyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StorageLayerRelTypesAndDegreeTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StorageLayerRelTypesAndDegreeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StorageLayerSchemaTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StorageLayerSchemaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StorageLayerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StorageLayerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StoreIteratorRelationshipCursorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StoreIteratorRelationshipCursorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StoreNodeRelationshipCursorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StoreNodeRelationshipCursorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StorePropertyCursorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StorePropertyCursorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StorePropertyPayloadCursorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StorePropertyPayloadCursorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StoreSingleRelationshipCursorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StoreSingleRelationshipCursorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/TestDegreeItem.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/TestDegreeItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/TestReferenceDangling.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/TestReferenceDangling.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/TestRelType.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/TestRelType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/cache/TestClockCache.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/cache/TestClockCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/BigStoreIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/BigStoreIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/ConcurrentCreateAndGetRelationshipsIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/ConcurrentCreateAndGetRelationshipsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/DenseNodeRelChainPositionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/DenseNodeRelChainPositionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/GraphPropertiesProxyTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/GraphPropertiesProxyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/InMemoryTokenCacheTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/InMemoryTokenCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/IteratingPropertyReceiverTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/IteratingPropertyReceiverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/JumpingFileSystemAbstraction.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/JumpingFileSystemAbstraction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/JumpingIdGeneratorFactory.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/JumpingIdGeneratorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/LargePropertiesIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/LargePropertiesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/ManyPropertyKeysIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/ManyPropertyKeysIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/Neo4jConstraintsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/Neo4jConstraintsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/NestedTransactionLocksIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/NestedTransactionLocksIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/NodeManagerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/NodeManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/NodeProxyTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/NodeProxyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/NodeTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/NodeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/PathProxyTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/PathProxyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/PropertyContainerProxyTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/PropertyContainerProxyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/RelationshipIterationWithDenseFirstNodeTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/RelationshipIterationWithDenseFirstNodeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/RelationshipIterationWithDenseSecondNodeTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/RelationshipIterationWithDenseSecondNodeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/RelationshipIterationWithDenseUnrelatedNodeTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/RelationshipIterationWithDenseUnrelatedNodeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/RelationshipIterationWithNoDenseNodesTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/RelationshipIterationWithNoDenseNodesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/RelationshipProxyTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/RelationshipProxyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/RelationshipTraversalCursorReuseMustNotFalselyMatchRelationships.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/RelationshipTraversalCursorReuseMustNotFalselyMatchRelationships.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/RelationshipsIterationTestSupport.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/RelationshipsIterationTestSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestCombinedPropertyTypes.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestCombinedPropertyTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestConcurrentIteratorModification.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestConcurrentIteratorModification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestConcurrentRelationshipChainLoadingIssue.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestConcurrentRelationshipChainLoadingIssue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestCrashWithRebuildSlow.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestCrashWithRebuildSlow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestExceptionTypeOnInvalidIds.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestExceptionTypeOnInvalidIds.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestIdReuse.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestIdReuse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestIsolationBasic.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestIsolationBasic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestJumpingIdGenerator.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestJumpingIdGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestLengthyArrayPacking.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestLengthyArrayPacking.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestLoopRelationships.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestLoopRelationships.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestNeo4j.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestNeo4j.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestNeo4jApiExceptions.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestNeo4jApiExceptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestNeo4jCacheAndPersistence.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestNeo4jCacheAndPersistence.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestProperties.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestPropertyTypes.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestPropertyTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestReadOnlyNeo4j.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestReadOnlyNeo4j.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestRelationship.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestRelationship.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestRelationshipCount.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestRelationshipCount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestShortStringProperties.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestShortStringProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestShutdownSequence.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestShutdownSequence.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TokenHolderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TokenHolderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/coreapi/TxStateTransactionDataViewTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/coreapi/TxStateTransactionDataViewTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/coreapi/schema/SchemaImplTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/coreapi/schema/SchemaImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/event/ExpectedTransactionData.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/event/ExpectedTransactionData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/event/PropertyEntryImpl.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/event/PropertyEntryImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/event/TestKernelEvents.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/event/TestKernelEvents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/event/TestTransactionEvents.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/event/TestTransactionEvents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/event/TransactionEventsIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/event/TransactionEventsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/event/VerifyingTransactionEventHandler.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/event/VerifyingTransactionEventHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/factory/CommunityCommitProcessFactoryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/factory/CommunityCommitProcessFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/factory/CommunityEditionModuleIntegrationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/factory/CommunityEditionModuleIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/factory/EditionModuleTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/factory/EditionModuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacadeTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacadeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/factory/StatementLocksFactorySelectorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/factory/StatementLocksFactorySelectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/AbstractGBPTreeFileUtilTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/AbstractGBPTreeFileUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/DummyIndexExtensionFactory.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/DummyIndexExtensionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/DummyIndexImplementation.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/DummyIndexImplementation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/GBPTreeFileUtilTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/GBPTreeFileUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/IndexDefineCommandTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/IndexDefineCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/IndexEntityTypeTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/IndexEntityTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/TestIndexImplOnNeo.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/TestIndexImplOnNeo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/TestIndexProviderStore.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/TestIndexProviderStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/CompositeLabelScanValueIteratorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/CompositeLabelScanValueIteratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/LabelScanValueIndexProgressorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/LabelScanValueIndexProgressorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/LabelScanValueIteratorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/LabelScanValueIteratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/LabelScanValueTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/LabelScanValueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/LabelScanWriteMonitorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/LabelScanWriteMonitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/MutableHit.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/MutableHit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/NativeAllEntriesLabelScanReaderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/NativeAllEntriesLabelScanReaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanReaderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanReaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStoreIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStoreIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStoreRebuildTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStoreRebuildTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanWriterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanWriterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/PhysicalToLogicalLabelChangesTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/PhysicalToLogicalLabelChangesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/ConflictDetectingValueMergerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/ConflictDetectingValueMergerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/DateLayoutTestUtil.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/DateLayoutTestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/DateNonUniqueSchemaIndexAccessorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/DateNonUniqueSchemaIndexAccessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/DateNonUniqueSchemaIndexPopulatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/DateNonUniqueSchemaIndexPopulatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/DateTimeLayoutTestUtil.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/DateTimeLayoutTestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/DateTimeNonUniqueSchemaIndexAccessorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/DateTimeNonUniqueSchemaIndexAccessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/DateTimeNonUniqueSchemaIndexPopulatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/DateTimeNonUniqueSchemaIndexPopulatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/DateTimeUniqueSchemaIndexAccessorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/DateTimeUniqueSchemaIndexAccessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/DateTimeUniqueSchemaIndexPopulatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/DateTimeUniqueSchemaIndexPopulatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/DateUniqueSchemaIndexAccessorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/DateUniqueSchemaIndexAccessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/DateUniqueSchemaIndexPopulatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/DateUniqueSchemaIndexPopulatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/DeferredConflictCheckingIndexUpdaterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/DeferredConflictCheckingIndexUpdaterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/DurationLayoutTestUtil.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/DurationLayoutTestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/DurationNonUniqueSchemaIndexAccessorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/DurationNonUniqueSchemaIndexAccessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/DurationNonUniqueSchemaIndexPopulatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/DurationNonUniqueSchemaIndexPopulatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/DurationUniqueSchemaIndexAccessorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/DurationUniqueSchemaIndexAccessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/DurationUniqueSchemaIndexPopulatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/DurationUniqueSchemaIndexPopulatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/FilteringNativeHitIndexProgressorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/FilteringNativeHitIndexProgressorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/FilteringNativeHitIteratorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/FilteringNativeHitIteratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/GatheringNodeValueClient.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/GatheringNodeValueClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/IndexPopulationStressTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/IndexPopulationStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/LayoutTestUtil.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/LayoutTestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/LocalDateTimeLayoutTestUtil.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/LocalDateTimeLayoutTestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/LocalDateTimeNonUniqueSchemaIndexAccessorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/LocalDateTimeNonUniqueSchemaIndexAccessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/LocalDateTimeNonUniqueSchemaIndexPopulatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/LocalDateTimeNonUniqueSchemaIndexPopulatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/LocalDateTimeUniqueSchemaIndexAccessorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/LocalDateTimeUniqueSchemaIndexAccessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/LocalDateTimeUniqueSchemaIndexPopulatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/LocalDateTimeUniqueSchemaIndexPopulatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/LocalTimeLayoutTestUtil.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/LocalTimeLayoutTestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/LocalTimeNonUniqueSchemaIndexAccessorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/LocalTimeNonUniqueSchemaIndexAccessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/LocalTimeNonUniqueSchemaIndexPopulatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/LocalTimeNonUniqueSchemaIndexPopulatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/LocalTimeUniqueSchemaIndexAccessorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/LocalTimeUniqueSchemaIndexAccessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/LocalTimeUniqueSchemaIndexPopulatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/LocalTimeUniqueSchemaIndexPopulatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NativeDistinctValuesProgressorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NativeDistinctValuesProgressorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NativeIndexProviderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NativeIndexProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NativeNonUniqueSchemaIndexPopulatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NativeNonUniqueSchemaIndexPopulatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NativeSchemaIndexAccessorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NativeSchemaIndexAccessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NativeSchemaIndexPopulatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NativeSchemaIndexPopulatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NativeSchemaIndexTestUtil.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NativeSchemaIndexTestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NativeUniqueSchemaIndexPopulatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NativeUniqueSchemaIndexPopulatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NumberFullScanNonUniqueIndexSamplerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NumberFullScanNonUniqueIndexSamplerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NumberIndexProviderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NumberIndexProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NumberLayoutTestUtil.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NumberLayoutTestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NumberNonUniqueLayoutTestUtil.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NumberNonUniqueLayoutTestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NumberNonUniqueSchemaIndexAccessorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NumberNonUniqueSchemaIndexAccessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NumberNonUniqueSchemaIndexPopulatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NumberNonUniqueSchemaIndexPopulatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NumberSchemaIndexAccessorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NumberSchemaIndexAccessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NumberUniqueLayoutTestUtil.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NumberUniqueLayoutTestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NumberUniqueSchemaIndexAccessorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NumberUniqueSchemaIndexAccessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NumberUniqueSchemaIndexPopulatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NumberUniqueSchemaIndexPopulatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/RawBitsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/RawBitsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/ResultCursor.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/ResultCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/SimpleHit.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/SimpleHit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/SpatialIndexCacheTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/SpatialIndexCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/SpatialIndexPopulationStressTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/SpatialIndexPopulationStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/SpatialIndexProviderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/SpatialIndexProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/SpatialIndexSettingsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/SpatialIndexSettingsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/SpatialLayoutTestUtil.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/SpatialLayoutTestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/SpatialNonUniqueSchemaIndexAccessorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/SpatialNonUniqueSchemaIndexAccessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/SpatialNonUniqueSchemaIndexPopulatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/SpatialNonUniqueSchemaIndexPopulatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/SpatialSchemaIndexAccessorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/SpatialSchemaIndexAccessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/SpatialUniqueSchemaIndexAccessorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/SpatialUniqueSchemaIndexAccessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/SpatialUniqueSchemaIndexPopulatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/SpatialUniqueSchemaIndexPopulatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/StringIndexProviderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/StringIndexProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/StringLayoutTestUtil.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/StringLayoutTestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/StringNonUniqueLayoutTestUtil.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/StringNonUniqueLayoutTestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/StringNonUniqueSchemaIndexAccessorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/StringNonUniqueSchemaIndexAccessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/StringNonUniqueSchemaIndexPopulatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/StringNonUniqueSchemaIndexPopulatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/StringSchemaIndexAccessorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/StringSchemaIndexAccessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/StringSchemaKeyTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/StringSchemaKeyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/StringUniqueLayoutTestUtil.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/StringUniqueLayoutTestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/StringUniqueSchemaIndexAccessorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/StringUniqueSchemaIndexAccessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/StringUniqueSchemaIndexPopulatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/StringUniqueSchemaIndexPopulatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/TemporalIndexCacheTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/TemporalIndexCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/TemporalIndexPopulationStressTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/TemporalIndexPopulationStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/TemporalIndexProviderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/TemporalIndexProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/TimeLayoutTestUtil.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/TimeLayoutTestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/TimeNonUniqueSchemaIndexAccessorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/TimeNonUniqueSchemaIndexAccessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/TimeNonUniqueSchemaIndexPopulatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/TimeNonUniqueSchemaIndexPopulatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/TimeUniqueSchemaIndexAccessorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/TimeUniqueSchemaIndexAccessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/TimeUniqueSchemaIndexPopulatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/TimeUniqueSchemaIndexPopulatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/UniqueLayoutTestUtil.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/UniqueLayoutTestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/ZonedDateTimeLayoutTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/ZonedDateTimeLayoutTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/ZonedDateTimeSchemaKeyTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/ZonedDateTimeSchemaKeyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/ZonedTimeSchemaKeyTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/ZonedTimeSchemaKeyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/config/SpaceFillingCurveSettingsFactoryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/config/SpaceFillingCurveSettingsFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/config/SpatialIndexValueTestUtil.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/config/SpatialIndexValueTestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/BridgingIndexProgressorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/BridgingIndexProgressorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexAccessorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexAccessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexPopulatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexPopulatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexProviderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexReaderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexReaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexTestHelp.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexTestHelp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexUpdaterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexUpdaterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/FusionVersion.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/FusionVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/InstanceSelectorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/InstanceSelectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/LazyInstanceSelectorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/LazyInstanceSelectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/AcquireAndReleaseLocksCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/AcquireAndReleaseLocksCompatibility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/AcquisitionTimeoutCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/AcquisitionTimeoutCompatibility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/ActiveLocksListingCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/ActiveLocksListingCompatibility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/CloseCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/CloseCompatibility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/DeadlockCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/DeadlockCompatibility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/IndexEntryResourceTypesTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/IndexEntryResourceTypesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/LockClientStateHolderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/LockClientStateHolderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/LockGroupTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/LockGroupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/LockReentrancyCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/LockReentrancyCompatibility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/LockWorkFailureDump.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/LockWorkFailureDump.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/LockWorker.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/LockWorker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/LockWorkerState.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/LockWorkerState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/LockingCompatibilityTestSuite.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/LockingCompatibilityTestSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/RWLockCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/RWLockCompatibility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/ReentrantLockServiceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/ReentrantLockServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/RelationshipCreateDeleteIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/RelationshipCreateDeleteIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/ResourceTypesIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/ResourceTypesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/StopCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/StopCompatibility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/TracerCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/TracerCompatibility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/community/CommunityLocksTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/community/CommunityLocksTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/community/LockManagerImplTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/community/LockManagerImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/community/RWLockTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/community/RWLockTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/AbstractNodeValueIndexCursorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/AbstractNodeValueIndexCursorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/CursorPropertyAccessorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/CursorPropertyAccessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/DeepRelationshipTraversalCursorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/DeepRelationshipTraversalCursorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/GraphPropertiesTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/GraphPropertiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/IndexCursorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/IndexCursorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/IndexTxStateUpdaterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/IndexTxStateUpdaterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/KernelTokenArgumentTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/KernelTokenArgumentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/LargeNodeCursorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/LargeNodeCursorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/MockStore.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/MockStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/NodeCursorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/NodeCursorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/NodeIndexTransactionStateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/NodeIndexTransactionStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/NodeLabelIndexCursorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/NodeLabelIndexCursorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/NodeSchemaMatcherTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/NodeSchemaMatcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/NodeTransactionStateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/NodeTransactionStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/NodeValueClientFilterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/NodeValueClientFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/NodeValueIndexCursorInMemoryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/NodeValueIndexCursorInMemoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/NodeWriteTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/NodeWriteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/OperationsLockTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/OperationsLockTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/PropertyCursorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/PropertyCursorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/RandomRelationshipTraversalCursorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/RandomRelationshipTraversalCursorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/ReadTestSupport.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/ReadTestSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/ReferencesTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/ReferencesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/RelationshipScanCursorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/RelationshipScanCursorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/RelationshipTransactionStateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/RelationshipTransactionStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/RelationshipTraversalCursorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/RelationshipTraversalCursorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/RelationshipWriteTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/RelationshipWriteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/TransactionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/TransactionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/TwoLayerTxStateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/TwoLayerTxStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/TwoPhaseNodeForRelationshipLockingTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/TwoPhaseNodeForRelationshipLockingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/UnionIndexCapabilityTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/UnionIndexCapabilityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/WriteTestSupport.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/WriteTestSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/pagecache/ConfigurableStandalonePageCacheFactoryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/pagecache/ConfigurableStandalonePageCacheFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/pagecache/ConfiguringPageCacheFactoryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/pagecache/ConfiguringPageCacheFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/pagecache/PageSwapperFactoryForTesting.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/pagecache/PageSwapperFactoryForTesting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/FieldInjectionsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/FieldInjectionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/JarBuilder.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/JarBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ListConverterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ListConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/MapConverterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/MapConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/MethodSignatureCompilerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/MethodSignatureCompilerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/OutputMappersTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/OutputMappersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ProcedureHolderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ProcedureHolderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ProcedureJarLoaderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ProcedureJarLoaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ProcedureSignatureTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ProcedureSignatureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ProceduresTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ProceduresTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureWithArgumentsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureWithArgumentsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveUserAggregationFunctionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveUserAggregationFunctionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveUserFunctionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveUserFunctionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ResourceInjectionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ResourceInjectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/TypeMappersTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/TypeMappersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/UserFunctionSignatureTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/UserFunctionSignatureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/UserFunctionsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/UserFunctionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/query/ClientConnectionInfoTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/query/ClientConnectionInfoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/query/Neo4jTransactionalContextTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/query/Neo4jTransactionalContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/query/QueryEngineProviderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/query/QueryEngineProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/recovery/KernelRecoveryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/recovery/KernelRecoveryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/recovery/RecoveryRequiredCheckerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/recovery/RecoveryRequiredCheckerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/scheduler/CentralJobSchedulerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/scheduler/CentralJobSchedulerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/scheduler/TimeBasedTaskSchedulerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/scheduler/TimeBasedTaskSchedulerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/security/FileURLAccessRuleTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/security/FileURLAccessRuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/RecordStorageEngineTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/RecordStorageEngineTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/StoreStatementTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/StoreStatementTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/AbstractDynamicStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/AbstractDynamicStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/ArrayQueueOutOfOrderSequenceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/ArrayQueueOutOfOrderSequenceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/CommonAbstractStoreBehaviourTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/CommonAbstractStoreBehaviourTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/CommonAbstractStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/CommonAbstractStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/CountsOracle.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/CountsOracle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/FreeIdsAfterRecoveryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/FreeIdsAfterRecoveryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/HighestTransactionIdTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/HighestTransactionIdTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/IdGeneratorContractTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/IdGeneratorContractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/IdGeneratorImplContractTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/IdGeneratorImplContractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/IdGeneratorRebuildFailureEmulationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/IdGeneratorRebuildFailureEmulationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/IdGeneratorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/IdGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/LabelTokenStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/LabelTokenStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/MetaDataStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/MetaDataStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/NeoStoreOpenFailureTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/NeoStoreOpenFailureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/NeoStoresIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/NeoStoresIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/NeoStoresTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/NeoStoresTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/NodeRecordTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/NodeRecordTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/NodeStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/NodeStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/PropertyKeyTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/PropertyKeyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/PropertyRecordTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/PropertyRecordTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/PropertyStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/PropertyStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/PropertyValueRecordSizeCalculatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/PropertyValueRecordSizeCalculatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/RecordCursorsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/RecordCursorsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/RecordStoreConsistentReadTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/RecordStoreConsistentReadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/RecordStoreUtil.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/RecordStoreUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/RelationshipChainPointerChasingTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/RelationshipChainPointerChasingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/RelationshipGroupStoreIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/RelationshipGroupStoreIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/RelationshipGroupStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/RelationshipGroupStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/SchemaStorageTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/SchemaStorageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/SchemaStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/SchemaStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/StandaloneDynamicRecordAllocator.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/StandaloneDynamicRecordAllocator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/StoreFactoryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/StoreFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/StoreTypeTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/StoreTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestArrayStore.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestArrayStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestDynamicStore.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestDynamicStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestGraphProperties.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestGraphProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestGrowingFileMemoryMapping.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestGrowingFileMemoryMapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestIdGeneratorRebuilding.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestIdGeneratorRebuilding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestLongerShortString.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestLongerShortString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestPropertyBlocks.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestPropertyBlocks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestShortArray.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestShortArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestStoreAccess.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestStoreAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestStringCharset.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestStringCharset.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/allocator/ReusableRecordsAllocatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/allocator/ReusableRecordsAllocatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/allocator/ReusableRecordsCompositeAllocatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/allocator/ReusableRecordsCompositeAllocatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/counts/CallTrackingClock.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/counts/CallTrackingClock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/counts/CountsComputerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/counts/CountsComputerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/counts/CountsRotationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/counts/CountsRotationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/counts/CountsTrackerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/counts/CountsTrackerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/AbstractRecordFormatTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/AbstractRecordFormatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/BaseRecordFormatTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/BaseRecordFormatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/BaseRecordFormatsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/BaseRecordFormatsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/ForcedSecondaryUnitRecordFormat.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/ForcedSecondaryUnitRecordFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/ForcedSecondaryUnitRecordFormats.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/ForcedSecondaryUnitRecordFormats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/FullyCoveringRecordKeys.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/FullyCoveringRecordKeys.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/LimitedRecordGenerators.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/LimitedRecordGenerators.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/RecordFormatPropertyConfiguratorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/RecordFormatPropertyConfiguratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/RecordGenerators.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/RecordGenerators.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/RecordKey.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/RecordKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/RecordKeys.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/RecordKeys.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/StandardRecordFormatTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/StandardRecordFormatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/standard/RelationshipGroupRecordFormatTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/standard/RelationshipGroupRecordFormatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/id/BatchingIdSequenceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/id/BatchingIdSequenceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/id/BufferingIdGeneratorFactoryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/id/BufferingIdGeneratorFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/id/DelayedBufferTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/id/DelayedBufferTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/id/FreeIdKeeperTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/id/FreeIdKeeperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/id/IdContainerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/id/IdContainerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/id/IdGeneratorImplTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/id/IdGeneratorImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/id/IdRangeIteratorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/id/IdRangeIteratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/id/RenewableBatchIdSequenceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/id/RenewableBatchIdSequenceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/id/ReuseExcessBatchIdsOnRestartIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/id/ReuseExcessBatchIdsOnRestartIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/id/configuration/CommunityIdTypeConfigurationProviderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/id/configuration/CommunityIdTypeConfigurationProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/kvstore/AbstractKeyValueStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/kvstore/AbstractKeyValueStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/kvstore/BigEndianByteArrayBufferTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/kvstore/BigEndianByteArrayBufferTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/kvstore/ConcurrentMapStateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/kvstore/ConcurrentMapStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/kvstore/KeyValueMergerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/kvstore/KeyValueMergerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/kvstore/KeyValueStoreFileFormatTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/kvstore/KeyValueStoreFileFormatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/kvstore/KeyValueStoreFileTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/kvstore/KeyValueStoreFileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/kvstore/KeyValueWriterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/kvstore/KeyValueWriterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/kvstore/MetadataCollectorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/kvstore/MetadataCollectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/kvstore/RotationTimerFactoryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/kvstore/RotationTimerFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/kvstore/StubCollector.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/kvstore/StubCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/record/ConstraintRuleTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/record/ConstraintRuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/record/IndexRuleTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/record/IndexRuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/record/SchemaRuleSerializationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/record/SchemaRuleSerializationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/record/SchemaRuleTestBase.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/record/SchemaRuleTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/MigrationTestUtils.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/MigrationTestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/StoreVersionCheckTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/StoreVersionCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/legacystore/v23/Legacy23Store.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/legacystore/v23/Legacy23Store.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/legacystore/v30/Legacy30Store.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/legacystore/v30/Legacy30Store.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/monitoring/VisibleMigrationProgressMonitorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/monitoring/VisibleMigrationProgressMonitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/participant/CountsMigratorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/participant/CountsMigratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/participant/ExplicitIndexMigratorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/participant/ExplicitIndexMigratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/participant/NativeLabelScanStoreMigratorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/participant/NativeLabelScanStoreMigratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/participant/SchemaIndexMigratorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/participant/SchemaIndexMigratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/participant/StoreMigratorIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/participant/StoreMigratorIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/participant/StoreMigratorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/participant/StoreMigratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/participant/StoreScanChunkIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/participant/StoreScanChunkIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/CommitContentionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/CommitContentionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/LogHeaderCacheTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/LogHeaderCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/LogPositionMarkerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/LogPositionMarkerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/LogVersionLocatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/LogVersionLocatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/ManualAcquireLockTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/ManualAcquireLockTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/PartialTransactionFailureIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/PartialTransactionFailureIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/PhysicalTransactionCursorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/PhysicalTransactionCursorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/ReadAheadLogChannelTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/ReadAheadLogChannelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/ReadTransactionLogWritingTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/ReadTransactionLogWritingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/ReaderLogVersionBridgeTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/ReaderLogVersionBridgeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/SimpleLogVersionRepository.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/SimpleLogVersionRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/SimpleTransactionIdStore.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/SimpleTransactionIdStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/SynchronizedArrayIdOrderingQueueStressTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/SynchronizedArrayIdOrderingQueueStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/SynchronizedArrayIdOrderingQueueTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/SynchronizedArrayIdOrderingQueueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/TransactionCountersChecker.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/TransactionCountersChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/TransactionMetadataCacheTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/TransactionMetadataCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/TransactionMonitorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/TransactionMonitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/CommandExtractor.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/CommandExtractor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/CommandHandlerContract.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/CommandHandlerContract.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/Commands.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/Commands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/HighIdTransactionApplierTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/HighIdTransactionApplierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/IndexBatchTransactionApplierTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/IndexBatchTransactionApplierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/IndexWorkSyncTransactionApplicationStressIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/IndexWorkSyncTransactionApplicationStressIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/LabelAndIndexUpdateBatchingIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/LabelAndIndexUpdateBatchingIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/NeoStoreTransactionApplierTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/NeoStoreTransactionApplierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/NeoTransactionIndexApplierTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/NeoTransactionIndexApplierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/PhysicalLogCommandReaderV2_2_4Test.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/PhysicalLogCommandReaderV2_2_4Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/PhysicalLogCommandReaderV3_0Test.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/PhysicalLogCommandReaderV3_0Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/PhysicalLogCommandReadersTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/PhysicalLogCommandReadersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/PhysicalLogNeoCommandReaderV2Test.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/PhysicalLogNeoCommandReaderV2Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/ArrayIOCursor.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/ArrayIOCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/BatchingTransactionAppenderConcurrencyTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/BatchingTransactionAppenderConcurrencyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/BatchingTransactionAppenderRotationIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/BatchingTransactionAppenderRotationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/BatchingTransactionAppenderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/BatchingTransactionAppenderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/EagerlyReversedTransactionCursorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/EagerlyReversedTransactionCursorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/FakeCommitment.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/FakeCommitment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/FilteringIOCursorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/FilteringIOCursorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/GivenTransactionCursor.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/GivenTransactionCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/InMemoryClosableChannel.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/InMemoryClosableChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/InMemoryVersionableReadableClosablePositionAwareChannel.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/InMemoryVersionableReadableClosablePositionAwareChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/LogPositionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/LogPositionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/LogVersionUpgradeCheckerIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/LogVersionUpgradeCheckerIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/LogVersionUpgradeCheckerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/LogVersionUpgradeCheckerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/PhysicalFlushableChannelTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/PhysicalFlushableChannelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/PhysicalLogicalTransactionStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/PhysicalLogicalTransactionStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/ReadAheadChannelTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/ReadAheadChannelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/TestableTransactionAppender.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/TestableTransactionAppender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/TransactionLogAppendAndRotateIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/TransactionLogAppendAndRotateIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/TransactionLogFileRotateAndReadRaceIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/TransactionLogFileRotateAndReadRaceIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/TransactionLogFileTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/TransactionLogFileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/TransactionPositionLocatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/TransactionPositionLocatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/checkpoint/AbstractCheckPointThresholdTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/checkpoint/AbstractCheckPointThresholdTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CheckPointSchedulerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CheckPointSchedulerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CheckPointThresholdTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CheckPointThresholdTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CheckPointThresholdTestSupport.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CheckPointThresholdTestSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CheckPointerConstraintCreationDeadlockIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CheckPointerConstraintCreationDeadlockIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CheckPointerImplTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CheckPointerImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CheckPointerIntegrationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CheckPointerIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/checkpoint/DefaultCheckPointerTracerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/checkpoint/DefaultCheckPointerTracerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/checkpoint/StoreCopyCheckPointMutexTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/checkpoint/StoreCopyCheckPointMutexTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/entry/LogEntryParserDispatcherV6Test.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/entry/LogEntryParserDispatcherV6Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/entry/LogEntryVersionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/entry/LogEntryVersionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/entry/LogHeaderReaderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/entry/LogHeaderReaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/entry/LogHeaderWriterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/entry/LogHeaderWriterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/entry/TestTxEntries.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/entry/TestTxEntries.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/entry/VersionAwareLogEntryReaderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/entry/VersionAwareLogEntryReaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/files/LogFilesBuilderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/files/LogFilesBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/files/TransactionLogFileInformationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/files/TransactionLogFileInformationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/files/TransactionLogFilesTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/files/TransactionLogFilesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/pruning/EntryCountThresholdTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/pruning/EntryCountThresholdTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/pruning/EntryTimespanThresholdTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/pruning/EntryTimespanThresholdTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/pruning/FileCountThresholdTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/pruning/FileCountThresholdTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/pruning/FileSizeThresholdTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/pruning/FileSizeThresholdTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/pruning/LogPruneStrategyFactoryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/pruning/LogPruneStrategyFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/pruning/LogPruningIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/pruning/LogPruningIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/pruning/LogPruningTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/pruning/LogPruningTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/pruning/TestLogPruning.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/pruning/TestLogPruning.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/pruning/ThresholdBasedPruneStrategyTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/pruning/ThresholdBasedPruneStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/pruning/ThresholdConfigParserTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/pruning/ThresholdConfigParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/pruning/ThresholdConfigValueTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/pruning/ThresholdConfigValueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/reverse/ReversedMultiFileTransactionCursorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/reverse/ReversedMultiFileTransactionCursorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/reverse/ReversedSingleFileTransactionCursorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/reverse/ReversedSingleFileTransactionCursorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/stresstest/TransactionAppenderStressTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/stresstest/TransactionAppenderStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/stresstest/workload/Runner.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/stresstest/workload/Runner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/stresstest/workload/TransactionRepresentationFactory.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/stresstest/workload/TransactionRepresentationFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/stresstest/workload/Worker.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/stresstest/workload/Worker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/ApplyRecoveredTransactionsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/ApplyRecoveredTransactionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/DataSourceManagerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/DataSourceManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/DefaultIndexProviderMapTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/DefaultIndexProviderMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/DependencyResolverSupplierTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/DependencyResolverSupplierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/IntegrityValidatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/IntegrityValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/LogTruncationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/LogTruncationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/NeoStoreFileListingTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/NeoStoreFileListingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/NodeCommandTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/NodeCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/NodeLabelsFieldTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/NodeLabelsFieldTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/NodeStoreScanTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/NodeStoreScanTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/PrepareTrackingRecordFormats.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/PrepareTrackingRecordFormats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/PropertyCreatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/PropertyCreatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/PropertyLoaderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/PropertyLoaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/RecordChangeSetTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/RecordChangeSetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/RecordChangesTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/RecordChangesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/RelationshipCreatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/RelationshipCreatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/RelationshipGroupGetterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/RelationshipGroupGetterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/SchemaRuleCommandTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/SchemaRuleCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/TestCommandMode.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/TestCommandMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/TrackingRecordAccess.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/TrackingRecordAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/TrackingRecordProxy.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/TrackingRecordProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/TransactionRecordStateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/TransactionRecordStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/WriteTransactionCommandOrderingTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/WriteTransactionCommandOrderingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/storeview/DynamicIndexStoreViewTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/storeview/DynamicIndexStoreViewTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/storeview/LabelScanViewNodeStoreScanTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/storeview/LabelScanViewNodeStoreScanTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/storeview/NeoStoreIndexStoreViewTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/storeview/NeoStoreIndexStoreViewTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/AbstractTraverserIteratorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/AbstractTraverserIteratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/AsOneStartBranchTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/AsOneStartBranchTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/CircularGraphTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/CircularGraphTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/DepthOneTraversalTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/DepthOneTraversalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/DepthPitfallGraphTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/DepthPitfallGraphTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/SmallestGraphEverTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/SmallestGraphEverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/SpecificDepthTraversalTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/SpecificDepthTraversalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TestBidirectionalTraversal.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TestBidirectionalTraversal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TestBranchState.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TestBranchState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TestConstantDirectionExpander.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TestConstantDirectionExpander.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TestEvaluators.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TestEvaluators.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TestMultiPruneEvaluators.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TestMultiPruneEvaluators.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TestMultiRelTypesAndDirections.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TestMultiRelTypesAndDirections.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TestMultipleFilters.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TestMultipleFilters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TestMultipleStartNodes.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TestMultipleStartNodes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TestOrderByTypeExpander.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TestOrderByTypeExpander.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TestPath.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TestPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TestSorting.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TestSorting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TestTraversalWithIterable.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TestTraversalWithIterable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TestTraversalWithLoops.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TestTraversalWithLoops.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TestUniqueness.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TestUniqueness.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TraversalBranchImplTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TraversalBranchImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TraversalTestBase.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TraversalTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TreeGraphTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TreeGraphTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/AutoCreatingHashMap.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/AutoCreatingHashMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/AutoCreatingHashMapTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/AutoCreatingHashMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/CappedLoggerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/CappedLoggerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/ConvertersTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/ConvertersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/CountingJobScheduler.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/CountingJobScheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/DefaultFileSystemWatcherServiceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/DefaultFileSystemWatcherServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/DefaultValueMapperTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/DefaultValueMapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/DependenciesTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/DependenciesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/FileUtilsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/FileUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/HexPrinterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/HexPrinterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/IOCursorAsResourceIterable.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/IOCursorAsResourceIterable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/LazySingleReferenceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/LazySingleReferenceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/MovingAverageTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/MovingAverageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/NumberAwareStringComparatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/NumberAwareStringComparatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/TestBits.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/TestBits.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/TestCopyOnWriteHashMap.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/TestCopyOnWriteHashMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/ValidatorsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/ValidatorsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/VersionedHashMapTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/VersionedHashMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/collection/ArrayCollectionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/collection/ArrayCollectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/collection/ContinuableArrayCursorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/collection/ContinuableArrayCursorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/collection/OffHeapCollectionsFactoryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/collection/OffHeapCollectionsFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/collection/SimpleBitSetTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/collection/SimpleBitSetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/collection/TimedRepositoryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/collection/TimedRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/dbstructure/CineastsDbStructure.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/dbstructure/CineastsDbStructure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/dbstructure/DbStructureArgumentFormatterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/dbstructure/DbStructureArgumentFormatterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/dbstructure/DbStructureCollectorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/dbstructure/DbStructureCollectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/dbstructure/DbStructureInvocationTracingAcceptanceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/dbstructure/DbStructureInvocationTracingAcceptanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/dbstructure/DbStructureLargeOptionalMatchStructure.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/dbstructure/DbStructureLargeOptionalMatchStructure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/dbstructure/GraphDbStructureGuideTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/dbstructure/GraphDbStructureGuideTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/dbstructure/QMULDbStructure.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/dbstructure/QMULDbStructure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/diffsets/DiffApplyingLongIteratorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/diffsets/DiffApplyingLongIteratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/diffsets/DiffApplyingPrimitiveLongIteratorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/diffsets/DiffApplyingPrimitiveLongIteratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/diffsets/PrimitiveLongDiffSetsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/diffsets/PrimitiveLongDiffSetsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/watcher/DefaultFileDeletionEventListenerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/watcher/DefaultFileDeletionEventListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/info/CannedJvmMetadataRepository.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/info/CannedJvmMetadataRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/info/JVMCheckerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/info/JVMCheckerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/internal/DatabaseHealthTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/internal/DatabaseHealthTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/internal/KernelDataTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/internal/KernelDataTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/internal/KernelDiagnosticsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/internal/KernelDiagnosticsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/internal/StoreLockerLifecycleAdapterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/internal/StoreLockerLifecycleAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/internal/StoreLockerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/internal/StoreLockerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/internal/VersionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/internal/VersionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/internal/locker/GlobalStoreLockerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/internal/locker/GlobalStoreLockerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/lifecycle/GitHub1304Test.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/lifecycle/GitHub1304Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/monitoring/MonitorsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/monitoring/MonitorsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/monitoring/VmPauseMonitorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/monitoring/VmPauseMonitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/monitoring/tracing/TracersTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/monitoring/tracing/TracersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/recovery/CorruptedLogsTruncatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/recovery/CorruptedLogsTruncatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/recovery/LogTailScannerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/recovery/LogTailScannerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/recovery/RecoveryProgressIndicatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/recovery/RecoveryProgressIndicatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/kernel/recovery/RecoveryStartInformationProviderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/recovery/RecoveryStartInformationProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/metatest/BatchTransactionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/metatest/BatchTransactionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/metatest/SubProcessTest.java
+++ b/community/kernel/src/test/java/org/neo4j/metatest/SubProcessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/metatest/TestCleanupRule.java
+++ b/community/kernel/src/test/java/org/neo4j/metatest/TestCleanupRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/metatest/TestEphemeralFileChannel.java
+++ b/community/kernel/src/test/java/org/neo4j/metatest/TestEphemeralFileChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/metatest/TestImpermanentGraphDatabase.java
+++ b/community/kernel/src/test/java/org/neo4j/metatest/TestImpermanentGraphDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/storageengine/api/schema/DefaultIndexReaderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/storageengine/api/schema/DefaultIndexReaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/storageengine/api/schema/SimpleNodeValueClient.java
+++ b/community/kernel/src/test/java/org/neo4j/storageengine/api/schema/SimpleNodeValueClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/sysinfo/UsageDataTest.java
+++ b/community/kernel/src/test/java/org/neo4j/sysinfo/UsageDataTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/AdversarialPageCacheGraphDatabaseFactory.java
+++ b/community/kernel/src/test/java/org/neo4j/test/AdversarialPageCacheGraphDatabaseFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/BatchTransaction.java
+++ b/community/kernel/src/test/java/org/neo4j/test/BatchTransaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/ConfigBuilder.java
+++ b/community/kernel/src/test/java/org/neo4j/test/ConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/DatabaseFunctions.java
+++ b/community/kernel/src/test/java/org/neo4j/test/DatabaseFunctions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/DbRepresentation.java
+++ b/community/kernel/src/test/java/org/neo4j/test/DbRepresentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/DoubleLatch.java
+++ b/community/kernel/src/test/java/org/neo4j/test/DoubleLatch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/FakeClockJobScheduler.java
+++ b/community/kernel/src/test/java/org/neo4j/test/FakeClockJobScheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/FakeCpuClock.java
+++ b/community/kernel/src/test/java/org/neo4j/test/FakeCpuClock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/FakeHeapAllocation.java
+++ b/community/kernel/src/test/java/org/neo4j/test/FakeHeapAllocation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/GraphDatabaseServiceCleaner.java
+++ b/community/kernel/src/test/java/org/neo4j/test/GraphDatabaseServiceCleaner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/GraphDefinition.java
+++ b/community/kernel/src/test/java/org/neo4j/test/GraphDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/GraphDescription.java
+++ b/community/kernel/src/test/java/org/neo4j/test/GraphDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/GraphHolder.java
+++ b/community/kernel/src/test/java/org/neo4j/test/GraphHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/ImpermanentGraphDatabase.java
+++ b/community/kernel/src/test/java/org/neo4j/test/ImpermanentGraphDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/InputStreamAwaiter.java
+++ b/community/kernel/src/test/java/org/neo4j/test/InputStreamAwaiter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/InputStreamAwaiterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/test/InputStreamAwaiterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/LimitedFileSystemGraphDatabase.java
+++ b/community/kernel/src/test/java/org/neo4j/test/LimitedFileSystemGraphDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/LogTestUtils.java
+++ b/community/kernel/src/test/java/org/neo4j/test/LogTestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/MockedNeoStores.java
+++ b/community/kernel/src/test/java/org/neo4j/test/MockedNeoStores.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/NamedFunction.java
+++ b/community/kernel/src/test/java/org/neo4j/test/NamedFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/OnDemandJobScheduler.java
+++ b/community/kernel/src/test/java/org/neo4j/test/OnDemandJobScheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/ProcessStreamHandler.java
+++ b/community/kernel/src/test/java/org/neo4j/test/ProcessStreamHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/ProcessTestUtil.java
+++ b/community/kernel/src/test/java/org/neo4j/test/ProcessTestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/Property.java
+++ b/community/kernel/src/test/java/org/neo4j/test/Property.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/RaceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/test/RaceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/ReflectionUtil.java
+++ b/community/kernel/src/test/java/org/neo4j/test/ReflectionUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/StreamConsumer.java
+++ b/community/kernel/src/test/java/org/neo4j/test/StreamConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/TestData.java
+++ b/community/kernel/src/test/java/org/neo4j/test/TestData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/TestGraphDatabaseBuilder.java
+++ b/community/kernel/src/test/java/org/neo4j/test/TestGraphDatabaseBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/TestGraphDatabaseFactory.java
+++ b/community/kernel/src/test/java/org/neo4j/test/TestGraphDatabaseFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/TestGraphDatabaseFactoryState.java
+++ b/community/kernel/src/test/java/org/neo4j/test/TestGraphDatabaseFactoryState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/TestLabels.java
+++ b/community/kernel/src/test/java/org/neo4j/test/TestLabels.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/Unzip.java
+++ b/community/kernel/src/test/java/org/neo4j/test/Unzip.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/assertion/Assert.java
+++ b/community/kernel/src/test/java/org/neo4j/test/assertion/Assert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/impl/EphemeralIdGenerator.java
+++ b/community/kernel/src/test/java/org/neo4j/test/impl/EphemeralIdGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/mockito/answer/AwaitAnswer.java
+++ b/community/kernel/src/test/java/org/neo4j/test/mockito/answer/AwaitAnswer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/mockito/answer/Neo4jMockitoAnswers.java
+++ b/community/kernel/src/test/java/org/neo4j/test/mockito/answer/Neo4jMockitoAnswers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/mockito/matcher/CollectionMatcher.java
+++ b/community/kernel/src/test/java/org/neo4j/test/mockito/matcher/CollectionMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/mockito/matcher/IterableMatcher.java
+++ b/community/kernel/src/test/java/org/neo4j/test/mockito/matcher/IterableMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/mockito/matcher/KernelExceptionUserMessageMatcher.java
+++ b/community/kernel/src/test/java/org/neo4j/test/mockito/matcher/KernelExceptionUserMessageMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/mockito/matcher/LogMatchers.java
+++ b/community/kernel/src/test/java/org/neo4j/test/mockito/matcher/LogMatchers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/mockito/matcher/Neo4jMatchers.java
+++ b/community/kernel/src/test/java/org/neo4j/test/mockito/matcher/Neo4jMatchers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/mockito/matcher/RegexMatcher.java
+++ b/community/kernel/src/test/java/org/neo4j/test/mockito/matcher/RegexMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/mockito/matcher/RootCauseMatcher.java
+++ b/community/kernel/src/test/java/org/neo4j/test/mockito/matcher/RootCauseMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/mockito/mock/GraphMock.java
+++ b/community/kernel/src/test/java/org/neo4j/test/mockito/mock/GraphMock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/mockito/mock/Link.java
+++ b/community/kernel/src/test/java/org/neo4j/test/mockito/mock/Link.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/mockito/mock/Properties.java
+++ b/community/kernel/src/test/java/org/neo4j/test/mockito/mock/Properties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/rule/CleanupRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/rule/CleanupRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/rule/ConfigurablePageCacheRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/rule/ConfigurablePageCacheRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/rule/DatabaseRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/rule/DatabaseRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/rule/EmbeddedDatabaseRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/rule/EmbeddedDatabaseRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/rule/GraphTransactionRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/rule/GraphTransactionRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/rule/ImpermanentDatabaseRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/rule/ImpermanentDatabaseRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/rule/LoggerRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/rule/LoggerRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/rule/NeoStoreDataSourceRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/rule/NeoStoreDataSourceRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/rule/NeoStoresRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/rule/NeoStoresRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/rule/RecordStorageEngineRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/rule/RecordStorageEngineRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/rule/ResourceRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/rule/ResourceRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/rule/Resources.java
+++ b/community/kernel/src/test/java/org/neo4j/test/rule/Resources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/rule/RetryACoupleOfTimesHandler.java
+++ b/community/kernel/src/test/java/org/neo4j/test/rule/RetryACoupleOfTimesHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/rule/RetryHandler.java
+++ b/community/kernel/src/test/java/org/neo4j/test/rule/RetryHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/rule/TimeRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/rule/TimeRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/rule/VerboseTimeout.java
+++ b/community/kernel/src/test/java/org/neo4j/test/rule/VerboseTimeout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/rule/concurrent/ThreadRepository.java
+++ b/community/kernel/src/test/java/org/neo4j/test/rule/concurrent/ThreadRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/rule/concurrent/ThreadingRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/rule/concurrent/ThreadingRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/rule/dump/DumpProcessInformation.java
+++ b/community/kernel/src/test/java/org/neo4j/test/rule/dump/DumpProcessInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/rule/dump/DumpProcessInformationRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/rule/dump/DumpProcessInformationRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/rule/dump/DumpProcessInformationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/test/rule/dump/DumpProcessInformationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/rule/dump/DumpVmInformation.java
+++ b/community/kernel/src/test/java/org/neo4j/test/rule/dump/DumpVmInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/rule/dump/DumpableProcess.java
+++ b/community/kernel/src/test/java/org/neo4j/test/rule/dump/DumpableProcess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/rule/system/SystemExitError.java
+++ b/community/kernel/src/test/java/org/neo4j/test/rule/system/SystemExitError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/rule/system/SystemExitRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/rule/system/SystemExitRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/rule/system/TestSecurityManager.java
+++ b/community/kernel/src/test/java/org/neo4j/test/rule/system/TestSecurityManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/runner/ParameterizedSuiteRunner.java
+++ b/community/kernel/src/test/java/org/neo4j/test/runner/ParameterizedSuiteRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/subprocess/ConnectionDisruptedException.java
+++ b/community/kernel/src/test/java/org/neo4j/test/subprocess/ConnectionDisruptedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/test/subprocess/SubProcess.java
+++ b/community/kernel/src/test/java/org/neo4j/test/subprocess/SubProcess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/batchinsert/BatchInsertersTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/batchinsert/BatchInsertersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/batchinsert/internal/BatchInserterImplTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/batchinsert/internal/BatchInserterImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/batchinsert/internal/BatchedFlushStrategyTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/batchinsert/internal/BatchedFlushStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/batchinsert/internal/FileSystemClosingBatchInserterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/batchinsert/internal/FileSystemClosingBatchInserterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/BatchCollector.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/BatchCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/CalculateDenseNodesStepTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/CalculateDenseNodesStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/CapturingSender.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/CapturingSender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/CapturingStep.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/CapturingStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/ConfigurationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/ConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/DataStatisticsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/DataStatisticsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/DeleteDuplicateNodesStepTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/DeleteDuplicateNodesStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/EncodeGroupsStepTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/EncodeGroupsStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/GeneratingInputIterator.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/GeneratingInputIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/HeapSizeSanityCheckerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/HeapSizeSanityCheckerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/HighestIdTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/HighestIdTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/ImportLogicTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/ImportLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/ImportPanicIT.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/ImportPanicIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/ProcessRelationshipCountsDataStepTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/ProcessRelationshipCountsDataStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/RandomsStates.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/RandomsStates.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/ReadGroupsFromCacheStepTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/ReadGroupsFromCacheStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/RecordIdIteratorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/RecordIdIteratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/RelationshipCountsProcessorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/RelationshipCountsProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/RelationshipGroupCacheTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/RelationshipGroupCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/RelationshipGroupDefragmenterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/RelationshipGroupDefragmenterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/StoreWithReservedId.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/StoreWithReservedId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/UpdateRecordsStepTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/UpdateRecordsStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/UtilsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/UtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/ByteArrayTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/ByteArrayTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/DynamicIntArrayTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/DynamicIntArrayTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/DynamicLongArrayTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/DynamicLongArrayTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/IntArrayTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/IntArrayTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/LongArrayTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/LongArrayTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/LongBitsManipulatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/LongBitsManipulatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/NodeLabelsCacheTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/NodeLabelsCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/NodeRelationshipCacheTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/NodeRelationshipCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/NumberArrayFactoryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/NumberArrayFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/NumberArrayPageCacheTestSupport.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/NumberArrayPageCacheTestSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/NumberArrayTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/NumberArrayTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/PageCacheArrayFactoryMonitorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/PageCacheArrayFactoryMonitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/PageCacheByteArrayConcurrencyTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/PageCacheByteArrayConcurrencyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/PageCacheIntArrayConcurrencyTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/PageCacheIntArrayConcurrencyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/PageCacheLongArrayConcurrencyTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/PageCacheLongArrayConcurrencyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/PageCacheLongArrayTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/PageCacheLongArrayTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/PageCacheNumberArrayConcurrencyTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/PageCacheNumberArrayConcurrencyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/BigIdTrackerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/BigIdTrackerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/ControlledEncoder.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/ControlledEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/EncodingIdMapperTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/EncodingIdMapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/GroupCacheTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/GroupCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/IntTrackerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/IntTrackerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/LongCollisionValuesTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/LongCollisionValuesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/LongEncoderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/LongEncoderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/StringCollisionValuesTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/StringCollisionValuesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/StringEncoderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/StringEncoderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/executor/DynamicTaskExecutorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/executor/DynamicTaskExecutorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/BadCollectorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/BadCollectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/DataGeneratorInput.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/DataGeneratorInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/Distribution.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/Distribution.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/EstimationSanityCheckerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/EstimationSanityCheckerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/GroupsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/GroupsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/InputCacheTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/InputCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/InputEntityCacherTokenCreationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/InputEntityCacherTokenCreationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/InputEntityDecoratorsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/InputEntityDecoratorsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/RandomEntityDataGenerator.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/RandomEntityDataGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInputBatchImportIT.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInputBatchImportIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInputEstimateCalculationIT.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInputEstimateCalculationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInputTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInputTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/DataFactoriesTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/DataFactoriesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/StringDeserialization.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/StringDeserialization.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/StringDeserializationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/StringDeserializationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/CoarseBoundedProgressExecutionMonitorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/CoarseBoundedProgressExecutionMonitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/ControlledStep.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/ControlledStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/DeadEndStep.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/DeadEndStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/DynamicProcessorAssignerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/DynamicProcessorAssignerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/ForkedProcessorStepTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/ForkedProcessorStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/HumanUnderstandableExecutionMonitorIT.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/HumanUnderstandableExecutionMonitorIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/LonelyProcessingStepTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/LonelyProcessingStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/MultiExecutionMonitorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/MultiExecutionMonitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/ProcessorAssignmentStrategies.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/ProcessorAssignmentStrategies.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/ProcessorStepTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/ProcessorStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/QuantizedProjectionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/QuantizedProjectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/SimpleStageControl.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/SimpleStageControl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/StageExecutionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/StageExecutionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/StageTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/StageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/TicketedProcessingTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/TicketedProcessingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/store/BatchingNeoStoresTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/store/BatchingNeoStoresTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/store/BatchingTokenRepositoryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/store/BatchingTokenRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/store/PageCacheFlusherTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/store/PageCacheFlusherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/store/SecondaryUnitPrepareIdSequenceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/store/SecondaryUnitPrepareIdSequenceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/logging/NOTICE.txt
+++ b/community/logging/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/community/logging/src/main/java/org/neo4j/logging/AbstractLog.java
+++ b/community/logging/src/main/java/org/neo4j/logging/AbstractLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/logging/src/main/java/org/neo4j/logging/AbstractLogProvider.java
+++ b/community/logging/src/main/java/org/neo4j/logging/AbstractLogProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/logging/src/main/java/org/neo4j/logging/AbstractPrintWriterLogger.java
+++ b/community/logging/src/main/java/org/neo4j/logging/AbstractPrintWriterLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/logging/src/main/java/org/neo4j/logging/BufferingLog.java
+++ b/community/logging/src/main/java/org/neo4j/logging/BufferingLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/logging/src/main/java/org/neo4j/logging/DuplicatingLog.java
+++ b/community/logging/src/main/java/org/neo4j/logging/DuplicatingLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/logging/src/main/java/org/neo4j/logging/DuplicatingLogProvider.java
+++ b/community/logging/src/main/java/org/neo4j/logging/DuplicatingLogProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/logging/src/main/java/org/neo4j/logging/FormattedLog.java
+++ b/community/logging/src/main/java/org/neo4j/logging/FormattedLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/logging/src/main/java/org/neo4j/logging/FormattedLogProvider.java
+++ b/community/logging/src/main/java/org/neo4j/logging/FormattedLogProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/logging/src/main/java/org/neo4j/logging/FormattedLogger.java
+++ b/community/logging/src/main/java/org/neo4j/logging/FormattedLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/logging/src/main/java/org/neo4j/logging/Level.java
+++ b/community/logging/src/main/java/org/neo4j/logging/Level.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/logging/src/main/java/org/neo4j/logging/Log.java
+++ b/community/logging/src/main/java/org/neo4j/logging/Log.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/logging/src/main/java/org/neo4j/logging/LogProvider.java
+++ b/community/logging/src/main/java/org/neo4j/logging/LogProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/logging/src/main/java/org/neo4j/logging/LogTimeZone.java
+++ b/community/logging/src/main/java/org/neo4j/logging/LogTimeZone.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/logging/src/main/java/org/neo4j/logging/Logger.java
+++ b/community/logging/src/main/java/org/neo4j/logging/Logger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/logging/src/main/java/org/neo4j/logging/NullLog.java
+++ b/community/logging/src/main/java/org/neo4j/logging/NullLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/logging/src/main/java/org/neo4j/logging/NullLogProvider.java
+++ b/community/logging/src/main/java/org/neo4j/logging/NullLogProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/logging/src/main/java/org/neo4j/logging/NullLogger.java
+++ b/community/logging/src/main/java/org/neo4j/logging/NullLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/logging/src/main/java/org/neo4j/logging/PrintStreamLogger.java
+++ b/community/logging/src/main/java/org/neo4j/logging/PrintStreamLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/logging/src/main/java/org/neo4j/logging/RotatingFileOutputStreamSupplier.java
+++ b/community/logging/src/main/java/org/neo4j/logging/RotatingFileOutputStreamSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/logging/src/main/java/org/neo4j/logging/async/AsyncLog.java
+++ b/community/logging/src/main/java/org/neo4j/logging/async/AsyncLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/logging/src/main/java/org/neo4j/logging/async/AsyncLogEvent.java
+++ b/community/logging/src/main/java/org/neo4j/logging/async/AsyncLogEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/logging/src/main/java/org/neo4j/logging/async/AsyncLogProvider.java
+++ b/community/logging/src/main/java/org/neo4j/logging/async/AsyncLogProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/logging/src/main/java/org/neo4j/logging/internal/LogMessageUtil.java
+++ b/community/logging/src/main/java/org/neo4j/logging/internal/LogMessageUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/logging/src/test/java/org/neo4j/logging/AssertableLogProvider.java
+++ b/community/logging/src/test/java/org/neo4j/logging/AssertableLogProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/logging/src/test/java/org/neo4j/logging/DuplicatingLogProviderTest.java
+++ b/community/logging/src/test/java/org/neo4j/logging/DuplicatingLogProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/logging/src/test/java/org/neo4j/logging/DuplicatingLogTest.java
+++ b/community/logging/src/test/java/org/neo4j/logging/DuplicatingLogTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/logging/src/test/java/org/neo4j/logging/FormattedLogProviderTest.java
+++ b/community/logging/src/test/java/org/neo4j/logging/FormattedLogProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/logging/src/test/java/org/neo4j/logging/FormattedLogTest.java
+++ b/community/logging/src/test/java/org/neo4j/logging/FormattedLogTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/logging/src/test/java/org/neo4j/logging/RotatingFileOutputStreamSupplierTest.java
+++ b/community/logging/src/test/java/org/neo4j/logging/RotatingFileOutputStreamSupplierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/logging/src/test/java/org/neo4j/logging/async/AsyncLogTest.java
+++ b/community/logging/src/test/java/org/neo4j/logging/async/AsyncLogTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/logging/src/test/java/org/neo4j/logging/internal/LogMessageUtilTest.java
+++ b/community/logging/src/test/java/org/neo4j/logging/internal/LogMessageUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index-upgrade/NOTICE.txt
+++ b/community/lucene-index-upgrade/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/community/lucene-index-upgrade/src/main/assembly/assembly.xml
+++ b/community/lucene-index-upgrade/src/main/assembly/assembly.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2018-2020 "Graph Foundation,"
+    Copyright (c) "Graph Foundation,"
     Graph Foundation, Inc. [https://graphfoundation.org]
 
     This file is part of ONgDB.

--- a/community/lucene-index-upgrade/src/main/java/org/neo4j/upgrade/loader/EmbeddedJarLoader.java
+++ b/community/lucene-index-upgrade/src/main/java/org/neo4j/upgrade/loader/EmbeddedJarLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index-upgrade/src/main/java/org/neo4j/upgrade/loader/EmbeddedJarNotFoundException.java
+++ b/community/lucene-index-upgrade/src/main/java/org/neo4j/upgrade/loader/EmbeddedJarNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index-upgrade/src/main/java/org/neo4j/upgrade/loader/JarLoaderSupplier.java
+++ b/community/lucene-index-upgrade/src/main/java/org/neo4j/upgrade/loader/JarLoaderSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index-upgrade/src/main/java/org/neo4j/upgrade/lucene/ExplicitIndexMigrationException.java
+++ b/community/lucene-index-upgrade/src/main/java/org/neo4j/upgrade/lucene/ExplicitIndexMigrationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index-upgrade/src/main/java/org/neo4j/upgrade/lucene/IndexUpgraderWrapper.java
+++ b/community/lucene-index-upgrade/src/main/java/org/neo4j/upgrade/lucene/IndexUpgraderWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index-upgrade/src/main/java/org/neo4j/upgrade/lucene/LuceneExplicitIndexUpgrader.java
+++ b/community/lucene-index-upgrade/src/main/java/org/neo4j/upgrade/lucene/LuceneExplicitIndexUpgrader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index-upgrade/src/test/java/org/neo4j/upgrade/lucene/IndexUpgraderWrapperTest.java
+++ b/community/lucene-index-upgrade/src/test/java/org/neo4j/upgrade/lucene/IndexUpgraderWrapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index-upgrade/src/test/java/org/neo4j/upgrade/lucene/LuceneExplicitIndexUpgraderTest.java
+++ b/community/lucene-index-upgrade/src/test/java/org/neo4j/upgrade/lucene/LuceneExplicitIndexUpgraderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index-upgrade/src/test/java/org/neo4j/upgrade/lucene/UpgraterStub.java
+++ b/community/lucene-index-upgrade/src/test/java/org/neo4j/upgrade/lucene/UpgraterStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/NOTICE.txt
+++ b/community/lucene-index/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/community/lucene-index/src/main/java/org/apache/lucene/index/PooledConcurrentMergeScheduler.java
+++ b/community/lucene-index/src/main/java/org/apache/lucene/index/PooledConcurrentMergeScheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/AbstractExplicitIndexHits.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/AbstractExplicitIndexHits.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/CombinedIndexHits.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/CombinedIndexHits.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/CommitContext.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/CommitContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/ConstantScoreIterator.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/ConstantScoreIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/DocToIdIterator.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/DocToIdIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/EmptyIndexHits.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/EmptyIndexHits.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/EntityId.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/EntityId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/ExactTxData.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/ExactTxData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/FullTxData.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/FullTxData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/IndexClockCache.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/IndexClockCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/IndexIdentifier.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/IndexIdentifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/IndexReference.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/IndexReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/IndexReferenceFactory.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/IndexReferenceFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/IndexType.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/IndexType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/IndexTypeCache.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/IndexTypeCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/LowerCaseKeywordAnalyzer.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/LowerCaseKeywordAnalyzer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/LuceneBatchInserterIndex.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/LuceneBatchInserterIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/LuceneBatchInserterIndexProviderNewImpl.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/LuceneBatchInserterIndexProviderNewImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/LuceneCommandApplier.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/LuceneCommandApplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/LuceneDataSource.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/LuceneDataSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/LuceneExplicitIndex.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/LuceneExplicitIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/LuceneExplicitIndexTransaction.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/LuceneExplicitIndexTransaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/LuceneIndexImplementation.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/LuceneIndexImplementation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/LuceneTransactionState.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/LuceneTransactionState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/LuceneUtil.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/LuceneUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/ReadOnlyIndexReference.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/ReadOnlyIndexReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/ReadOnlyIndexReferenceFactory.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/ReadOnlyIndexReferenceFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/TopDocsIterator.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/TopDocsIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/TxData.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/TxData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/TxDataHolder.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/TxDataHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/WritableIndexReference.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/WritableIndexReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/WritableIndexReferenceFactory.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/WritableIndexReferenceFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/package-info.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/index/lucene/LuceneKernelExtension.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/lucene/LuceneKernelExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/index/lucene/LuceneKernelExtensionFactory.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/lucene/LuceneKernelExtensionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/index/lucene/LuceneTimeline.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/lucene/LuceneTimeline.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/index/lucene/QueryContext.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/lucene/QueryContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/index/lucene/TimelineIndex.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/lucene/TimelineIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/index/lucene/ValueContext.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/lucene/ValueContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/index/lucene/package-info.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/lucene/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/index/lucene/unsafe/batchinsert/LuceneBatchInserterIndexProvider.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/lucene/unsafe/batchinsert/LuceneBatchInserterIndexProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/AbstractLuceneIndex.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/AbstractLuceneIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/DatabaseIndex.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/DatabaseIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/IndexWriterConfigs.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/IndexWriterConfigs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneAllDocumentsReader.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneAllDocumentsReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneDocumentRetrievalException.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneDocumentRetrievalException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneKernelExtension.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneKernelExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneKernelExtensionFactory.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneKernelExtensionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneKernelExtensions.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneKernelExtensions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LucenePartitionAllDocumentsReader.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LucenePartitionAllDocumentsReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/ReadOnlyAbstractDatabaseIndex.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/ReadOnlyAbstractDatabaseIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/WritableAbstractDatabaseIndex.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/WritableAbstractDatabaseIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/backup/LuceneIndexSnapshots.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/backup/LuceneIndexSnapshots.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/backup/ReadOnlyIndexSnapshotFileIterator.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/backup/ReadOnlyIndexSnapshotFileIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/backup/SnapshotReleaseException.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/backup/SnapshotReleaseException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/backup/UnsupportedIndexDeletionPolicy.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/backup/UnsupportedIndexDeletionPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/backup/WritableIndexSnapshotFileIterator.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/backup/WritableIndexSnapshotFileIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/builder/AbstractLuceneIndexBuilder.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/builder/AbstractLuceneIndexBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/builder/LuceneIndexStorageBuilder.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/builder/LuceneIndexStorageBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/collector/DocValuesAccess.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/collector/DocValuesAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/collector/DocValuesCollector.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/collector/DocValuesCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/collector/ValuesIterator.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/collector/ValuesIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/partition/AbstractIndexPartition.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/partition/AbstractIndexPartition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/partition/IndexPartitionFactory.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/partition/IndexPartitionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/partition/PartitionSearcher.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/partition/PartitionSearcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/partition/ReadOnlyIndexPartition.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/partition/ReadOnlyIndexPartition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/partition/ReadOnlyIndexPartitionFactory.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/partition/ReadOnlyIndexPartitionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/partition/WritableIndexPartition.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/partition/WritableIndexPartition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/partition/WritableIndexPartitionFactory.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/partition/WritableIndexPartitionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/sampler/AggregatingIndexSampler.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/sampler/AggregatingIndexSampler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/storage/DirectoryFactory.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/storage/DirectoryFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/storage/FailureStorage.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/storage/FailureStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/storage/IndexStorageFactory.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/storage/IndexStorageFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/storage/PartitionedIndexStorage.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/storage/PartitionedIndexStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/storage/layout/FolderLayout.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/storage/layout/FolderLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/storage/layout/IndexFolderLayout.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/storage/layout/IndexFolderLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/IndexProviderFactoryUtil.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/IndexProviderFactoryUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/LuceneDocumentStructure.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/LuceneDocumentStructure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/LuceneIndexAccessor.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/LuceneIndexAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/LuceneIndexProvider.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/LuceneIndexProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/LuceneIndexProviderFactory.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/LuceneIndexProviderFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/LuceneIndexReaderAcquisitionException.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/LuceneIndexReaderAcquisitionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/LuceneSchemaIndex.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/LuceneSchemaIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/LuceneSchemaIndexBuilder.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/LuceneSchemaIndexBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/NativeLuceneFusionIndexProviderFactory.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/NativeLuceneFusionIndexProviderFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/NativeLuceneFusionIndexProviderFactory10.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/NativeLuceneFusionIndexProviderFactory10.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/NativeLuceneFusionIndexProviderFactory20.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/NativeLuceneFusionIndexProviderFactory20.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/ReadOnlyDatabaseSchemaIndex.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/ReadOnlyDatabaseSchemaIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/SchemaIndex.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/SchemaIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/ValueEncoding.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/ValueEncoding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/WritableDatabaseSchemaIndex.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/WritableDatabaseSchemaIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/populator/LuceneIndexPopulatingUpdater.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/populator/LuceneIndexPopulatingUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/populator/LuceneIndexPopulator.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/populator/LuceneIndexPopulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/populator/NonUniqueLuceneIndexPopulatingUpdater.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/populator/NonUniqueLuceneIndexPopulatingUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/populator/NonUniqueLuceneIndexPopulator.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/populator/NonUniqueLuceneIndexPopulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/populator/UniqueLuceneIndexPopulatingUpdater.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/populator/UniqueLuceneIndexPopulatingUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/populator/UniqueLuceneIndexPopulator.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/populator/UniqueLuceneIndexPopulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/reader/IndexReaderCloseException.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/reader/IndexReaderCloseException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/reader/LuceneAllEntriesIndexAccessorReader.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/reader/LuceneAllEntriesIndexAccessorReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/reader/LuceneDistinctValuesProgressor.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/reader/LuceneDistinctValuesProgressor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/reader/PartitionedIndexReader.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/reader/PartitionedIndexReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/reader/SimpleIndexReader.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/reader/SimpleIndexReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/sampler/LuceneIndexSampler.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/sampler/LuceneIndexSampler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/sampler/NonUniqueLuceneIndexSampler.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/sampler/NonUniqueLuceneIndexSampler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/sampler/UniqueLuceneIndexSampler.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/sampler/UniqueLuceneIndexSampler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/verification/CompositeDuplicateCheckingCollector.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/verification/CompositeDuplicateCheckingCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/verification/DuplicateCheckStrategy.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/verification/DuplicateCheckStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/verification/DuplicateCheckingCollector.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/verification/DuplicateCheckingCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/verification/PartitionedUniquenessVerifier.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/verification/PartitionedUniquenessVerifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/verification/SimpleUniquenessVerifier.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/verification/SimpleUniquenessVerifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/verification/UniquenessVerifier.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/verification/UniquenessVerifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/writer/LuceneIndexWriter.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/writer/LuceneIndexWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/writer/PartitionedIndexWriter.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/writer/PartitionedIndexWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/impl/api/ExplicitIndexValueValidator.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/impl/api/ExplicitIndexValueValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/impl/api/LuceneIndexValueValidator.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/impl/api/LuceneIndexValueValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/spi/legacyindex/IndexProviders.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/spi/legacyindex/IndexProviders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/examples/RelatedNodesQuestionTest.java
+++ b/community/lucene-index/src/test/java/examples/RelatedNodesQuestionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/apache/lucene/index/PooledConcurrentMergeSchedulerTest.java
+++ b/community/lucene-index/src/test/java/org/apache/lucene/index/PooledConcurrentMergeSchedulerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/concurrencytest/ConstraintIndexConcurrencyTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/concurrencytest/ConstraintIndexConcurrencyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/graphdb/MandatoryTransactionsForIndexHitsFacadeTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/graphdb/MandatoryTransactionsForIndexHitsFacadeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/graphdb/MandatoryTransactionsForNodeIndexFacadeTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/graphdb/MandatoryTransactionsForNodeIndexFacadeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/graphdb/MandatoryTransactionsForRelationshipIndexFacadeTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/graphdb/MandatoryTransactionsForRelationshipIndexFacadeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/graphdb/NodeIndexFacadeMethods.java
+++ b/community/lucene-index/src/test/java/org/neo4j/graphdb/NodeIndexFacadeMethods.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/graphdb/RelationshipIndexFacadeMethods.java
+++ b/community/lucene-index/src/test/java/org/neo4j/graphdb/RelationshipIndexFacadeMethods.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/index/ExplicitIndexTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/ExplicitIndexTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/index/IndexConstraintsTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/IndexConstraintsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/index/Neo4jTestCase.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/Neo4jTestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/index/explicit/ExplicitIndexRegressionTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/explicit/ExplicitIndexRegressionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/AbstractLuceneIndexTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/AbstractLuceneIndexTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/AutoIndexOperationsTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/AutoIndexOperationsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/BatchInsertionIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/BatchInsertionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/BeginTransactionCommand.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/BeginTransactionCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/CloseTrackingIndexReader.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/CloseTrackingIndexReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/CommandState.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/CommandState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/CommitCommand.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/CommitCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/Contains.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/Contains.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/CreateNodeAndIndexByCommand.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/CreateNodeAndIndexByCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/CustomAnalyzer.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/CustomAnalyzer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/DeleteIndexCommand.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/DeleteIndexCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/DieCommand.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/DieCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/IndexCreationTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/IndexCreationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/IndexTypeTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/IndexTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/Inserter.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/Inserter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/LuceneBatchInserterIndexProviderNewImplTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/LuceneBatchInserterIndexProviderNewImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/LuceneCommandApplierTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/LuceneCommandApplierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/LuceneDataSourceTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/LuceneDataSourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/LuceneRecoveryIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/LuceneRecoveryIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/MyStandardAnalyzer.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/MyStandardAnalyzer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/NonUniqueIndexTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/NonUniqueIndexTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/PutIfAbsentCommand.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/PutIfAbsentCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/QueryIndexCommand.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/QueryIndexCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/ReadOnlyIndexReferenceFactoryTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/ReadOnlyIndexReferenceFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/ReadOnlyIndexReferenceTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/ReadOnlyIndexReferenceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/RecoveryTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/RecoveryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/RemoveFromIndexCommand.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/RemoveFromIndexCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/RollbackCommand.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/RollbackCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/TestAutoIndexReopen.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/TestAutoIndexReopen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/TestAutoIndexing.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/TestAutoIndexing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/TestIndexDelectionFs.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/TestIndexDelectionFs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/TestIndexDeletion.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/TestIndexDeletion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/TestIndexNames.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/TestIndexNames.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/TestLuceneIndex.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/TestLuceneIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/TestMigration.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/TestMigration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/WorkThread.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/WorkThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/WritableIndexReferenceFactoryTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/WritableIndexReferenceFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/WritableIndexReferenceTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/WritableIndexReferenceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/index/lucene/ConstraintIndexFailureIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/lucene/ConstraintIndexFailureIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/index/recovery/UniqueIndexRecoveryTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/recovery/UniqueIndexRecoveryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/index/timeline/TestTimeline.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/timeline/TestTimeline.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/LuceneTestUtil.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/LuceneTestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/AccidentalUniquenessConstraintViolationIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/AccidentalUniquenessConstraintViolationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/DatabaseIndexConstraintProviderApprovalTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/DatabaseIndexConstraintProviderApprovalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/DatabaseIndexIndexProviderApprovalTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/DatabaseIndexIndexProviderApprovalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/DatabaseIndexIntegrationTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/DatabaseIndexIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/IndexReaderStub.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/IndexReaderStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneAllDocumentsReaderTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneAllDocumentsReaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneSchemaIndexPopulationIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneSchemaIndexPopulationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneSchemaIndexUniquenessVerificationIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneSchemaIndexUniquenessVerificationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/TestPropertyAccessor.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/TestPropertyAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/backup/ReadOnlyIndexSnapshotFileIteratorTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/backup/ReadOnlyIndexSnapshotFileIteratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/backup/WritableIndexSnapshotFileIteratorTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/backup/WritableIndexSnapshotFileIteratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/collector/DocValuesCollectorTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/collector/DocValuesCollectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/partition/IndexPartitionFactoryTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/partition/IndexPartitionFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/sampler/AggregatingIndexSamplerTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/sampler/AggregatingIndexSamplerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/storage/FailureStorageTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/storage/FailureStorageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/storage/PartitionedIndexStorageTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/storage/PartitionedIndexStorageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/storage/layout/IndexFolderLayoutTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/storage/layout/IndexFolderLayoutTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/verification/PartitionedUniquenessVerifierTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/verification/PartitionedUniquenessVerifierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/verification/SimpleUniquenessVerifierTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/verification/SimpleUniquenessVerifierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/AccessUniqueDatabaseIndexTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/AccessUniqueDatabaseIndexTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/AllNodesCollector.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/AllNodesCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/DatabaseCompositeIndexAccessorTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/DatabaseCompositeIndexAccessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/DatabaseIndexAccessorTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/DatabaseIndexAccessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/DefaultSchemaIndexConfigTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/DefaultSchemaIndexConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/FusionIndexIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/FusionIndexIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/FusionIndexProvider10CompatibilitySuiteTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/FusionIndexProvider10CompatibilitySuiteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/FusionIndexProvider20CompatibilitySuiteTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/FusionIndexProvider20CompatibilitySuiteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LongArrayMatcher.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LongArrayMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneDocumentStructureTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneDocumentStructureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneIndexAccessorTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneIndexAccessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneIndexProviderCompatibilitySuiteTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneIndexProviderCompatibilitySuiteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneIndexProviderTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneIndexProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneIndexRecoveryIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneIndexRecoveryIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneSchemaIndexBuilderTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneSchemaIndexBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneSchemaIndexCorruptionTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneSchemaIndexCorruptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneSchemaIndexIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneSchemaIndexIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneSchemaIndexPopulatorTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneSchemaIndexPopulatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneSchemaIndexTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneSchemaIndexTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/ReadOnlyLuceneSchemaIndexTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/ReadOnlyLuceneSchemaIndexTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/SchemaIndexAcceptanceTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/SchemaIndexAcceptanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/StringLengthIndexValidationIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/StringLengthIndexValidationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/UniqueIndexApplicationIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/UniqueIndexApplicationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/UniqueSpatialIndexIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/UniqueSpatialIndexIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/populator/NonUniqueDatabaseIndexPopulatingUpdaterTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/populator/NonUniqueDatabaseIndexPopulatingUpdaterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/populator/NonUniqueDatabaseIndexPopulatorTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/populator/NonUniqueDatabaseIndexPopulatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/populator/UniqueDatabaseIndexPopulatingUpdaterTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/populator/UniqueDatabaseIndexPopulatingUpdaterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/populator/UniqueDatabaseIndexPopulatorTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/populator/UniqueDatabaseIndexPopulatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/reader/PartitionedIndexReaderTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/reader/PartitionedIndexReaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/reader/SimpleIndexReaderDistinctValuesTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/reader/SimpleIndexReaderDistinctValuesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/reader/SimpleIndexReaderTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/reader/SimpleIndexReaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/sampler/LuceneIndexSamplerReleaseTaskControlUnderFusion.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/sampler/LuceneIndexSamplerReleaseTaskControlUnderFusion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/sampler/NonUniqueDatabaseIndexSamplerTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/sampler/NonUniqueDatabaseIndexSamplerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/sampler/UniqueDatabaseIndexSamplerTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/sampler/UniqueDatabaseIndexSamplerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/verification/DuplicateCheckStrategyTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/verification/DuplicateCheckStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/impl/api/ExplicitIndexValueValidatorTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/impl/api/ExplicitIndexValueValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/impl/api/LuceneIndexValueValidatorTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/impl/api/LuceneIndexValueValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/impl/api/MultipleOpenCursorsTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/impl/api/MultipleOpenCursorsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintCreationIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintCreationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintRecoveryIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintRecoveryIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/impl/api/index/IndexingServiceIntegrationTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/impl/api/index/IndexingServiceIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/impl/event/TestTransactionEventsWithIndexes.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/impl/event/TestTransactionEventsWithIndexes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/impl/newapi/ConstraintTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/impl/newapi/ConstraintTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/impl/newapi/ExplicitIndexCursorTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/impl/newapi/ExplicitIndexCursorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/impl/newapi/ExplicitIndexCursorWritesTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/impl/newapi/ExplicitIndexCursorWritesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/impl/newapi/LockingTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/impl/newapi/LockingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/impl/newapi/NodeValueIndexCursorLuceneTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/impl/newapi/NodeValueIndexCursorLuceneTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/impl/newapi/NodeValueIndexCursorNative10Test.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/impl/newapi/NodeValueIndexCursorNative10Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/impl/newapi/NodeValueIndexCursorNative20Test.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/impl/newapi/NodeValueIndexCursorNative20Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/unsafe/batchinsert/internal/BatchInsertIndexProviderTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/unsafe/batchinsert/internal/BatchInsertIndexProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/lucene-index/src/test/java/org/neo4j/unsafe/batchinsert/internal/BatchInsertTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/unsafe/batchinsert/internal/BatchInsertTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j-community/NOTICE.txt
+++ b/community/neo4j-community/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/community/neo4j-harness/NOTICE.txt
+++ b/community/neo4j-harness/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/community/neo4j-harness/src/main/java/org/neo4j/harness/ServerControls.java
+++ b/community/neo4j-harness/src/main/java/org/neo4j/harness/ServerControls.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j-harness/src/main/java/org/neo4j/harness/TestServerBuilder.java
+++ b/community/neo4j-harness/src/main/java/org/neo4j/harness/TestServerBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j-harness/src/main/java/org/neo4j/harness/TestServerBuilders.java
+++ b/community/neo4j-harness/src/main/java/org/neo4j/harness/TestServerBuilders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j-harness/src/main/java/org/neo4j/harness/internal/AbstractInProcessServerBuilder.java
+++ b/community/neo4j-harness/src/main/java/org/neo4j/harness/internal/AbstractInProcessServerBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j-harness/src/main/java/org/neo4j/harness/internal/Extensions.java
+++ b/community/neo4j-harness/src/main/java/org/neo4j/harness/internal/Extensions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j-harness/src/main/java/org/neo4j/harness/internal/Fixtures.java
+++ b/community/neo4j-harness/src/main/java/org/neo4j/harness/internal/Fixtures.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j-harness/src/main/java/org/neo4j/harness/internal/HarnessRegisteredProcs.java
+++ b/community/neo4j-harness/src/main/java/org/neo4j/harness/internal/HarnessRegisteredProcs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j-harness/src/main/java/org/neo4j/harness/internal/InProcessServerBuilder.java
+++ b/community/neo4j-harness/src/main/java/org/neo4j/harness/internal/InProcessServerBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j-harness/src/main/java/org/neo4j/harness/internal/InProcessServerControls.java
+++ b/community/neo4j-harness/src/main/java/org/neo4j/harness/internal/InProcessServerControls.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j-harness/src/main/java/org/neo4j/harness/junit/Neo4jRule.java
+++ b/community/neo4j-harness/src/main/java/org/neo4j/harness/junit/Neo4jRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j-harness/src/test/java/org/neo4j/harness/FixturesTestIT.java
+++ b/community/neo4j-harness/src/test/java/org/neo4j/harness/FixturesTestIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j-harness/src/test/java/org/neo4j/harness/InProcessBuilderTestIT.java
+++ b/community/neo4j-harness/src/test/java/org/neo4j/harness/InProcessBuilderTestIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j-harness/src/test/java/org/neo4j/harness/JUnitRuleTestIT.java
+++ b/community/neo4j-harness/src/test/java/org/neo4j/harness/JUnitRuleTestIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j-harness/src/test/java/org/neo4j/harness/JavaAggregationFunctionsTestIT.java
+++ b/community/neo4j-harness/src/test/java/org/neo4j/harness/JavaAggregationFunctionsTestIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j-harness/src/test/java/org/neo4j/harness/JavaFunctionsTestIT.java
+++ b/community/neo4j-harness/src/test/java/org/neo4j/harness/JavaFunctionsTestIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j-harness/src/test/java/org/neo4j/harness/JavaProceduresTest.java
+++ b/community/neo4j-harness/src/test/java/org/neo4j/harness/JavaProceduresTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j-harness/src/test/java/org/neo4j/harness/MyCoreAPI.java
+++ b/community/neo4j-harness/src/test/java/org/neo4j/harness/MyCoreAPI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j-harness/src/test/java/org/neo4j/harness/MyExtensionThatAddsAlternativeCoreAPI.java
+++ b/community/neo4j-harness/src/test/java/org/neo4j/harness/MyExtensionThatAddsAlternativeCoreAPI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j-harness/src/test/java/org/neo4j/harness/MyExtensionThatAddsInjectable.java
+++ b/community/neo4j-harness/src/test/java/org/neo4j/harness/MyExtensionThatAddsInjectable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j-harness/src/test/java/org/neo4j/harness/SomeService.java
+++ b/community/neo4j-harness/src/test/java/org/neo4j/harness/SomeService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j-harness/src/test/java/org/neo4j/harness/extensionpackage/MyUnmanagedExtension.java
+++ b/community/neo4j-harness/src/test/java/org/neo4j/harness/extensionpackage/MyUnmanagedExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j-slf4j/NOTICE.txt
+++ b/community/neo4j-slf4j/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/community/neo4j-slf4j/src/main/java/org/neo4j/logging/slf4j/Slf4jLog.java
+++ b/community/neo4j-slf4j/src/main/java/org/neo4j/logging/slf4j/Slf4jLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j-slf4j/src/main/java/org/neo4j/logging/slf4j/Slf4jLogProvider.java
+++ b/community/neo4j-slf4j/src/main/java/org/neo4j/logging/slf4j/Slf4jLogProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j-slf4j/src/test/java/org/neo4j/logging/slf4j/AccumulatingAppender.java
+++ b/community/neo4j-slf4j/src/test/java/org/neo4j/logging/slf4j/AccumulatingAppender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j-slf4j/src/test/java/org/neo4j/logging/slf4j/Slf4jLogProviderTest.java
+++ b/community/neo4j-slf4j/src/test/java/org/neo4j/logging/slf4j/Slf4jLogProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j/NOTICE.txt
+++ b/community/neo4j/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/community/neo4j/src/test/java/counts/RebuildCountsTest.java
+++ b/community/neo4j/src/test/java/counts/RebuildCountsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j/src/test/java/db/DatabaseShutdownTest.java
+++ b/community/neo4j/src/test/java/db/DatabaseShutdownTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j/src/test/java/db/DatabaseStartupTest.java
+++ b/community/neo4j/src/test/java/db/DatabaseStartupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j/src/test/java/db/QueryRestartIT.java
+++ b/community/neo4j/src/test/java/db/QueryRestartIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j/src/test/java/files/NativeIndexFileFilterTest.java
+++ b/community/neo4j/src/test/java/files/NativeIndexFileFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j/src/test/java/files/TestNoFileDescriptorLeaks.java
+++ b/community/neo4j/src/test/java/files/TestNoFileDescriptorLeaks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j/src/test/java/migration/PointPropertiesRecordFormatIT.java
+++ b/community/neo4j/src/test/java/migration/PointPropertiesRecordFormatIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j/src/test/java/migration/RecordFormatMigrationIT.java
+++ b/community/neo4j/src/test/java/migration/RecordFormatMigrationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j/src/test/java/migration/StartOldDbOn3_4AndCreateFusionIndexIT.java
+++ b/community/neo4j/src/test/java/migration/StartOldDbOn3_4AndCreateFusionIndexIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j/src/test/java/migration/TemporalPropertiesRecordFormatIT.java
+++ b/community/neo4j/src/test/java/migration/TemporalPropertiesRecordFormatIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j/src/test/java/org/neo4j/index/AccessExplicitIndexReadOnlyIT.java
+++ b/community/neo4j/src/test/java/org/neo4j/index/AccessExplicitIndexReadOnlyIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j/src/test/java/org/neo4j/index/BigPropertyIndexValidationIT.java
+++ b/community/neo4j/src/test/java/org/neo4j/index/BigPropertyIndexValidationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j/src/test/java/org/neo4j/index/ExplicitIndexTest.java
+++ b/community/neo4j/src/test/java/org/neo4j/index/ExplicitIndexTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j/src/test/java/org/neo4j/index/IndexFailureOnStartupTest.java
+++ b/community/neo4j/src/test/java/org/neo4j/index/IndexFailureOnStartupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j/src/test/java/org/neo4j/index/IndexFreshDataReadIT.java
+++ b/community/neo4j/src/test/java/org/neo4j/index/IndexFreshDataReadIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j/src/test/java/org/neo4j/index/IndexSamplingIntegrationTest.java
+++ b/community/neo4j/src/test/java/org/neo4j/index/IndexSamplingIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j/src/test/java/org/neo4j/index/IndexTxStateLookupTest.java
+++ b/community/neo4j/src/test/java/org/neo4j/index/IndexTxStateLookupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j/src/test/java/org/neo4j/index/ShutdownOnIndexUpdateIT.java
+++ b/community/neo4j/src/test/java/org/neo4j/index/ShutdownOnIndexUpdateIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j/src/test/java/org/neo4j/index/backup/IndexBackupIT.java
+++ b/community/neo4j/src/test/java/org/neo4j/index/backup/IndexBackupIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j/src/test/java/org/neo4j/kernel/impl/index/schema/IndexCreateIT.java
+++ b/community/neo4j/src/test/java/org/neo4j/kernel/impl/index/schema/IndexCreateIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j/src/test/java/org/neo4j/kernel/impl/index/schema/NativeStringIndexingIT.java
+++ b/community/neo4j/src/test/java/org/neo4j/kernel/impl/index/schema/NativeStringIndexingIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j/src/test/java/org/neo4j/kernel/impl/index/schema/NestedIndexReadersIT.java
+++ b/community/neo4j/src/test/java/org/neo4j/kernel/impl/index/schema/NestedIndexReadersIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j/src/test/java/org/neo4j/kernel/impl/index/schema/RecoverIndexDropIT.java
+++ b/community/neo4j/src/test/java/org/neo4j/kernel/impl/index/schema/RecoverIndexDropIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j/src/test/java/org/neo4j/kernel/impl/index/schema/UniqueIndexSeekIT.java
+++ b/community/neo4j/src/test/java/org/neo4j/kernel/impl/index/schema/UniqueIndexSeekIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j/src/test/java/org/neo4j/kernel/impl/index/schema/tracking/TrackingIndexExtensionFactory.java
+++ b/community/neo4j/src/test/java/org/neo4j/kernel/impl/index/schema/tracking/TrackingIndexExtensionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j/src/test/java/org/neo4j/kernel/impl/index/schema/tracking/TrackingIndexReader.java
+++ b/community/neo4j/src/test/java/org/neo4j/kernel/impl/index/schema/tracking/TrackingIndexReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j/src/test/java/org/neo4j/kernel/impl/index/schema/tracking/TrackingReadersIndexAccessor.java
+++ b/community/neo4j/src/test/java/org/neo4j/kernel/impl/index/schema/tracking/TrackingReadersIndexAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j/src/test/java/org/neo4j/kernel/impl/index/schema/tracking/TrackingReadersIndexProvider.java
+++ b/community/neo4j/src/test/java/org/neo4j/kernel/impl/index/schema/tracking/TrackingReadersIndexProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j/src/test/java/org/neo4j/kernel/impl/storemigration/StoreUpgraderTest.java
+++ b/community/neo4j/src/test/java/org/neo4j/kernel/impl/storemigration/StoreUpgraderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j/src/test/java/org/neo4j/kernel/internal/KernelDiagnosticsIT.java
+++ b/community/neo4j/src/test/java/org/neo4j/kernel/internal/KernelDiagnosticsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j/src/test/java/org/neo4j/locking/CommunityLockAcquisitionTimeoutIT.java
+++ b/community/neo4j/src/test/java/org/neo4j/locking/CommunityLockAcquisitionTimeoutIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j/src/test/java/org/neo4j/locking/QueryExecutionLocksIT.java
+++ b/community/neo4j/src/test/java/org/neo4j/locking/QueryExecutionLocksIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j/src/test/java/org/neo4j/metatest/TestGraphDescription.java
+++ b/community/neo4j/src/test/java/org/neo4j/metatest/TestGraphDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j/src/test/java/org/neo4j/store/watch/FileWatchIT.java
+++ b/community/neo4j/src/test/java/org/neo4j/store/watch/FileWatchIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j/src/test/java/org/neo4j/tracers/PageCacheCountersIT.java
+++ b/community/neo4j/src/test/java/org/neo4j/tracers/PageCacheCountersIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j/src/test/java/org/neo4j/unsafe/impl/batchimport/IdGroupDistribution.java
+++ b/community/neo4j/src/test/java/org/neo4j/unsafe/impl/batchimport/IdGroupDistribution.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j/src/test/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporterTest.java
+++ b/community/neo4j/src/test/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j/src/test/java/recovery/CountsStoreRecoveryTest.java
+++ b/community/neo4j/src/test/java/recovery/CountsStoreRecoveryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j/src/test/java/recovery/RecoveryCleanupIT.java
+++ b/community/neo4j/src/test/java/recovery/RecoveryCleanupIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j/src/test/java/recovery/TestRecoveryMultipleDataSources.java
+++ b/community/neo4j/src/test/java/recovery/TestRecoveryMultipleDataSources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j/src/test/java/recovery/TestRecoveryScenarios.java
+++ b/community/neo4j/src/test/java/recovery/TestRecoveryScenarios.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j/src/test/java/recovery/UniquenessRecoveryTest.java
+++ b/community/neo4j/src/test/java/recovery/UniquenessRecoveryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j/src/test/java/schema/DynamicIndexStoreViewIT.java
+++ b/community/neo4j/src/test/java/schema/DynamicIndexStoreViewIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j/src/test/java/schema/IndexPopulationFlipRaceIT.java
+++ b/community/neo4j/src/test/java/schema/IndexPopulationFlipRaceIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j/src/test/java/schema/IndexPopulationIT.java
+++ b/community/neo4j/src/test/java/schema/IndexPopulationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j/src/test/java/schema/IndexValuesValidationTest.java
+++ b/community/neo4j/src/test/java/schema/IndexValuesValidationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j/src/test/java/schema/MultiIndexPopulationConcurrentUpdatesIT.java
+++ b/community/neo4j/src/test/java/schema/MultiIndexPopulationConcurrentUpdatesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j/src/test/java/schema/MultipleIndexPopulationStressIT.java
+++ b/community/neo4j/src/test/java/schema/MultipleIndexPopulationStressIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j/src/test/java/synchronization/ConcurrentChangesOnEntitiesTest.java
+++ b/community/neo4j/src/test/java/synchronization/ConcurrentChangesOnEntitiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j/src/test/java/synchronization/TestStartTransactionDuringLogRotation.java
+++ b/community/neo4j/src/test/java/synchronization/TestStartTransactionDuringLogRotation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j/src/test/java/upgrade/DatabaseContentVerifier.java
+++ b/community/neo4j/src/test/java/upgrade/DatabaseContentVerifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j/src/test/java/upgrade/PlatformConstraintStoreUpgradeTest.java
+++ b/community/neo4j/src/test/java/upgrade/PlatformConstraintStoreUpgradeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j/src/test/java/upgrade/StoreUpgradeOnStartupTest.java
+++ b/community/neo4j/src/test/java/upgrade/StoreUpgradeOnStartupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j/src/test/java/upgrade/StoreUpgraderInterruptionTestIT.java
+++ b/community/neo4j/src/test/java/upgrade/StoreUpgraderInterruptionTestIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j/src/test/java/visibility/TestDatasourceCommitOrderDataVisibility.java
+++ b/community/neo4j/src/test/java/visibility/TestDatasourceCommitOrderDataVisibility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/neo4j/src/test/java/visibility/TestPropertyReadOnNewEntityBeforeLockRelease.java
+++ b/community/neo4j/src/test/java/visibility/TestPropertyReadOnNewEntityBeforeLockRelease.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/NOTICE.txt
+++ b/community/primitive-collections/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/pool/LinkedQueuePool.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/pool/LinkedQueuePool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/pool/MarshlandPool.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/pool/MarshlandPool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/pool/Pool.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/pool/Pool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/Primitive.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/Primitive.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveArrays.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveArrays.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveCollection.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveCollection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveCommons.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveCommons.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveIntCollection.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveIntCollection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveIntCollections.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveIntCollections.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveIntIterable.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveIntIterable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveIntIterator.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveIntIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveIntLongMap.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveIntLongMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveIntLongVisitor.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveIntLongVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveIntObjectMap.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveIntObjectMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveIntObjectVisitor.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveIntObjectVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveIntSet.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveIntSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveIntStack.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveIntStack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveIntVisitor.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveIntVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveLongArrayQueue.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveLongArrayQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveLongCollection.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveLongCollection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveLongCollections.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveLongCollections.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveLongIntKeyValueArray.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveLongIntKeyValueArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveLongIntMap.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveLongIntMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveLongIntVisitor.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveLongIntVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveLongIterable.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveLongIterable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveLongIterator.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveLongIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveLongList.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveLongList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveLongLongMap.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveLongLongMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveLongLongVisitor.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveLongLongVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveLongObjectMap.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveLongObjectMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveLongObjectVisitor.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveLongObjectVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveLongPeekingIterator.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveLongPeekingIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveLongResourceCollections.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveLongResourceCollections.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveLongResourceIterator.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveLongResourceIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveLongSet.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveLongSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveLongStack.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveLongStack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveLongVisitor.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveLongVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/base/Empty.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/base/Empty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/AbstractHopScotchCollection.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/AbstractHopScotchCollection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/AbstractIntHopScotchCollection.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/AbstractIntHopScotchCollection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/AbstractLongHopScotchCollection.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/AbstractLongHopScotchCollection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/HopScotchHashingAlgorithm.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/HopScotchHashingAlgorithm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/IntArrayBasedKeyTable.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/IntArrayBasedKeyTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/IntKeyLongValueTable.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/IntKeyLongValueTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/IntKeyObjectValueTable.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/IntKeyObjectValueTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/IntKeyTable.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/IntKeyTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/IntKeyUnsafeTable.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/IntKeyUnsafeTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/LongKeyIntValueTable.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/LongKeyIntValueTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/LongKeyLongValueTable.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/LongKeyLongValueTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/LongKeyLongValueUnsafeTable.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/LongKeyLongValueUnsafeTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/LongKeyObjectValueTable.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/LongKeyObjectValueTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/LongKeyTable.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/LongKeyTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/LongKeyUnsafeTable.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/LongKeyUnsafeTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/PowerOfTwoQuantizedTable.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/PowerOfTwoQuantizedTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/PrimitiveIntHashSet.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/PrimitiveIntHashSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/PrimitiveIntLongHashMap.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/PrimitiveIntLongHashMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/PrimitiveIntObjectHashMap.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/PrimitiveIntObjectHashMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/PrimitiveLongHashSet.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/PrimitiveLongHashSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/PrimitiveLongIntHashMap.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/PrimitiveLongIntHashMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/PrimitiveLongLongHashMap.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/PrimitiveLongLongHashMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/PrimitiveLongObjectHashMap.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/PrimitiveLongObjectHashMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/Table.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/Table.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/TableKeyIterator.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/TableKeyIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/UnsafeTable.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/UnsafeTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/concurrent/AsyncApply.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/concurrent/AsyncApply.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/concurrent/AsyncEvent.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/concurrent/AsyncEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/concurrent/AsyncEventSender.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/concurrent/AsyncEventSender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/concurrent/AsyncEvents.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/concurrent/AsyncEvents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/concurrent/BinaryLatch.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/concurrent/BinaryLatch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/concurrent/DecayingFlags.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/concurrent/DecayingFlags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/concurrent/Futures.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/concurrent/Futures.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/concurrent/RecentK.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/concurrent/RecentK.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/concurrent/Runnables.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/concurrent/Runnables.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/concurrent/Work.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/concurrent/Work.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/concurrent/WorkSync.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/concurrent/WorkSync.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/cursor/Cursor.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/cursor/Cursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/cursor/CursorValue.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/cursor/CursorValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/cursor/IOCursor.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/cursor/IOCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/cursor/RawCursor.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/cursor/RawCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/register/Register.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/register/Register.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/main/java/org/neo4j/register/Registers.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/register/Registers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/test/java/org/neo4j/collection/pool/LinkedQueuePoolTest.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/collection/pool/LinkedQueuePoolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/test/java/org/neo4j/collection/pool/MarshlandPoolTest.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/collection/pool/MarshlandPoolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/PrimitiveArraysTest.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/PrimitiveArraysTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/PrimitiveArraysUnionTest.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/PrimitiveArraysUnionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/PrimitiveCollectionsAllocationsTest.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/PrimitiveCollectionsAllocationsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/PrimitiveIntCollectionsTest.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/PrimitiveIntCollectionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/PrimitiveIntStackTest.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/PrimitiveIntStackTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/PrimitiveLongArrayQueueTest.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/PrimitiveLongArrayQueueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/PrimitiveLongCollectionsTest.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/PrimitiveLongCollectionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/PrimitiveLongIntKeyValueArrayTest.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/PrimitiveLongIntKeyValueArrayTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/PrimitiveLongListTest.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/PrimitiveLongListTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/PrimitiveLongPeekingIteratorTest.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/PrimitiveLongPeekingIteratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/PrimitiveLongResourceCollectionsTest.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/PrimitiveLongResourceCollectionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/PrimitiveLongStackTest.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/PrimitiveLongStackTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/hopscotch/BasicTableTest.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/hopscotch/BasicTableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/hopscotch/ClosingTablesTest.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/hopscotch/ClosingTablesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/hopscotch/DebugMonitor.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/hopscotch/DebugMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/hopscotch/HopScotchHashingAlgorithmTest.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/hopscotch/HopScotchHashingAlgorithmTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/hopscotch/JumpingSequencePutTest.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/hopscotch/JumpingSequencePutTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/hopscotch/PrimitiveCollectionEqualityTest.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/hopscotch/PrimitiveCollectionEqualityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/hopscotch/PrimitiveIntObjectHashMapTest.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/hopscotch/PrimitiveIntObjectHashMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/hopscotch/PrimitiveLongIntMapRIT.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/hopscotch/PrimitiveLongIntMapRIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/hopscotch/PrimitiveLongMapTest.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/hopscotch/PrimitiveLongMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/hopscotch/PrimitiveLongObjectMapRIT.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/hopscotch/PrimitiveLongObjectMapRIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/hopscotch/PrimitiveLongSetRIT.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/hopscotch/PrimitiveLongSetRIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/hopscotch/PrimitiveLongSetTest.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/hopscotch/PrimitiveLongSetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/test/java/org/neo4j/concurrent/AsyncEventsTest.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/concurrent/AsyncEventsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/test/java/org/neo4j/concurrent/BinaryLatchTest.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/concurrent/BinaryLatchTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/test/java/org/neo4j/concurrent/DecayingFlagsTest.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/concurrent/DecayingFlagsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/test/java/org/neo4j/concurrent/FuturesTest.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/concurrent/FuturesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/test/java/org/neo4j/concurrent/RecentKTest.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/concurrent/RecentKTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/test/java/org/neo4j/concurrent/WorkSyncTest.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/concurrent/WorkSyncTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/test/java/org/neo4j/test/randomized/Action.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/test/randomized/Action.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/test/java/org/neo4j/test/randomized/LinePrinter.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/test/randomized/LinePrinter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/test/java/org/neo4j/test/randomized/PrintStreamLinePrinter.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/test/randomized/PrintStreamLinePrinter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/test/java/org/neo4j/test/randomized/Printable.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/test/randomized/Printable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/test/java/org/neo4j/test/randomized/RandomizedTester.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/test/randomized/RandomizedTester.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/test/java/org/neo4j/test/randomized/Result.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/test/randomized/Result.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/test/java/org/neo4j/test/randomized/TestCaseWriter.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/test/randomized/TestCaseWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/primitive-collections/src/test/java/org/neo4j/test/randomized/TestResource.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/test/randomized/TestResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-api/NOTICE.txt
+++ b/community/procedure-api/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/community/procedure-api/src/main/java/org/neo4j/procedure/Context.java
+++ b/community/procedure-api/src/main/java/org/neo4j/procedure/Context.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-api/src/main/java/org/neo4j/procedure/Description.java
+++ b/community/procedure-api/src/main/java/org/neo4j/procedure/Description.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-api/src/main/java/org/neo4j/procedure/Mode.java
+++ b/community/procedure-api/src/main/java/org/neo4j/procedure/Mode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-api/src/main/java/org/neo4j/procedure/Name.java
+++ b/community/procedure-api/src/main/java/org/neo4j/procedure/Name.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-api/src/main/java/org/neo4j/procedure/PerformsWrites.java
+++ b/community/procedure-api/src/main/java/org/neo4j/procedure/PerformsWrites.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-api/src/main/java/org/neo4j/procedure/Procedure.java
+++ b/community/procedure-api/src/main/java/org/neo4j/procedure/Procedure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-api/src/main/java/org/neo4j/procedure/ProcedureTransaction.java
+++ b/community/procedure-api/src/main/java/org/neo4j/procedure/ProcedureTransaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-api/src/main/java/org/neo4j/procedure/TerminationGuard.java
+++ b/community/procedure-api/src/main/java/org/neo4j/procedure/TerminationGuard.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-api/src/main/java/org/neo4j/procedure/UserAggregationFunction.java
+++ b/community/procedure-api/src/main/java/org/neo4j/procedure/UserAggregationFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-api/src/main/java/org/neo4j/procedure/UserAggregationResult.java
+++ b/community/procedure-api/src/main/java/org/neo4j/procedure/UserAggregationResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-api/src/main/java/org/neo4j/procedure/UserAggregationUpdate.java
+++ b/community/procedure-api/src/main/java/org/neo4j/procedure/UserAggregationUpdate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-api/src/main/java/org/neo4j/procedure/UserFunction.java
+++ b/community/procedure-api/src/main/java/org/neo4j/procedure/UserFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/integration-tests/NOTICE.txt
+++ b/community/procedure-compiler/integration-tests/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/community/procedure-compiler/integration-tests/src/test/java/org/neo4j/tooling/procedure/ProcedureTest.java
+++ b/community/procedure-compiler/integration-tests/src/test/java/org/neo4j/tooling/procedure/ProcedureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/NOTICE.txt
+++ b/community/procedure-compiler/processor/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/CompilerOptions.java
+++ b/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/CompilerOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/DuplicationAwareBaseProcessor.java
+++ b/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/DuplicationAwareBaseProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/ProcedureProcessor.java
+++ b/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/ProcedureProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/UserAggregationFunctionProcessor.java
+++ b/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/UserAggregationFunctionProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/UserFunctionProcessor.java
+++ b/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/UserFunctionProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/compilerutils/CustomNameExtractor.java
+++ b/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/compilerutils/CustomNameExtractor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/compilerutils/TypeMirrorUtils.java
+++ b/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/compilerutils/TypeMirrorUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/messages/AggregationError.java
+++ b/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/messages/AggregationError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/messages/CompilationMessage.java
+++ b/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/messages/CompilationMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/messages/ContextFieldError.java
+++ b/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/messages/ContextFieldError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/messages/ContextFieldWarning.java
+++ b/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/messages/ContextFieldWarning.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/messages/DuplicatedProcedureError.java
+++ b/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/messages/DuplicatedProcedureError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/messages/ExtensionMissingPublicNoArgConstructor.java
+++ b/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/messages/ExtensionMissingPublicNoArgConstructor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/messages/FieldError.java
+++ b/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/messages/FieldError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/messages/FunctionInRootNamespaceError.java
+++ b/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/messages/FunctionInRootNamespaceError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/messages/MessagePrinter.java
+++ b/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/messages/MessagePrinter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/messages/ParameterMissingAnnotationError.java
+++ b/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/messages/ParameterMissingAnnotationError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/messages/ParameterTypeError.java
+++ b/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/messages/ParameterTypeError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/messages/PerformsWriteMisuseError.java
+++ b/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/messages/PerformsWriteMisuseError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/messages/RecordTypeError.java
+++ b/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/messages/RecordTypeError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/messages/ReturnTypeError.java
+++ b/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/messages/ReturnTypeError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/validators/AllowedTypesValidator.java
+++ b/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/validators/AllowedTypesValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/validators/DuplicatedExtensionValidator.java
+++ b/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/validators/DuplicatedExtensionValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/visitors/AnnotationTypeVisitor.java
+++ b/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/visitors/AnnotationTypeVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/visitors/ContextFieldVisitor.java
+++ b/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/visitors/ContextFieldVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/visitors/ExtensionClassVisitor.java
+++ b/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/visitors/ExtensionClassVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/visitors/FieldVisitor.java
+++ b/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/visitors/FieldVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/visitors/FunctionVisitor.java
+++ b/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/visitors/FunctionVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/visitors/ParameterTypeVisitor.java
+++ b/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/visitors/ParameterTypeVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/visitors/ParameterVisitor.java
+++ b/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/visitors/ParameterVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/visitors/PerformsWriteMethodVisitor.java
+++ b/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/visitors/PerformsWriteMethodVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/visitors/ProcedureVisitor.java
+++ b/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/visitors/ProcedureVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/visitors/QualifiedTypeVisitor.java
+++ b/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/visitors/QualifiedTypeVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/visitors/RecordFieldTypeVisitor.java
+++ b/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/visitors/RecordFieldTypeVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/visitors/RecordTypeVisitor.java
+++ b/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/visitors/RecordTypeVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/visitors/UserAggregationFunctionVisitor.java
+++ b/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/visitors/UserAggregationFunctionVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/visitors/UserFunctionVisitor.java
+++ b/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/visitors/UserFunctionVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/ExtensionTestBase.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/ExtensionTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/ProcedureProcessorTest.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/ProcedureProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/UserAggregationFunctionProcessorTest.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/UserAggregationFunctionProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/UserFunctionProcessorTest.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/UserFunctionProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/compilerutils/CustomNameExtractorTest.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/compilerutils/CustomNameExtractorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/procedures/invalid/aggregation/FunctionWithParameters.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/procedures/invalid/aggregation/FunctionWithParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/procedures/invalid/aggregation/FunctionWithWrongReturnType.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/procedures/invalid/aggregation/FunctionWithWrongReturnType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/procedures/invalid/aggregation/FunctionWithoutAggregationMethods.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/procedures/invalid/aggregation/FunctionWithoutAggregationMethods.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/procedures/invalid/bad_context_field/BadContextFields.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/procedures/invalid/bad_context_field/BadContextFields.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/procedures/invalid/bad_context_field/BadContextRestrictedTypeField.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/procedures/invalid/bad_context_field/BadContextRestrictedTypeField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/procedures/invalid/bad_context_field/BadContextUnsupportedTypeError.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/procedures/invalid/bad_context_field/BadContextUnsupportedTypeError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/procedures/invalid/bad_proc_input_type/BadGenericInputSproc.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/procedures/invalid/bad_proc_input_type/BadGenericInputSproc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/procedures/invalid/bad_proc_input_type/BadGenericInputUserFunction.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/procedures/invalid/bad_proc_input_type/BadGenericInputUserFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/procedures/invalid/bad_proc_input_type/BadPrimitiveInputSproc.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/procedures/invalid/bad_proc_input_type/BadPrimitiveInputSproc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/procedures/invalid/bad_proc_input_type/BadPrimitiveInputUserFunction.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/procedures/invalid/bad_proc_input_type/BadPrimitiveInputUserFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/procedures/invalid/bad_record_field_type/BadRecordGenericFieldType.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/procedures/invalid/bad_record_field_type/BadRecordGenericFieldType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/procedures/invalid/bad_record_field_type/BadRecordGenericFieldTypeSproc.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/procedures/invalid/bad_record_field_type/BadRecordGenericFieldTypeSproc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/procedures/invalid/bad_record_field_type/BadRecordSimpleFieldType.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/procedures/invalid/bad_record_field_type/BadRecordSimpleFieldType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/procedures/invalid/bad_record_field_type/BadRecordSimpleFieldTypeSproc.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/procedures/invalid/bad_record_field_type/BadRecordSimpleFieldTypeSproc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/procedures/invalid/bad_record_type/BadRecord.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/procedures/invalid/bad_record_type/BadRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/procedures/invalid/bad_record_type/BadRecordTypeSproc.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/procedures/invalid/bad_record_type/BadRecordTypeSproc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/procedures/invalid/bad_return_type/BadReturnTypeSproc.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/procedures/invalid/bad_return_type/BadReturnTypeSproc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/procedures/invalid/bad_return_type/BadReturnTypeUserFunction.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/procedures/invalid/bad_return_type/BadReturnTypeUserFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/procedures/invalid/conflicting_mode/ConflictingMode.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/procedures/invalid/conflicting_mode/ConflictingMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/procedures/invalid/duplicated/Sproc1.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/procedures/invalid/duplicated/Sproc1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/procedures/invalid/duplicated/Sproc2.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/procedures/invalid/duplicated/Sproc2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/procedures/invalid/duplicated/UserFunction1.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/procedures/invalid/duplicated/UserFunction1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/procedures/invalid/duplicated/UserFunction2.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/procedures/invalid/duplicated/UserFunction2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/procedures/invalid/missing_constructor/MissingConstructorProcedure.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/procedures/invalid/missing_constructor/MissingConstructorProcedure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/procedures/invalid/missing_name/MissingNameSproc.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/procedures/invalid/missing_name/MissingNameSproc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/procedures/invalid/missing_name/MissingNameUserFunction.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/procedures/invalid/missing_name/MissingNameUserFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/procedures/valid/Procedures.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/procedures/valid/Procedures.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/procedures/valid/Records.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/procedures/valid/Records.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/procedures/valid/UserFunctions.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/procedures/valid/UserFunctions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/testutils/ElementTestUtils.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/testutils/ElementTestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/testutils/JavaFileObjectUtils.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/testutils/JavaFileObjectUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/testutils/TypeMirrorTestUtils.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/testutils/TypeMirrorTestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/validators/AllowedTypesValidatorTest.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/validators/AllowedTypesValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/validators/DuplicatedExtensionValidatorTest.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/validators/DuplicatedExtensionValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/validators/examples/DefaultProcedureA.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/validators/examples/DefaultProcedureA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/validators/examples/DefaultProcedureB.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/validators/examples/DefaultProcedureB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/validators/examples/OverriddenProcedureB.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/validators/examples/OverriddenProcedureB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/validators/examples/override/OverriddenProcedureA.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/validators/examples/override/OverriddenProcedureA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/visitors/ContextFieldVisitorTest.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/visitors/ContextFieldVisitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/visitors/FieldVisitorTest.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/visitors/FieldVisitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/visitors/ParameterTypeVisitorTest.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/visitors/ParameterTypeVisitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/visitors/PerformsWriteMethodVisitorTest.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/visitors/PerformsWriteMethodVisitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/visitors/RecordFieldTypeVisitorTest.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/visitors/RecordFieldTypeVisitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/visitors/RecordTypeVisitorTest.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/visitors/RecordTypeVisitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/visitors/TypeValidationTestSuite.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/visitors/TypeValidationTestSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/visitors/UserAggregationFunctionVisitorTest.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/visitors/UserAggregationFunctionVisitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/visitors/UserFunctionVisitorTest.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/visitors/UserFunctionVisitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/visitors/examples/FinalContextMisuse.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/visitors/examples/FinalContextMisuse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/visitors/examples/GoodContextUse.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/visitors/examples/GoodContextUse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/visitors/examples/InvalidRecord.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/visitors/examples/InvalidRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/visitors/examples/NonPublicContextMisuse.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/visitors/examples/NonPublicContextMisuse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/visitors/examples/PerformsWriteProcedures.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/visitors/examples/PerformsWriteProcedures.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/visitors/examples/RestrictedContextTypes.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/visitors/examples/RestrictedContextTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/visitors/examples/StaticContextMisuse.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/visitors/examples/StaticContextMisuse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/visitors/examples/StaticNonContextMisuse.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/visitors/examples/StaticNonContextMisuse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/visitors/examples/UnknownContextType.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/visitors/examples/UnknownContextType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/visitors/examples/UserAggregationFunctionsExamples.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/visitors/examples/UserAggregationFunctionsExamples.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/visitors/examples/UserFunctionsExamples.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/visitors/examples/UserFunctionsExamples.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/visitors/examples/ValidRecord.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/visitors/examples/ValidRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/push-to-cloud/NOTICE.txt
+++ b/community/push-to-cloud/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgBD
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/community/push-to-cloud/src/main/java/org/neo4j/pushtocloud/HttpCopier.java
+++ b/community/push-to-cloud/src/main/java/org/neo4j/pushtocloud/HttpCopier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/push-to-cloud/src/main/java/org/neo4j/pushtocloud/ProgressTrackingOutputStream.java
+++ b/community/push-to-cloud/src/main/java/org/neo4j/pushtocloud/ProgressTrackingOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/push-to-cloud/src/main/java/org/neo4j/pushtocloud/PushToCloudCommand.java
+++ b/community/push-to-cloud/src/main/java/org/neo4j/pushtocloud/PushToCloudCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/push-to-cloud/src/main/java/org/neo4j/pushtocloud/PushToCloudCommandProvider.java
+++ b/community/push-to-cloud/src/main/java/org/neo4j/pushtocloud/PushToCloudCommandProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/push-to-cloud/src/main/java/org/neo4j/pushtocloud/RealDumpCreator.java
+++ b/community/push-to-cloud/src/main/java/org/neo4j/pushtocloud/RealDumpCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/push-to-cloud/src/test/java/org/neo4j/pushtocloud/ControlledOutsideWorld.java
+++ b/community/push-to-cloud/src/test/java/org/neo4j/pushtocloud/ControlledOutsideWorld.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/push-to-cloud/src/test/java/org/neo4j/pushtocloud/HttpCopierTest.java
+++ b/community/push-to-cloud/src/test/java/org/neo4j/pushtocloud/HttpCopierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/push-to-cloud/src/test/java/org/neo4j/pushtocloud/ProgressTrackingOutputStreamTest.java
+++ b/community/push-to-cloud/src/test/java/org/neo4j/pushtocloud/ProgressTrackingOutputStreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/push-to-cloud/src/test/java/org/neo4j/pushtocloud/PushToCloudCommandTest.java
+++ b/community/push-to-cloud/src/test/java/org/neo4j/pushtocloud/PushToCloudCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/community/resource/NOTICE.txt
+++ b/community/resource/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/community/resource/src/main/java/org/neo4j/graphdb/Resource.java
+++ b/community/resource/src/main/java/org/neo4j/graphdb/Resource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/resource/src/main/java/org/neo4j/graphdb/ResourceIterable.java
+++ b/community/resource/src/main/java/org/neo4j/graphdb/ResourceIterable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/resource/src/main/java/org/neo4j/graphdb/ResourceIterator.java
+++ b/community/resource/src/main/java/org/neo4j/graphdb/ResourceIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/resource/src/main/java/org/neo4j/graphdb/ResourceUtils.java
+++ b/community/resource/src/main/java/org/neo4j/graphdb/ResourceUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/security/NOTICE.txt
+++ b/community/security/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/community/security/src/main/java/org/neo4j/commandline/admin/security/AuthenticationCommandSection.java
+++ b/community/security/src/main/java/org/neo4j/commandline/admin/security/AuthenticationCommandSection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/security/src/main/java/org/neo4j/commandline/admin/security/SetDefaultAdminCommand.java
+++ b/community/security/src/main/java/org/neo4j/commandline/admin/security/SetDefaultAdminCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/security/src/main/java/org/neo4j/commandline/admin/security/SetDefaultAdminCommandProvider.java
+++ b/community/security/src/main/java/org/neo4j/commandline/admin/security/SetDefaultAdminCommandProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/security/src/main/java/org/neo4j/commandline/admin/security/SetInitialPasswordCommand.java
+++ b/community/security/src/main/java/org/neo4j/commandline/admin/security/SetInitialPasswordCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/security/src/main/java/org/neo4j/commandline/admin/security/SetInitialPasswordCommandProvider.java
+++ b/community/security/src/main/java/org/neo4j/commandline/admin/security/SetInitialPasswordCommandProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/security/src/main/java/org/neo4j/server/security/auth/AbstractUserRepository.java
+++ b/community/security/src/main/java/org/neo4j/server/security/auth/AbstractUserRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/security/src/main/java/org/neo4j/server/security/auth/AuthProcedures.java
+++ b/community/security/src/main/java/org/neo4j/server/security/auth/AuthProcedures.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/security/src/main/java/org/neo4j/server/security/auth/AuthenticationStrategy.java
+++ b/community/security/src/main/java/org/neo4j/server/security/auth/AuthenticationStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/security/src/main/java/org/neo4j/server/security/auth/BasicAuthManager.java
+++ b/community/security/src/main/java/org/neo4j/server/security/auth/BasicAuthManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/security/src/main/java/org/neo4j/server/security/auth/BasicLoginContext.java
+++ b/community/security/src/main/java/org/neo4j/server/security/auth/BasicLoginContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/security/src/main/java/org/neo4j/server/security/auth/BasicPasswordPolicy.java
+++ b/community/security/src/main/java/org/neo4j/server/security/auth/BasicPasswordPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/security/src/main/java/org/neo4j/server/security/auth/CommunitySecurityModule.java
+++ b/community/security/src/main/java/org/neo4j/server/security/auth/CommunitySecurityModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/security/src/main/java/org/neo4j/server/security/auth/FileRepositorySerializer.java
+++ b/community/security/src/main/java/org/neo4j/server/security/auth/FileRepositorySerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/security/src/main/java/org/neo4j/server/security/auth/FileUserRepository.java
+++ b/community/security/src/main/java/org/neo4j/server/security/auth/FileUserRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/security/src/main/java/org/neo4j/server/security/auth/ListSnapshot.java
+++ b/community/security/src/main/java/org/neo4j/server/security/auth/ListSnapshot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/security/src/main/java/org/neo4j/server/security/auth/RateLimitedAuthenticationStrategy.java
+++ b/community/security/src/main/java/org/neo4j/server/security/auth/RateLimitedAuthenticationStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/security/src/main/java/org/neo4j/server/security/auth/UserRepository.java
+++ b/community/security/src/main/java/org/neo4j/server/security/auth/UserRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/security/src/main/java/org/neo4j/server/security/auth/UserSerialization.java
+++ b/community/security/src/main/java/org/neo4j/server/security/auth/UserSerialization.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/security/src/main/java/org/neo4j/server/security/auth/exception/ConcurrentModificationException.java
+++ b/community/security/src/main/java/org/neo4j/server/security/auth/exception/ConcurrentModificationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/security/src/main/java/org/neo4j/server/security/auth/exception/FormatException.java
+++ b/community/security/src/main/java/org/neo4j/server/security/auth/exception/FormatException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/security/src/test/java/org/neo4j/commandline/admin/security/SetDefaultAdminCommandIT.java
+++ b/community/security/src/test/java/org/neo4j/commandline/admin/security/SetDefaultAdminCommandIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/security/src/test/java/org/neo4j/commandline/admin/security/SetDefaultAdminCommandTest.java
+++ b/community/security/src/test/java/org/neo4j/commandline/admin/security/SetDefaultAdminCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/security/src/test/java/org/neo4j/commandline/admin/security/SetInitialPasswordCommandIT.java
+++ b/community/security/src/test/java/org/neo4j/commandline/admin/security/SetInitialPasswordCommandIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/security/src/test/java/org/neo4j/commandline/admin/security/SetInitialPasswordCommandTest.java
+++ b/community/security/src/test/java/org/neo4j/commandline/admin/security/SetInitialPasswordCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/security/src/test/java/org/neo4j/kernel/impl/security/CredentialTest.java
+++ b/community/security/src/test/java/org/neo4j/kernel/impl/security/CredentialTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/security/src/test/java/org/neo4j/server/security/auth/AuthProceduresIT.java
+++ b/community/security/src/test/java/org/neo4j/server/security/auth/AuthProceduresIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/security/src/test/java/org/neo4j/server/security/auth/AuthProceduresTest.java
+++ b/community/security/src/test/java/org/neo4j/server/security/auth/AuthProceduresTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/security/src/test/java/org/neo4j/server/security/auth/BasicAuthManagerTest.java
+++ b/community/security/src/test/java/org/neo4j/server/security/auth/BasicAuthManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/security/src/test/java/org/neo4j/server/security/auth/FileUserRepositoryTest.java
+++ b/community/security/src/test/java/org/neo4j/server/security/auth/FileUserRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/security/src/test/java/org/neo4j/server/security/auth/InMemoryUserRepository.java
+++ b/community/security/src/test/java/org/neo4j/server/security/auth/InMemoryUserRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/security/src/test/java/org/neo4j/server/security/auth/InitialUserTest.java
+++ b/community/security/src/test/java/org/neo4j/server/security/auth/InitialUserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/security/src/test/java/org/neo4j/server/security/auth/RateLimitedAuthenticationStrategyTest.java
+++ b/community/security/src/test/java/org/neo4j/server/security/auth/RateLimitedAuthenticationStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/security/src/test/java/org/neo4j/server/security/auth/SecurityContextDescriptionTest.java
+++ b/community/security/src/test/java/org/neo4j/server/security/auth/SecurityContextDescriptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/security/src/test/java/org/neo4j/server/security/auth/SecurityTestUtils.java
+++ b/community/security/src/test/java/org/neo4j/server/security/auth/SecurityTestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/security/src/test/java/org/neo4j/server/security/auth/UserSerializationTest.java
+++ b/community/security/src/test/java/org/neo4j/server/security/auth/UserSerializationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/security/src/test/java/org/neo4j/server/security/auth/UserTest.java
+++ b/community/security/src/test/java/org/neo4j/server/security/auth/UserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server-api/NOTICE.txt
+++ b/community/server-api/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/community/server-api/src/main/java/org/neo4j/server/helpers/PropertyTypeDispatcher.java
+++ b/community/server-api/src/main/java/org/neo4j/server/helpers/PropertyTypeDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server-api/src/main/java/org/neo4j/server/plugins/BadPluginInvocationException.java
+++ b/community/server-api/src/main/java/org/neo4j/server/plugins/BadPluginInvocationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server-api/src/main/java/org/neo4j/server/plugins/Description.java
+++ b/community/server-api/src/main/java/org/neo4j/server/plugins/Description.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server-api/src/main/java/org/neo4j/server/plugins/Injectable.java
+++ b/community/server-api/src/main/java/org/neo4j/server/plugins/Injectable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server-api/src/main/java/org/neo4j/server/plugins/Name.java
+++ b/community/server-api/src/main/java/org/neo4j/server/plugins/Name.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server-api/src/main/java/org/neo4j/server/plugins/Parameter.java
+++ b/community/server-api/src/main/java/org/neo4j/server/plugins/Parameter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server-api/src/main/java/org/neo4j/server/plugins/ParameterDescriptionConsumer.java
+++ b/community/server-api/src/main/java/org/neo4j/server/plugins/ParameterDescriptionConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server-api/src/main/java/org/neo4j/server/plugins/ParameterList.java
+++ b/community/server-api/src/main/java/org/neo4j/server/plugins/ParameterList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server-api/src/main/java/org/neo4j/server/plugins/PluginInvocationFailureException.java
+++ b/community/server-api/src/main/java/org/neo4j/server/plugins/PluginInvocationFailureException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server-api/src/main/java/org/neo4j/server/plugins/PluginLifecycle.java
+++ b/community/server-api/src/main/java/org/neo4j/server/plugins/PluginLifecycle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server-api/src/main/java/org/neo4j/server/plugins/PluginLookupException.java
+++ b/community/server-api/src/main/java/org/neo4j/server/plugins/PluginLookupException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server-api/src/main/java/org/neo4j/server/plugins/PluginPoint.java
+++ b/community/server-api/src/main/java/org/neo4j/server/plugins/PluginPoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server-api/src/main/java/org/neo4j/server/plugins/PluginPointFactory.java
+++ b/community/server-api/src/main/java/org/neo4j/server/plugins/PluginPointFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server-api/src/main/java/org/neo4j/server/plugins/PluginTarget.java
+++ b/community/server-api/src/main/java/org/neo4j/server/plugins/PluginTarget.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server-api/src/main/java/org/neo4j/server/plugins/ServerExtender.java
+++ b/community/server-api/src/main/java/org/neo4j/server/plugins/ServerExtender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server-api/src/main/java/org/neo4j/server/plugins/ServerPlugin.java
+++ b/community/server-api/src/main/java/org/neo4j/server/plugins/ServerPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server-api/src/main/java/org/neo4j/server/plugins/Source.java
+++ b/community/server-api/src/main/java/org/neo4j/server/plugins/Source.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server-api/src/main/java/org/neo4j/server/rest/repr/BadInputException.java
+++ b/community/server-api/src/main/java/org/neo4j/server/rest/repr/BadInputException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server-api/src/main/java/org/neo4j/server/rest/repr/ExtensibleRepresentation.java
+++ b/community/server-api/src/main/java/org/neo4j/server/rest/repr/ExtensibleRepresentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server-api/src/main/java/org/neo4j/server/rest/repr/ExtensionInjector.java
+++ b/community/server-api/src/main/java/org/neo4j/server/rest/repr/ExtensionInjector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server-api/src/main/java/org/neo4j/server/rest/repr/FullPath.java
+++ b/community/server-api/src/main/java/org/neo4j/server/rest/repr/FullPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server-api/src/main/java/org/neo4j/server/rest/repr/InputFormat.java
+++ b/community/server-api/src/main/java/org/neo4j/server/rest/repr/InputFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server-api/src/main/java/org/neo4j/server/rest/repr/InvalidArgumentsException.java
+++ b/community/server-api/src/main/java/org/neo4j/server/rest/repr/InvalidArgumentsException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server-api/src/main/java/org/neo4j/server/rest/repr/ListRepresentation.java
+++ b/community/server-api/src/main/java/org/neo4j/server/rest/repr/ListRepresentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server-api/src/main/java/org/neo4j/server/rest/repr/ListSerializer.java
+++ b/community/server-api/src/main/java/org/neo4j/server/rest/repr/ListSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server-api/src/main/java/org/neo4j/server/rest/repr/ListWriter.java
+++ b/community/server-api/src/main/java/org/neo4j/server/rest/repr/ListWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server-api/src/main/java/org/neo4j/server/rest/repr/MappingRepresentation.java
+++ b/community/server-api/src/main/java/org/neo4j/server/rest/repr/MappingRepresentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server-api/src/main/java/org/neo4j/server/rest/repr/MappingSerializer.java
+++ b/community/server-api/src/main/java/org/neo4j/server/rest/repr/MappingSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server-api/src/main/java/org/neo4j/server/rest/repr/MappingWriter.java
+++ b/community/server-api/src/main/java/org/neo4j/server/rest/repr/MappingWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server-api/src/main/java/org/neo4j/server/rest/repr/Representation.java
+++ b/community/server-api/src/main/java/org/neo4j/server/rest/repr/Representation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server-api/src/main/java/org/neo4j/server/rest/repr/RepresentationFormat.java
+++ b/community/server-api/src/main/java/org/neo4j/server/rest/repr/RepresentationFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server-api/src/main/java/org/neo4j/server/rest/repr/RepresentationType.java
+++ b/community/server-api/src/main/java/org/neo4j/server/rest/repr/RepresentationType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server-api/src/main/java/org/neo4j/server/rest/repr/Serializer.java
+++ b/community/server-api/src/main/java/org/neo4j/server/rest/repr/Serializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server-api/src/main/java/org/neo4j/server/rest/repr/ValueRepresentation.java
+++ b/community/server-api/src/main/java/org/neo4j/server/rest/repr/ValueRepresentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server-api/src/main/java/org/neo4j/server/rest/web/NodeNotFoundException.java
+++ b/community/server-api/src/main/java/org/neo4j/server/rest/web/NodeNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server-api/src/main/java/org/neo4j/server/rest/web/RelationshipNotFoundException.java
+++ b/community/server-api/src/main/java/org/neo4j/server/rest/web/RelationshipNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server-api/src/test/java/org/neo4j/server/rest/repr/SerializerTest.java
+++ b/community/server-api/src/test/java/org/neo4j/server/rest/repr/SerializerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server-plugin-test/NOTICE.txt
+++ b/community/server-plugin-test/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/community/server-plugin-test/src/test/java/org/neo4j/server/plugins/CloneSubgraphPluginTestIT.java
+++ b/community/server-plugin-test/src/test/java/org/neo4j/server/plugins/CloneSubgraphPluginTestIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server-plugin-test/src/test/java/org/neo4j/server/plugins/ExtensionListingFunctionalTestIT.java
+++ b/community/server-plugin-test/src/test/java/org/neo4j/server/plugins/ExtensionListingFunctionalTestIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server-plugin-test/src/test/java/org/neo4j/server/plugins/FunctionalTestPlugin.java
+++ b/community/server-plugin-test/src/test/java/org/neo4j/server/plugins/FunctionalTestPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server-plugin-test/src/test/java/org/neo4j/server/plugins/GraphCloner.java
+++ b/community/server-plugin-test/src/test/java/org/neo4j/server/plugins/GraphCloner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server-plugin-test/src/test/java/org/neo4j/server/plugins/Plugin.java
+++ b/community/server-plugin-test/src/test/java/org/neo4j/server/plugins/Plugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server-plugin-test/src/test/java/org/neo4j/server/plugins/PluginFunctionalTestHelper.java
+++ b/community/server-plugin-test/src/test/java/org/neo4j/server/plugins/PluginFunctionalTestHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server-plugin-test/src/test/java/org/neo4j/server/plugins/PluginFunctionalTestIT.java
+++ b/community/server-plugin-test/src/test/java/org/neo4j/server/plugins/PluginFunctionalTestIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server-plugin-test/src/test/java/org/neo4j/server/plugins/PluginManagerTest.java
+++ b/community/server-plugin-test/src/test/java/org/neo4j/server/plugins/PluginManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/NOTICE.txt
+++ b/community/server/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/community/server/src/main/java/org/neo4j/server/AbstractNeoServer.java
+++ b/community/server/src/main/java/org/neo4j/server/AbstractNeoServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/BlockingBootstrapper.java
+++ b/community/server/src/main/java/org/neo4j/server/BlockingBootstrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/Bootstrapper.java
+++ b/community/server/src/main/java/org/neo4j/server/Bootstrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/CommunityBootstrapper.java
+++ b/community/server/src/main/java/org/neo4j/server/CommunityBootstrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/CommunityEntryPoint.java
+++ b/community/server/src/main/java/org/neo4j/server/CommunityEntryPoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/CommunityNeoServer.java
+++ b/community/server/src/main/java/org/neo4j/server/CommunityNeoServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/LoggingProvider.java
+++ b/community/server/src/main/java/org/neo4j/server/LoggingProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/NeoServer.java
+++ b/community/server/src/main/java/org/neo4j/server/NeoServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/NeoServerProvider.java
+++ b/community/server/src/main/java/org/neo4j/server/NeoServerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/ServerBootstrapper.java
+++ b/community/server/src/main/java/org/neo4j/server/ServerBootstrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/ServerCommandLineArgs.java
+++ b/community/server/src/main/java/org/neo4j/server/ServerCommandLineArgs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/ServerStartupException.java
+++ b/community/server/src/main/java/org/neo4j/server/ServerStartupException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/configuration/ServerSettings.java
+++ b/community/server/src/main/java/org/neo4j/server/configuration/ServerSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/configuration/ThirdPartyJaxRsPackage.java
+++ b/community/server/src/main/java/org/neo4j/server/configuration/ThirdPartyJaxRsPackage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/database/CypherExecutor.java
+++ b/community/server/src/main/java/org/neo4j/server/database/CypherExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/database/CypherExecutorProvider.java
+++ b/community/server/src/main/java/org/neo4j/server/database/CypherExecutorProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/database/Database.java
+++ b/community/server/src/main/java/org/neo4j/server/database/Database.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/database/DatabaseProvider.java
+++ b/community/server/src/main/java/org/neo4j/server/database/DatabaseProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/database/GraphDatabaseServiceProvider.java
+++ b/community/server/src/main/java/org/neo4j/server/database/GraphDatabaseServiceProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/database/InjectableProvider.java
+++ b/community/server/src/main/java/org/neo4j/server/database/InjectableProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/database/LifecycleManagingDatabase.java
+++ b/community/server/src/main/java/org/neo4j/server/database/LifecycleManagingDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/database/WrappedDatabase.java
+++ b/community/server/src/main/java/org/neo4j/server/database/WrappedDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/diagnostics/ServerDiagnosticsOfflineReportProvider.java
+++ b/community/server/src/main/java/org/neo4j/server/diagnostics/ServerDiagnosticsOfflineReportProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/exception/ServerStartupErrors.java
+++ b/community/server/src/main/java/org/neo4j/server/exception/ServerStartupErrors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/exception/UpgradeDisallowedStartupException.java
+++ b/community/server/src/main/java/org/neo4j/server/exception/UpgradeDisallowedStartupException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/logging/JULBridge.java
+++ b/community/server/src/main/java/org/neo4j/server/logging/JULBridge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/logging/JettyLogBridge.java
+++ b/community/server/src/main/java/org/neo4j/server/logging/JettyLogBridge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/modules/AuthorizationModule.java
+++ b/community/server/src/main/java/org/neo4j/server/modules/AuthorizationModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/modules/ConsoleModule.java
+++ b/community/server/src/main/java/org/neo4j/server/modules/ConsoleModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/modules/DBMSModule.java
+++ b/community/server/src/main/java/org/neo4j/server/modules/DBMSModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/modules/ExtensionInitializer.java
+++ b/community/server/src/main/java/org/neo4j/server/modules/ExtensionInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/modules/ManagementApiModule.java
+++ b/community/server/src/main/java/org/neo4j/server/modules/ManagementApiModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/modules/Neo4jBrowserModule.java
+++ b/community/server/src/main/java/org/neo4j/server/modules/Neo4jBrowserModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/modules/RESTApiModule.java
+++ b/community/server/src/main/java/org/neo4j/server/modules/RESTApiModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/modules/SecurityRulesModule.java
+++ b/community/server/src/main/java/org/neo4j/server/modules/SecurityRulesModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/modules/ServerModule.java
+++ b/community/server/src/main/java/org/neo4j/server/modules/ServerModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/modules/ThirdPartyJAXRSModule.java
+++ b/community/server/src/main/java/org/neo4j/server/modules/ThirdPartyJAXRSModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/plugins/BooleanTypeCaster.java
+++ b/community/server/src/main/java/org/neo4j/server/plugins/BooleanTypeCaster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/plugins/ByteTypeCaster.java
+++ b/community/server/src/main/java/org/neo4j/server/plugins/ByteTypeCaster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/plugins/CharacterTypeCaster.java
+++ b/community/server/src/main/java/org/neo4j/server/plugins/CharacterTypeCaster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/plugins/ConfigAdapter.java
+++ b/community/server/src/main/java/org/neo4j/server/plugins/ConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/plugins/DataExtractor.java
+++ b/community/server/src/main/java/org/neo4j/server/plugins/DataExtractor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/plugins/DoubleTypeCaster.java
+++ b/community/server/src/main/java/org/neo4j/server/plugins/DoubleTypeCaster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/plugins/FloatTypeCaster.java
+++ b/community/server/src/main/java/org/neo4j/server/plugins/FloatTypeCaster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/plugins/IntegerTypeCaster.java
+++ b/community/server/src/main/java/org/neo4j/server/plugins/IntegerTypeCaster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/plugins/ListParameterExtractor.java
+++ b/community/server/src/main/java/org/neo4j/server/plugins/ListParameterExtractor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/plugins/LongTypeCaster.java
+++ b/community/server/src/main/java/org/neo4j/server/plugins/LongTypeCaster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/plugins/MapTypeCaster.java
+++ b/community/server/src/main/java/org/neo4j/server/plugins/MapTypeCaster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/plugins/NodeTypeCaster.java
+++ b/community/server/src/main/java/org/neo4j/server/plugins/NodeTypeCaster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/plugins/ParameterExtractor.java
+++ b/community/server/src/main/java/org/neo4j/server/plugins/ParameterExtractor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/plugins/PluginInvocator.java
+++ b/community/server/src/main/java/org/neo4j/server/plugins/PluginInvocator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/plugins/PluginInvocatorProvider.java
+++ b/community/server/src/main/java/org/neo4j/server/plugins/PluginInvocatorProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/plugins/PluginManager.java
+++ b/community/server/src/main/java/org/neo4j/server/plugins/PluginManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/plugins/PluginMethod.java
+++ b/community/server/src/main/java/org/neo4j/server/plugins/PluginMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/plugins/PluginPointFactoryImpl.java
+++ b/community/server/src/main/java/org/neo4j/server/plugins/PluginPointFactoryImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/plugins/RelationshipTypeCaster.java
+++ b/community/server/src/main/java/org/neo4j/server/plugins/RelationshipTypeCaster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/plugins/RelationshipTypeTypeCaster.java
+++ b/community/server/src/main/java/org/neo4j/server/plugins/RelationshipTypeTypeCaster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/plugins/ResultConverter.java
+++ b/community/server/src/main/java/org/neo4j/server/plugins/ResultConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/plugins/SPIPluginLifecycle.java
+++ b/community/server/src/main/java/org/neo4j/server/plugins/SPIPluginLifecycle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/plugins/ShortTypeCaster.java
+++ b/community/server/src/main/java/org/neo4j/server/plugins/ShortTypeCaster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/plugins/SourceExtractor.java
+++ b/community/server/src/main/java/org/neo4j/server/plugins/SourceExtractor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/plugins/StringTypeCaster.java
+++ b/community/server/src/main/java/org/neo4j/server/plugins/StringTypeCaster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/plugins/TypeCaster.java
+++ b/community/server/src/main/java/org/neo4j/server/plugins/TypeCaster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/plugins/URLTypeCaster.java
+++ b/community/server/src/main/java/org/neo4j/server/plugins/URLTypeCaster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/plugins/UriTypeCaster.java
+++ b/community/server/src/main/java/org/neo4j/server/plugins/UriTypeCaster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/preflight/PreFlightTasks.java
+++ b/community/server/src/main/java/org/neo4j/server/preflight/PreFlightTasks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/preflight/PreflightTask.java
+++ b/community/server/src/main/java/org/neo4j/server/preflight/PreflightTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/batch/BatchOperationResults.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/batch/BatchOperationResults.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/batch/BatchOperations.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/batch/BatchOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/batch/NonStreamingBatchOperations.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/batch/NonStreamingBatchOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/batch/StreamingBatchOperationResults.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/batch/StreamingBatchOperationResults.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/dbms/AuthorizationDisabledFilter.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/dbms/AuthorizationDisabledFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/dbms/AuthorizationEnabledFilter.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/dbms/AuthorizationEnabledFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/dbms/AuthorizationFilter.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/dbms/AuthorizationFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/dbms/AuthorizationHeaders.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/dbms/AuthorizationHeaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/dbms/AuthorizedRequestWrapper.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/dbms/AuthorizedRequestWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/dbms/DelegatingPrincipal.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/dbms/DelegatingPrincipal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/dbms/UserService.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/dbms/UserService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/discovery/DiscoveryService.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/discovery/DiscoveryService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/domain/BatchOperationFailedException.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/domain/BatchOperationFailedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/domain/EndNodeNotFoundException.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/domain/EndNodeNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/domain/EvaluationException.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/domain/EvaluationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/domain/EvaluatorFactory.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/domain/EvaluatorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/domain/GraphDatabaseName.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/domain/GraphDatabaseName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/domain/HtmlHelper.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/domain/HtmlHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/domain/JsonBuildRuntimeException.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/domain/JsonBuildRuntimeException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/domain/JsonHelper.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/domain/JsonHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/domain/JsonParseException.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/domain/JsonParseException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/domain/PropertySettingStrategy.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/domain/PropertySettingStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/domain/RelationshipDirection.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/domain/RelationshipDirection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/domain/RelationshipExpanderBuilder.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/domain/RelationshipExpanderBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/domain/StartNodeNotFoundException.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/domain/StartNodeNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/domain/TraversalDescriptionBuilder.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/domain/TraversalDescriptionBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/domain/TraverserReturnType.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/domain/TraverserReturnType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/domain/URIHelper.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/domain/URIHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/management/AdvertisableService.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/management/AdvertisableService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/management/JmxService.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/management/JmxService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/management/RootService.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/management/RootService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/management/VersionAndEditionService.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/management/VersionAndEditionService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/management/console/ConsoleService.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/management/console/ConsoleService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/management/console/ConsoleSessionCreator.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/management/console/ConsoleSessionCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/management/console/ConsoleSessionFactory.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/management/console/ConsoleSessionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/management/console/CypherSession.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/management/console/CypherSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/management/console/CypherSessionCreator.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/management/console/CypherSessionCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/management/console/ScriptSession.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/management/console/ScriptSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/management/console/SessionFactoryImpl.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/management/console/SessionFactoryImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/management/console/ShellSession.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/management/console/ShellSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/management/console/ShellSessionCreator.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/management/console/ShellSessionCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/management/repr/ConsoleServiceRepresentation.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/management/repr/ConsoleServiceRepresentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/management/repr/JmxAttributeRepresentation.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/management/repr/JmxAttributeRepresentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/management/repr/JmxAttributeRepresentationDispatcher.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/management/repr/JmxAttributeRepresentationDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/management/repr/JmxCompositeDataRepresentation.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/management/repr/JmxCompositeDataRepresentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/management/repr/JmxDomainRepresentation.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/management/repr/JmxDomainRepresentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/management/repr/JmxMBeanRepresentation.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/management/repr/JmxMBeanRepresentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/management/repr/NameDescriptionValueRepresentation.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/management/repr/NameDescriptionValueRepresentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/management/repr/ServerRootRepresentation.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/management/repr/ServerRootRepresentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/management/repr/ServiceDefinitionRepresentation.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/management/repr/ServiceDefinitionRepresentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/paging/Leasable.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/paging/Leasable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/paging/Lease.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/paging/Lease.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/paging/LeaseAlreadyExpiredException.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/paging/LeaseAlreadyExpiredException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/paging/LeaseManager.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/paging/LeaseManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/paging/LeaseManagerProvider.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/paging/LeaseManagerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/paging/PagedTraverser.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/paging/PagedTraverser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/AccessDeniedDiscoveryRepresentation.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/AccessDeniedDiscoveryRepresentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/AuthorizationRepresentation.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/AuthorizationRepresentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/ConstraintDefinitionRepresentation.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/ConstraintDefinitionRepresentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/CypherPlanRepresentation.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/CypherPlanRepresentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/CypherRepresentationDispatcher.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/CypherRepresentationDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/CypherResultRepresentation.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/CypherResultRepresentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/CypherStatisticsRepresentation.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/CypherStatisticsRepresentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/DatabaseRepresentation.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/DatabaseRepresentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/DefaultFormat.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/DefaultFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/DiscoveryRepresentation.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/DiscoveryRepresentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/EntityRepresentation.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/EntityRepresentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/ExceptionRepresentation.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/ExceptionRepresentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/ExtensionPointRepresentation.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/ExtensionPointRepresentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/FullPathRepresentation.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/FullPathRepresentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/IndexDefinitionRepresentation.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/IndexDefinitionRepresentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/IndexRepresentation.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/IndexRepresentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/IndexedEntityRepresentation.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/IndexedEntityRepresentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/InputFormatProvider.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/InputFormatProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/ListEntityRepresentation.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/ListEntityRepresentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/MapRepresentation.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/MapRepresentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/MediaTypeNotSupportedException.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/MediaTypeNotSupportedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/NodeAutoIndexRepresentation.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/NodeAutoIndexRepresentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/NodeIndexRepresentation.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/NodeIndexRepresentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/NodeIndexRootRepresentation.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/NodeIndexRootRepresentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/NodeRepresentation.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/NodeRepresentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/ObjectRepresentation.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/ObjectRepresentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/ObjectToRepresentationConverter.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/ObjectToRepresentationConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/OutputFormat.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/OutputFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/OutputFormatProvider.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/OutputFormatProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/PathRepresentation.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/PathRepresentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/PropertiesRepresentation.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/PropertiesRepresentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/RelationshipAutoIndexRepresentation.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/RelationshipAutoIndexRepresentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/RelationshipIndexRepresentation.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/RelationshipIndexRepresentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/RelationshipIndexRootRepresentation.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/RelationshipIndexRootRepresentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/RelationshipRepresentation.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/RelationshipRepresentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/RepresentationDispatcher.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/RepresentationDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/RepresentationExceptionHandlingIterable.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/RepresentationExceptionHandlingIterable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/RepresentationFormatRepository.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/RepresentationFormatRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/RepresentationWriteHandler.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/RepresentationWriteHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/ScoredEntityRepresentation.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/ScoredEntityRepresentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/ScoredNodeRepresentation.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/ScoredNodeRepresentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/ScoredRelationshipRepresentation.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/ScoredRelationshipRepresentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/ServerExtensionRepresentation.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/ServerExtensionRepresentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/ServerListRepresentation.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/ServerListRepresentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/StreamingFormat.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/StreamingFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/WeightedPathRepresentation.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/WeightedPathRepresentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/formats/CompactJsonFormat.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/formats/CompactJsonFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/formats/HtmlFormat.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/formats/HtmlFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/formats/JsonFormat.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/formats/JsonFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/formats/ListWrappingWriter.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/formats/ListWrappingWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/formats/MapWrappingWriter.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/formats/MapWrappingWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/formats/NullFormat.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/formats/NullFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/formats/StreamingJsonFormat.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/formats/StreamingJsonFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/formats/UrlFormFormat.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/formats/UrlFormFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/util/RFC1123.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/util/RFC1123.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/security/AuthenticationException.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/security/AuthenticationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/security/AuthenticationExceptionMapper.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/security/AuthenticationExceptionMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/security/ForbiddingSecurityRule.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/security/ForbiddingSecurityRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/security/SecurityFilter.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/security/SecurityFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/security/SecurityRule.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/security/SecurityRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/security/UriPathWildcardMatcher.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/security/UriPathWildcardMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/AggregatingWriter.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/AggregatingWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/CommitOnSuccessfulStatusCodeRepresentationWriteHandler.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/CommitOnSuccessfulStatusCodeRepresentationWriteHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/DeserializationException.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/DeserializationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/ExecutionResultSerializer.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/ExecutionResultSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/GraphExtractionWriter.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/GraphExtractionWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/Neo4jJsonCodec.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/Neo4jJsonCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/RestRepresentationWriter.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/RestRepresentationWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/ResultDataContent.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/ResultDataContent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/ResultDataContentWriter.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/ResultDataContentWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/RowWriter.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/RowWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/Statement.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/Statement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/StatementDeserializer.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/StatementDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/TransactionFacade.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/TransactionFacade.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/TransactionFilter.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/TransactionFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/TransactionHandle.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/TransactionHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/TransactionHandleRegistry.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/TransactionHandleRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/TransactionRegistry.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/TransactionRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/TransactionStateChecker.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/TransactionStateChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/TransactionTerminationHandle.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/TransactionTerminationHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/TransactionalRequestDispatcher.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/TransactionalRequestDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/TransitionalPeriodTransactionMessContainer.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/TransitionalPeriodTransactionMessContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/TransitionalTxManagementKernelTransaction.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/TransitionalTxManagementKernelTransaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/error/InternalBeginTransactionError.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/error/InternalBeginTransactionError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/error/InvalidConcurrentTransactionAccess.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/error/InvalidConcurrentTransactionAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/error/InvalidTransactionId.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/error/InvalidTransactionId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/error/Neo4jError.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/error/Neo4jError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/error/TransactionLifecycleException.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/error/TransactionLifecycleException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/web/BatchOperationService.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/web/BatchOperationService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/web/CollectUserAgentFilter.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/web/CollectUserAgentFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/web/CorsFilter.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/web/CorsFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/web/CustomStatusType.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/web/CustomStatusType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/web/CypherService.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/web/CypherService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/web/DatabaseActions.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/web/DatabaseActions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/web/DatabaseMetadataService.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/web/DatabaseMetadataService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/web/ExtensionService.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/web/ExtensionService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/web/HttpConnectionInfoFactory.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/web/HttpConnectionInfoFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/web/InternalJettyServletRequest.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/web/InternalJettyServletRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/web/InternalJettyServletResponse.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/web/InternalJettyServletResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/web/NoSuchPropertyException.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/web/NoSuchPropertyException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/web/PropertyValueException.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/web/PropertyValueException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/web/ResourcesService.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/web/ResourcesService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/web/RestfulGraphDatabase.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/web/RestfulGraphDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/web/ScriptExecutionMode.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/web/ScriptExecutionMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/web/StreamingBatchOperations.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/web/StreamingBatchOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/web/Surface.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/web/Surface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/web/TransactionUriScheme.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/web/TransactionUriScheme.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/rest/web/TransactionalService.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/web/TransactionalService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/scripting/NoSuchScriptLanguageException.java
+++ b/community/server/src/main/java/org/neo4j/server/scripting/NoSuchScriptLanguageException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/scripting/ScriptExecutor.java
+++ b/community/server/src/main/java/org/neo4j/server/scripting/ScriptExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/scripting/ScriptExecutorFactoryRepository.java
+++ b/community/server/src/main/java/org/neo4j/server/scripting/ScriptExecutorFactoryRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/scripting/UserScriptClassWhiteList.java
+++ b/community/server/src/main/java/org/neo4j/server/scripting/UserScriptClassWhiteList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/scripting/javascript/GlobalJavascriptInitializer.java
+++ b/community/server/src/main/java/org/neo4j/server/scripting/javascript/GlobalJavascriptInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/scripting/javascript/JavascriptExecutor.java
+++ b/community/server/src/main/java/org/neo4j/server/scripting/javascript/JavascriptExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/scripting/javascript/WhiteListClassShutter.java
+++ b/community/server/src/main/java/org/neo4j/server/scripting/javascript/WhiteListClassShutter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/scripting/javascript/WhiteListJavaWrapper.java
+++ b/community/server/src/main/java/org/neo4j/server/scripting/javascript/WhiteListJavaWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/security/ssl/HttpsRequestCustomizer.java
+++ b/community/server/src/main/java/org/neo4j/server/security/ssl/HttpsRequestCustomizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/security/ssl/SslSocketConnectorFactory.java
+++ b/community/server/src/main/java/org/neo4j/server/security/ssl/SslSocketConnectorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/web/AsyncRequestLog.java
+++ b/community/server/src/main/java/org/neo4j/server/web/AsyncRequestLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/web/FastSlf4jLog.java
+++ b/community/server/src/main/java/org/neo4j/server/web/FastSlf4jLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/web/HttpChannelOptionalRequestLogHandler.java
+++ b/community/server/src/main/java/org/neo4j/server/web/HttpChannelOptionalRequestLogHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/web/HttpConnectorFactory.java
+++ b/community/server/src/main/java/org/neo4j/server/web/HttpConnectorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/web/HttpHeaderUtils.java
+++ b/community/server/src/main/java/org/neo4j/server/web/HttpHeaderUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/web/HttpMethod.java
+++ b/community/server/src/main/java/org/neo4j/server/web/HttpMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/web/InjectableWrapper.java
+++ b/community/server/src/main/java/org/neo4j/server/web/InjectableWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/web/JaxRsServletHolderFactory.java
+++ b/community/server/src/main/java/org/neo4j/server/web/JaxRsServletHolderFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/web/Jetty9WebServer.java
+++ b/community/server/src/main/java/org/neo4j/server/web/Jetty9WebServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/web/JettyThreadCalculator.java
+++ b/community/server/src/main/java/org/neo4j/server/web/JettyThreadCalculator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/web/NeoJettyErrorHandler.java
+++ b/community/server/src/main/java/org/neo4j/server/web/NeoJettyErrorHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/web/NeoServletContainer.java
+++ b/community/server/src/main/java/org/neo4j/server/web/NeoServletContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/web/SimpleUriBuilder.java
+++ b/community/server/src/main/java/org/neo4j/server/web/SimpleUriBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/web/StaticContentFilter.java
+++ b/community/server/src/main/java/org/neo4j/server/web/StaticContentFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/web/WebServer.java
+++ b/community/server/src/main/java/org/neo4j/server/web/WebServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/web/WebServerProvider.java
+++ b/community/server/src/main/java/org/neo4j/server/web/WebServerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/web/XForwardFilter.java
+++ b/community/server/src/main/java/org/neo4j/server/web/XForwardFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/main/java/org/neo4j/server/web/XForwardUtil.java
+++ b/community/server/src/main/java/org/neo4j/server/web/XForwardUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/dummy/web/service/DummyPluginInitializer.java
+++ b/community/server/src/test/java/org/dummy/web/service/DummyPluginInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/dummy/web/service/DummyThirdPartyWebService.java
+++ b/community/server/src/test/java/org/dummy/web/service/DummyThirdPartyWebService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/bolt/v1/transport/integration/CertificatesIT.java
+++ b/community/server/src/test/java/org/neo4j/bolt/v1/transport/integration/CertificatesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/AcceptorConfigurationIT.java
+++ b/community/server/src/test/java/org/neo4j/server/AcceptorConfigurationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/BaseBootstrapperTestIT.java
+++ b/community/server/src/test/java/org/neo4j/server/BaseBootstrapperTestIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/BatchOperationHeaderIT.java
+++ b/community/server/src/test/java/org/neo4j/server/BatchOperationHeaderIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/BlockingBootstrapperTest.java
+++ b/community/server/src/test/java/org/neo4j/server/BlockingBootstrapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/BoltIT.java
+++ b/community/server/src/test/java/org/neo4j/server/BoltIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/CommunityBootstrapperTestIT.java
+++ b/community/server/src/test/java/org/neo4j/server/CommunityBootstrapperTestIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/CommunityEntryPointTest.java
+++ b/community/server/src/test/java/org/neo4j/server/CommunityEntryPointTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/ExplicitIndexIT.java
+++ b/community/server/src/test/java/org/neo4j/server/ExplicitIndexIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/HttpHeadersIT.java
+++ b/community/server/src/test/java/org/neo4j/server/HttpHeadersIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/HttpsAccessIT.java
+++ b/community/server/src/test/java/org/neo4j/server/HttpsAccessIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/NeoServerDefaultPortAndHostnameIT.java
+++ b/community/server/src/test/java/org/neo4j/server/NeoServerDefaultPortAndHostnameIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/NeoServerIT.java
+++ b/community/server/src/test/java/org/neo4j/server/NeoServerIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/NeoServerJAXRSIT.java
+++ b/community/server/src/test/java/org/neo4j/server/NeoServerJAXRSIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/NeoServerPortConflictIT.java
+++ b/community/server/src/test/java/org/neo4j/server/NeoServerPortConflictIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/NeoServerRestartTestCommunityIT.java
+++ b/community/server/src/test/java/org/neo4j/server/NeoServerRestartTestCommunityIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/NeoServerRestartTestIT.java
+++ b/community/server/src/test/java/org/neo4j/server/NeoServerRestartTestIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/NeoServerShutdownLoggingIT.java
+++ b/community/server/src/test/java/org/neo4j/server/NeoServerShutdownLoggingIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/NeoServerStartupLoggingIT.java
+++ b/community/server/src/test/java/org/neo4j/server/NeoServerStartupLoggingIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/RedirectToBrowserTestIT.java
+++ b/community/server/src/test/java/org/neo4j/server/RedirectToBrowserTestIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/ServerBootstrapperTest.java
+++ b/community/server/src/test/java/org/neo4j/server/ServerBootstrapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/ServerCommandLineArgsTest.java
+++ b/community/server/src/test/java/org/neo4j/server/ServerCommandLineArgsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/ServerConfigIT.java
+++ b/community/server/src/test/java/org/neo4j/server/ServerConfigIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/ServerTestUtils.java
+++ b/community/server/src/test/java/org/neo4j/server/ServerTestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/TransactionTimeoutIT.java
+++ b/community/server/src/test/java/org/neo4j/server/TransactionTimeoutIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/XForwardFilterTest.java
+++ b/community/server/src/test/java/org/neo4j/server/XForwardFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/configuration/ConfigFileBuilder.java
+++ b/community/server/src/test/java/org/neo4j/server/configuration/ConfigFileBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/configuration/ConfigLoaderTest.java
+++ b/community/server/src/test/java/org/neo4j/server/configuration/ConfigLoaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/configuration/ServerSettingsTest.java
+++ b/community/server/src/test/java/org/neo4j/server/configuration/ServerSettingsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/database/CypherExecutorTest.java
+++ b/community/server/src/test/java/org/neo4j/server/database/CypherExecutorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/database/LifecycleManagingDatabaseTest.java
+++ b/community/server/src/test/java/org/neo4j/server/database/LifecycleManagingDatabaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/database/TestLifecycleManagedDatabase.java
+++ b/community/server/src/test/java/org/neo4j/server/database/TestLifecycleManagedDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/exception/ServerStartupErrorsTest.java
+++ b/community/server/src/test/java/org/neo4j/server/exception/ServerStartupErrorsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/helpers/CommunityServerBuilder.java
+++ b/community/server/src/test/java/org/neo4j/server/helpers/CommunityServerBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/helpers/FunctionalTestHelper.java
+++ b/community/server/src/test/java/org/neo4j/server/helpers/FunctionalTestHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/helpers/ServerHelper.java
+++ b/community/server/src/test/java/org/neo4j/server/helpers/ServerHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/helpers/Transactor.java
+++ b/community/server/src/test/java/org/neo4j/server/helpers/Transactor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/helpers/UnitOfWork.java
+++ b/community/server/src/test/java/org/neo4j/server/helpers/UnitOfWork.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/integration/ServerConfigIT.java
+++ b/community/server/src/test/java/org/neo4j/server/integration/ServerConfigIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/integration/StartupLoggingIT.java
+++ b/community/server/src/test/java/org/neo4j/server/integration/StartupLoggingIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/modules/DBMSModuleTest.java
+++ b/community/server/src/test/java/org/neo4j/server/modules/DBMSModuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/modules/ExtensionInitializerTest.java
+++ b/community/server/src/test/java/org/neo4j/server/modules/ExtensionInitializerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/modules/ManagementApiModuleTest.java
+++ b/community/server/src/test/java/org/neo4j/server/modules/ManagementApiModuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/modules/RESTApiModuleTest.java
+++ b/community/server/src/test/java/org/neo4j/server/modules/RESTApiModuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/modules/SecurityRulesModuleTest.java
+++ b/community/server/src/test/java/org/neo4j/server/modules/SecurityRulesModuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/modules/ThirdPartyJAXRSModuleTest.java
+++ b/community/server/src/test/java/org/neo4j/server/modules/ThirdPartyJAXRSModuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/plugins/ConfigAdapterTest.java
+++ b/community/server/src/test/java/org/neo4j/server/plugins/ConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/preflight/TestPreflightTasks.java
+++ b/community/server/src/test/java/org/neo4j/server/preflight/TestPreflightTasks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/AbstractRestFunctionalDocTestBase.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/AbstractRestFunctionalDocTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/AbstractRestFunctionalTestBase.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/AbstractRestFunctionalTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/AutoIndexIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/AutoIndexIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/AutoIndexWithNonDefaultConfigurationThroughRESTAPIIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/AutoIndexWithNonDefaultConfigurationThroughRESTAPIIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/BatchOperationIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/BatchOperationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/CompactJsonIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/CompactJsonIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/ConfigureBaseUriIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/ConfigureBaseUriIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/CreateRelationshipTestIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/CreateRelationshipTestIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/CypherIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/CypherIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/CypherSessionTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/CypherSessionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/DatabaseMetadataServiceIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/DatabaseMetadataServiceIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/DegreeIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/DegreeIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/DisableWADLIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/DisableWADLIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/DiscoveryServiceIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/DiscoveryServiceIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/GetIndexRootIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/GetIndexRootIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/GetNodePropertiesIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/GetNodePropertiesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/GetOnRootIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/GetOnRootIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/GetRelationshipPropertiesIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/GetRelationshipPropertiesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/HtmlIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/HtmlIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/IndexNodeIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/IndexNodeIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/IndexRelationshipIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/IndexRelationshipIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/JSONPrettifier.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/JSONPrettifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/JaxRsResponse.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/JaxRsResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/JmxServiceIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/JmxServiceIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/LabelsIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/LabelsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/ListPropertyKeysIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/ListPropertyKeysIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/ManageNodeIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/ManageNodeIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/PathsIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/PathsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/PrettyJSON.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/PrettyJSON.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/RESTRequestGenerator.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/RESTRequestGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/RedirectorIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/RedirectorIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/RelationshipIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/RelationshipIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/RemoveNodePropertiesIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/RemoveNodePropertiesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/RemoveRelationshipIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/RemoveRelationshipIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/RequestData.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/RequestData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/RestRequest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/RestRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/RetrieveNodeIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/RetrieveNodeIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/RetrieveRelationshipsFromNodeIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/RetrieveRelationshipsFromNodeIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/SchemaConstraintsIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/SchemaConstraintsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/SchemaIndexIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/SchemaIndexIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/SetNodePropertiesIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/SetNodePropertiesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/SetRelationshipPropertiesIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/SetRelationshipPropertiesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/TraverserIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/TraverserIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/UniqueStrings.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/UniqueStrings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/batch/BatchOperationsTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/batch/BatchOperationsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/dbms/AuthorizationFilterTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/dbms/AuthorizationFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/dbms/AuthorizationHeadersTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/dbms/AuthorizationHeadersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/dbms/UserServiceTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/dbms/UserServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/discovery/DiscoveryServiceTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/discovery/DiscoveryServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/domain/GraphDbHelper.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/domain/GraphDbHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/domain/PropertySettingStrategyTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/domain/PropertySettingStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/domain/RelationshipExpanderBuilderTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/domain/RelationshipExpanderBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/domain/TraversalDescriptionBuilderTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/domain/TraversalDescriptionBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/paging/HexMatcher.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/paging/HexMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/paging/LeaseManagerTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/paging/LeaseManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/paging/LeaseTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/paging/LeaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/paging/PagedTraverserIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/paging/PagedTraverserIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/paging/PagedTraverserTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/paging/PagedTraverserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/repr/CypherResultRepresentationTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/repr/CypherResultRepresentationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/repr/DatabaseRepresentationTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/repr/DatabaseRepresentationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/repr/DiscoveryRepresentationTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/repr/DiscoveryRepresentationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/repr/ExceptionRepresentationTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/repr/ExceptionRepresentationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/repr/MapRepresentationTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/repr/MapRepresentationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/repr/NodeRepresentationTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/repr/NodeRepresentationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/repr/OutputFormatTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/repr/OutputFormatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/repr/PathRepresentationTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/repr/PathRepresentationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/repr/PropertiesRepresentationTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/repr/PropertiesRepresentationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/repr/RelationshipRepresentationTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/repr/RelationshipRepresentationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/repr/RepresentationFormatRepositoryTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/repr/RepresentationFormatRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/repr/RepresentationTestAccess.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/repr/RepresentationTestAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/repr/RepresentationTestBase.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/repr/RepresentationTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/repr/SchemaIndexRepresentationTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/repr/SchemaIndexRepresentationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/repr/XForwardFilterIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/repr/XForwardFilterIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/repr/formats/CompactJsonFormatTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/repr/formats/CompactJsonFormatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/repr/formats/DefaultFormatTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/repr/formats/DefaultFormatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/repr/formats/JsonFormatTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/repr/formats/JsonFormatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/repr/formats/JsonInputTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/repr/formats/JsonInputTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/repr/formats/StreamingJsonFormatTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/repr/formats/StreamingJsonFormatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/repr/formats/UrlFormFormatTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/repr/formats/UrlFormFormatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/repr/util/RFC1123Test.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/repr/util/RFC1123Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/security/AuthenticationIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/security/AuthenticationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/security/AuthorizationCorsIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/security/AuthorizationCorsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/security/CommunityServerTestBase.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/security/CommunityServerTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/security/NoAccessToDatabaseSecurityRule.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/security/NoAccessToDatabaseSecurityRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/security/PermanentlyFailingSecurityRule.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/security/PermanentlyFailingSecurityRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/security/PermanentlyFailingSecurityRuleWithComplexWildcardPath.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/security/PermanentlyFailingSecurityRuleWithComplexWildcardPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/security/PermanentlyFailingSecurityRuleWithWildcardPath.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/security/PermanentlyFailingSecurityRuleWithWildcardPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/security/PermanentlyForbiddenSecurityRule.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/security/PermanentlyForbiddenSecurityRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/security/PermanentlyPassingSecurityRule.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/security/PermanentlyPassingSecurityRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/security/SecurityFilterTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/security/SecurityFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/security/SecurityRulesIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/security/SecurityRulesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/security/UriPathWildcardMatcherTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/security/UriPathWildcardMatcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/security/UsersIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/security/UsersIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/streaming/StreamingBatchOperationIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/streaming/StreamingBatchOperationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/streaming/StreamingCypherIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/streaming/StreamingCypherIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/streaming/StreamingIndexNodeIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/streaming/StreamingIndexNodeIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/streaming/StreamingPathsIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/streaming/StreamingPathsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/streaming/StreamingRelationshipIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/streaming/StreamingRelationshipIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/streaming/StreamingTraverserIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/streaming/StreamingTraverserIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/ConcurrentTransactionAccessTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/ConcurrentTransactionAccessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/ExecutionResultSerializerTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/ExecutionResultSerializerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/GraphExtractionWriterTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/GraphExtractionWriterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/Neo4jJsonCodecTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/Neo4jJsonCodecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/RestRepresentationWriterTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/RestRepresentationWriterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/RowWriterTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/RowWriterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/StatementDeserializerTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/StatementDeserializerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/StubStatementDeserializer.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/StubStatementDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/TransactionHandleRegistryTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/TransactionHandleRegistryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/TransactionHandleTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/TransactionHandleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/TransactionTestIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/TransactionTestIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/TransitionalTxManagementKernelTransactionTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/TransitionalTxManagementKernelTransactionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/TxStateCheckerTestSupport.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/TxStateCheckerTestSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/ClientErrorIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/ClientErrorIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/DeadlockIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/DeadlockIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/PointTypeIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/PointTypeIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/QueryResultsSerializationTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/QueryResultsSerializationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/ReadOnlyIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/ReadOnlyIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/RowFormatMetaFieldTestIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/RowFormatMetaFieldTestIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/SnapshotQueryExecutionIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/SnapshotQueryExecutionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/TemporalTypeIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/TemporalTypeIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/TransactionErrorIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/TransactionErrorIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/TransactionIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/TransactionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/TransactionMatchers.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/TransactionMatchers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/TransientErrorIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/TransientErrorIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/web/CollectUserAgentFilterIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/web/CollectUserAgentFilterIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/web/CollectUserAgentFilterTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/web/CollectUserAgentFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/web/CorsFilterTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/web/CorsFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/web/DatabaseActionsTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/web/DatabaseActionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/web/DatabaseMetadataServiceTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/web/DatabaseMetadataServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/web/ModelBuilder.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/web/ModelBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/web/PagingTraversalTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/web/PagingTraversalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/web/RestfulGraphDatabasePagedTraversalTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/web/RestfulGraphDatabasePagedTraversalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/web/RestfulGraphDatabaseTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/web/RestfulGraphDatabaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/web/ScriptExecutionModeTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/web/ScriptExecutionModeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/web/TransactionWrappedDatabaseActions.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/web/TransactionWrappedDatabaseActions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/web/TransactionWrappingRestfulGraphDatabase.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/web/TransactionWrappingRestfulGraphDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/rest/web/integration/CypherOldEndpointIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/web/integration/CypherOldEndpointIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/scripting/TestScriptExecutorFactoryRepository.java
+++ b/community/server/src/test/java/org/neo4j/server/scripting/TestScriptExecutorFactoryRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/scripting/javascript/TestGlobalJavascriptInitializer.java
+++ b/community/server/src/test/java/org/neo4j/server/scripting/javascript/TestGlobalJavascriptInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/scripting/javascript/TestJavascriptExecutor.java
+++ b/community/server/src/test/java/org/neo4j/server/scripting/javascript/TestJavascriptExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/scripting/javascript/TestJavascriptSecurityRestrictions.java
+++ b/community/server/src/test/java/org/neo4j/server/scripting/javascript/TestJavascriptSecurityRestrictions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/scripting/javascript/TestWhiteListClassShutter.java
+++ b/community/server/src/test/java/org/neo4j/server/scripting/javascript/TestWhiteListClassShutter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/scripting/javascript/TestWhiteListJavaWrapper.java
+++ b/community/server/src/test/java/org/neo4j/server/scripting/javascript/TestWhiteListJavaWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/security/auth/AuthorizationDisabledIT.java
+++ b/community/server/src/test/java/org/neo4j/server/security/auth/AuthorizationDisabledIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/security/auth/AuthorizationWhitelistIT.java
+++ b/community/server/src/test/java/org/neo4j/server/security/auth/AuthorizationWhitelistIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/security/ssl/HttpsRequestCustomizerTest.java
+++ b/community/server/src/test/java/org/neo4j/server/security/ssl/HttpsRequestCustomizerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/web/HelloWorldWebResource.java
+++ b/community/server/src/test/java/org/neo4j/server/web/HelloWorldWebResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/web/HttpHeaderUtilsTest.java
+++ b/community/server/src/test/java/org/neo4j/server/web/HttpHeaderUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/web/HttpMethodTest.java
+++ b/community/server/src/test/java/org/neo4j/server/web/HttpMethodTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/web/Jetty9WebServerIT.java
+++ b/community/server/src/test/java/org/neo4j/server/web/Jetty9WebServerIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/web/JettyThreadCalculatorTest.java
+++ b/community/server/src/test/java/org/neo4j/server/web/JettyThreadCalculatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/web/JettyThreadLimitIT.java
+++ b/community/server/src/test/java/org/neo4j/server/web/JettyThreadLimitIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/web/StaticContentFilterTest.java
+++ b/community/server/src/test/java/org/neo4j/server/web/StaticContentFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/web/WebServerDirectoryListingTestIT.java
+++ b/community/server/src/test/java/org/neo4j/server/web/WebServerDirectoryListingTestIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/server/web/logging/HTTPLoggingIT.java
+++ b/community/server/src/test/java/org/neo4j/server/web/logging/HTTPLoggingIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/test/server/EntityOutputFormat.java
+++ b/community/server/src/test/java/org/neo4j/test/server/EntityOutputFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/test/server/ExclusiveServerTestBase.java
+++ b/community/server/src/test/java/org/neo4j/test/server/ExclusiveServerTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/test/server/HTTP.java
+++ b/community/server/src/test/java/org/neo4j/test/server/HTTP.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/test/server/InsecureTrustManager.java
+++ b/community/server/src/test/java/org/neo4j/test/server/InsecureTrustManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/test/server/ServerHolder.java
+++ b/community/server/src/test/java/org/neo4j/test/server/ServerHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/server/src/test/java/org/neo4j/test/server/SharedServerTestBase.java
+++ b/community/server/src/test/java/org/neo4j/test/server/SharedServerTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/NOTICE.txt
+++ b/community/shell/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/community/shell/src/main/java/org/neo4j/shell/App.java
+++ b/community/shell/src/main/java/org/neo4j/shell/App.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/AppCommandParser.java
+++ b/community/shell/src/main/java/org/neo4j/shell/AppCommandParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/AppShellServer.java
+++ b/community/shell/src/main/java/org/neo4j/shell/AppShellServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/ColumnPrinter.java
+++ b/community/shell/src/main/java/org/neo4j/shell/ColumnPrinter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/Console.java
+++ b/community/shell/src/main/java/org/neo4j/shell/Console.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/Continuation.java
+++ b/community/shell/src/main/java/org/neo4j/shell/Continuation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/CtrlCHandler.java
+++ b/community/shell/src/main/java/org/neo4j/shell/CtrlCHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/InterruptSignalHandler.java
+++ b/community/shell/src/main/java/org/neo4j/shell/InterruptSignalHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/OptionDefinition.java
+++ b/community/shell/src/main/java/org/neo4j/shell/OptionDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/OptionValueType.java
+++ b/community/shell/src/main/java/org/neo4j/shell/OptionValueType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/Output.java
+++ b/community/shell/src/main/java/org/neo4j/shell/Output.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/OutputAsWriter.java
+++ b/community/shell/src/main/java/org/neo4j/shell/OutputAsWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/Response.java
+++ b/community/shell/src/main/java/org/neo4j/shell/Response.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/Session.java
+++ b/community/shell/src/main/java/org/neo4j/shell/Session.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/ShellClient.java
+++ b/community/shell/src/main/java/org/neo4j/shell/ShellClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/ShellException.java
+++ b/community/shell/src/main/java/org/neo4j/shell/ShellException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/ShellLobby.java
+++ b/community/shell/src/main/java/org/neo4j/shell/ShellLobby.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/ShellServer.java
+++ b/community/shell/src/main/java/org/neo4j/shell/ShellServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/ShellSettings.java
+++ b/community/shell/src/main/java/org/neo4j/shell/ShellSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/StartClient.java
+++ b/community/shell/src/main/java/org/neo4j/shell/StartClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/TabCompletion.java
+++ b/community/shell/src/main/java/org/neo4j/shell/TabCompletion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/Variables.java
+++ b/community/shell/src/main/java/org/neo4j/shell/Variables.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/Welcome.java
+++ b/community/shell/src/main/java/org/neo4j/shell/Welcome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/apps/Alias.java
+++ b/community/shell/src/main/java/org/neo4j/shell/apps/Alias.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/apps/Env.java
+++ b/community/shell/src/main/java/org/neo4j/shell/apps/Env.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/apps/Export.java
+++ b/community/shell/src/main/java/org/neo4j/shell/apps/Export.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/apps/Help.java
+++ b/community/shell/src/main/java/org/neo4j/shell/apps/Help.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/apps/Man.java
+++ b/community/shell/src/main/java/org/neo4j/shell/apps/Man.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/apps/NoopApp.java
+++ b/community/shell/src/main/java/org/neo4j/shell/apps/NoopApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/apps/extra/Gsh.java
+++ b/community/shell/src/main/java/org/neo4j/shell/apps/extra/Gsh.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/apps/extra/GshExecutor.java
+++ b/community/shell/src/main/java/org/neo4j/shell/apps/extra/GshExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/apps/extra/Jsh.java
+++ b/community/shell/src/main/java/org/neo4j/shell/apps/extra/Jsh.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/apps/extra/JshExecutor.java
+++ b/community/shell/src/main/java/org/neo4j/shell/apps/extra/JshExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/apps/extra/PathShellApp.java
+++ b/community/shell/src/main/java/org/neo4j/shell/apps/extra/PathShellApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/apps/extra/ScriptExecutor.java
+++ b/community/shell/src/main/java/org/neo4j/shell/apps/extra/ScriptExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/impl/AbstractApp.java
+++ b/community/shell/src/main/java/org/neo4j/shell/impl/AbstractApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/impl/AbstractAppServer.java
+++ b/community/shell/src/main/java/org/neo4j/shell/impl/AbstractAppServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/impl/AbstractClient.java
+++ b/community/shell/src/main/java/org/neo4j/shell/impl/AbstractClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/impl/BashVariableInterpreter.java
+++ b/community/shell/src/main/java/org/neo4j/shell/impl/BashVariableInterpreter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/impl/CollectingOutput.java
+++ b/community/shell/src/main/java/org/neo4j/shell/impl/CollectingOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/impl/HostBoundSocketFactory.java
+++ b/community/shell/src/main/java/org/neo4j/shell/impl/HostBoundSocketFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/impl/JLineConsole.java
+++ b/community/shell/src/main/java/org/neo4j/shell/impl/JLineConsole.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/impl/RelationshipToNodeIterable.java
+++ b/community/shell/src/main/java/org/neo4j/shell/impl/RelationshipToNodeIterable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/impl/RemoteClient.java
+++ b/community/shell/src/main/java/org/neo4j/shell/impl/RemoteClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/impl/RemoteOutput.java
+++ b/community/shell/src/main/java/org/neo4j/shell/impl/RemoteOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/impl/RemotelyAvailableServer.java
+++ b/community/shell/src/main/java/org/neo4j/shell/impl/RemotelyAvailableServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/impl/RmiLocation.java
+++ b/community/shell/src/main/java/org/neo4j/shell/impl/RmiLocation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/impl/SameJvmClient.java
+++ b/community/shell/src/main/java/org/neo4j/shell/impl/SameJvmClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/impl/ShellBootstrap.java
+++ b/community/shell/src/main/java/org/neo4j/shell/impl/ShellBootstrap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/impl/ShellServerExtensionFactory.java
+++ b/community/shell/src/main/java/org/neo4j/shell/impl/ShellServerExtensionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/impl/ShellServerKernelExtension.java
+++ b/community/shell/src/main/java/org/neo4j/shell/impl/ShellServerKernelExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/impl/ShellTabCompleter.java
+++ b/community/shell/src/main/java/org/neo4j/shell/impl/ShellTabCompleter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/impl/SimpleAppServer.java
+++ b/community/shell/src/main/java/org/neo4j/shell/impl/SimpleAppServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/impl/StandardConsole.java
+++ b/community/shell/src/main/java/org/neo4j/shell/impl/StandardConsole.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/impl/SystemOutput.java
+++ b/community/shell/src/main/java/org/neo4j/shell/impl/SystemOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/GraphDatabaseShellServer.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/GraphDatabaseShellServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/ReadOnlyGraphDatabaseProxy.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/ReadOnlyGraphDatabaseProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/Begin.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/Begin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/Cd.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/Cd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/Commit.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/Commit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/Dbinfo.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/Dbinfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/Gsh.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/Gsh.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/IndexProviderShellApp.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/IndexProviderShellApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/Jsh.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/Jsh.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/Ls.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/Ls.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/Mknode.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/Mknode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/Mkrel.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/Mkrel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/Mv.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/Mv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/NodeOrRelationship.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/NodeOrRelationship.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/NonTransactionProvidingApp.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/NonTransactionProvidingApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/Pwd.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/Pwd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/Rm.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/Rm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/Rmnode.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/Rmnode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/Rmrel.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/Rmrel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/Rollback.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/Rollback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/Schema.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/Schema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/Set.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/Set.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/TransactionProvidingApp.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/TransactionProvidingApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/Trav.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/Trav.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/TypedId.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/TypedId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/cypher/Call.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/cypher/Call.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/cypher/Create.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/cypher/Create.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/cypher/Cypher.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/cypher/Cypher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/cypher/Drop.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/cypher/Drop.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/cypher/Dump.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/cypher/Dump.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/cypher/Explain.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/cypher/Explain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/cypher/Exporter.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/cypher/Exporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/cypher/Foreach.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/cypher/Foreach.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/cypher/Load.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/cypher/Load.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/cypher/Match.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/cypher/Match.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/cypher/Merge.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/cypher/Merge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/cypher/Optional.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/cypher/Optional.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/cypher/Planner.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/cypher/Planner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/cypher/Profile.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/cypher/Profile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/cypher/Return.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/cypher/Return.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/cypher/Runtime.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/cypher/Runtime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/cypher/Start.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/cypher/Start.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/cypher/Unwind.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/cypher/Unwind.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/cypher/Using.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/cypher/Using.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/cypher/With.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/cypher/With.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/util/json/JSONArray.java
+++ b/community/shell/src/main/java/org/neo4j/shell/util/json/JSONArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/util/json/JSONException.java
+++ b/community/shell/src/main/java/org/neo4j/shell/util/json/JSONException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/util/json/JSONObject.java
+++ b/community/shell/src/main/java/org/neo4j/shell/util/json/JSONObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/util/json/JSONParser.java
+++ b/community/shell/src/main/java/org/neo4j/shell/util/json/JSONParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/util/json/JSONString.java
+++ b/community/shell/src/main/java/org/neo4j/shell/util/json/JSONString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/main/java/org/neo4j/shell/util/json/JSONTokener.java
+++ b/community/shell/src/main/java/org/neo4j/shell/util/json/JSONTokener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/test/java/org/neo4j/shell/AbstractShellIT.java
+++ b/community/shell/src/test/java/org/neo4j/shell/AbstractShellIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/test/java/org/neo4j/shell/AppsIT.java
+++ b/community/shell/src/test/java/org/neo4j/shell/AppsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/test/java/org/neo4j/shell/ClientReconnectIT.java
+++ b/community/shell/src/test/java/org/neo4j/shell/ClientReconnectIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/test/java/org/neo4j/shell/ConfigurationIT.java
+++ b/community/shell/src/test/java/org/neo4j/shell/ConfigurationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/test/java/org/neo4j/shell/CtrlCTest.java
+++ b/community/shell/src/test/java/org/neo4j/shell/CtrlCTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/test/java/org/neo4j/shell/DontShutdownClient.java
+++ b/community/shell/src/test/java/org/neo4j/shell/DontShutdownClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/test/java/org/neo4j/shell/DontShutdownLocalServer.java
+++ b/community/shell/src/test/java/org/neo4j/shell/DontShutdownLocalServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/test/java/org/neo4j/shell/ErrorsAndWarningsIT.java
+++ b/community/shell/src/test/java/org/neo4j/shell/ErrorsAndWarningsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/test/java/org/neo4j/shell/FreePortIT.java
+++ b/community/shell/src/test/java/org/neo4j/shell/FreePortIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/test/java/org/neo4j/shell/OutputAsWriterTest.java
+++ b/community/shell/src/test/java/org/neo4j/shell/OutputAsWriterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/test/java/org/neo4j/shell/ReadOnlyServerIT.java
+++ b/community/shell/src/test/java/org/neo4j/shell/ReadOnlyServerIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/test/java/org/neo4j/shell/RmiPublicationIT.java
+++ b/community/shell/src/test/java/org/neo4j/shell/RmiPublicationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/test/java/org/neo4j/shell/ServerClientInteractionIT.java
+++ b/community/shell/src/test/java/org/neo4j/shell/ServerClientInteractionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/test/java/org/neo4j/shell/SessionTest.java
+++ b/community/shell/src/test/java/org/neo4j/shell/SessionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/test/java/org/neo4j/shell/SilentLocalOutput.java
+++ b/community/shell/src/test/java/org/neo4j/shell/SilentLocalOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/test/java/org/neo4j/shell/StartClientIT.java
+++ b/community/shell/src/test/java/org/neo4j/shell/StartClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/test/java/org/neo4j/shell/TestTransactionApps.java
+++ b/community/shell/src/test/java/org/neo4j/shell/TestTransactionApps.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/test/java/org/neo4j/shell/impl/BashVariableInterpreterTest.java
+++ b/community/shell/src/test/java/org/neo4j/shell/impl/BashVariableInterpreterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/test/java/org/neo4j/shell/impl/ClientIT.java
+++ b/community/shell/src/test/java/org/neo4j/shell/impl/ClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/test/java/org/neo4j/shell/impl/JLineConsoleTest.java
+++ b/community/shell/src/test/java/org/neo4j/shell/impl/JLineConsoleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/test/java/org/neo4j/shell/impl/ShellBootstrapTest.java
+++ b/community/shell/src/test/java/org/neo4j/shell/impl/ShellBootstrapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/test/java/org/neo4j/shell/impl/TestShellServerExtension.java
+++ b/community/shell/src/test/java/org/neo4j/shell/impl/TestShellServerExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/shell/src/test/java/org/neo4j/shell/kernel/apps/CdTest.java
+++ b/community/shell/src/test/java/org/neo4j/shell/kernel/apps/CdTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/spatial-index/NOTICE.txt
+++ b/community/spatial-index/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/community/spatial-index/src/main/java/org/neo4j/gis/spatial/index/Envelope.java
+++ b/community/spatial-index/src/main/java/org/neo4j/gis/spatial/index/Envelope.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/spatial-index/src/main/java/org/neo4j/gis/spatial/index/curves/HilbertSpaceFillingCurve2D.java
+++ b/community/spatial-index/src/main/java/org/neo4j/gis/spatial/index/curves/HilbertSpaceFillingCurve2D.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/spatial-index/src/main/java/org/neo4j/gis/spatial/index/curves/HilbertSpaceFillingCurve3D.java
+++ b/community/spatial-index/src/main/java/org/neo4j/gis/spatial/index/curves/HilbertSpaceFillingCurve3D.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/spatial-index/src/main/java/org/neo4j/gis/spatial/index/curves/PartialOverlapConfiguration.java
+++ b/community/spatial-index/src/main/java/org/neo4j/gis/spatial/index/curves/PartialOverlapConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/spatial-index/src/main/java/org/neo4j/gis/spatial/index/curves/SearchEnvelope.java
+++ b/community/spatial-index/src/main/java/org/neo4j/gis/spatial/index/curves/SearchEnvelope.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/spatial-index/src/main/java/org/neo4j/gis/spatial/index/curves/SpaceFillingCurve.java
+++ b/community/spatial-index/src/main/java/org/neo4j/gis/spatial/index/curves/SpaceFillingCurve.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/spatial-index/src/main/java/org/neo4j/gis/spatial/index/curves/SpaceFillingCurveConfiguration.java
+++ b/community/spatial-index/src/main/java/org/neo4j/gis/spatial/index/curves/SpaceFillingCurveConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/spatial-index/src/main/java/org/neo4j/gis/spatial/index/curves/SpaceFillingCurveMonitor.java
+++ b/community/spatial-index/src/main/java/org/neo4j/gis/spatial/index/curves/SpaceFillingCurveMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/spatial-index/src/main/java/org/neo4j/gis/spatial/index/curves/StandardConfiguration.java
+++ b/community/spatial-index/src/main/java/org/neo4j/gis/spatial/index/curves/StandardConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/spatial-index/src/main/java/org/neo4j/gis/spatial/index/curves/ZOrderSpaceFillingCurve2D.java
+++ b/community/spatial-index/src/main/java/org/neo4j/gis/spatial/index/curves/ZOrderSpaceFillingCurve2D.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/spatial-index/src/test/java/org/neo4j/gis/spatial/index/EnvelopeTest.java
+++ b/community/spatial-index/src/test/java/org/neo4j/gis/spatial/index/EnvelopeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/spatial-index/src/test/java/org/neo4j/gis/spatial/index/curves/HistogramMonitor.java
+++ b/community/spatial-index/src/test/java/org/neo4j/gis/spatial/index/curves/HistogramMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/spatial-index/src/test/java/org/neo4j/gis/spatial/index/curves/SpaceFillingCurveConfigurationTest.java
+++ b/community/spatial-index/src/test/java/org/neo4j/gis/spatial/index/curves/SpaceFillingCurveConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/spatial-index/src/test/java/org/neo4j/gis/spatial/index/curves/SpaceFillingCurveTest.java
+++ b/community/spatial-index/src/test/java/org/neo4j/gis/spatial/index/curves/SpaceFillingCurveTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/spatial-index/src/test/java/org/neo4j/gis/spatial/index/curves/TraverseToBottomConfiguration.java
+++ b/community/spatial-index/src/test/java/org/neo4j/gis/spatial/index/curves/TraverseToBottomConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/ssl/NOTICE.txt
+++ b/community/ssl/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/community/ssl/src/main/java/org/neo4j/ssl/ClientAuth.java
+++ b/community/ssl/src/main/java/org/neo4j/ssl/ClientAuth.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/ssl/src/main/java/org/neo4j/ssl/InsecureRandom.java
+++ b/community/ssl/src/main/java/org/neo4j/ssl/InsecureRandom.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/ssl/src/main/java/org/neo4j/ssl/KeyStoreInformation.java
+++ b/community/ssl/src/main/java/org/neo4j/ssl/KeyStoreInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/ssl/src/main/java/org/neo4j/ssl/PkiUtils.java
+++ b/community/ssl/src/main/java/org/neo4j/ssl/PkiUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/ssl/src/main/java/org/neo4j/ssl/SslPolicy.java
+++ b/community/ssl/src/main/java/org/neo4j/ssl/SslPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/ssl/src/test/java/org/neo4j/ssl/SslResource.java
+++ b/community/ssl/src/test/java/org/neo4j/ssl/SslResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/ssl/src/test/java/org/neo4j/ssl/SslResourceBuilder.java
+++ b/community/ssl/src/test/java/org/neo4j/ssl/SslResourceBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/ssl/src/test/java/org/neo4j/ssl/TestSslCertificateFactory.java
+++ b/community/ssl/src/test/java/org/neo4j/ssl/TestSslCertificateFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/udc/NOTICE.txt
+++ b/community/udc/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/community/udc/src/main/java/org/neo4j/ext/udc/Edition.java
+++ b/community/udc/src/main/java/org/neo4j/ext/udc/Edition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/udc/src/main/java/org/neo4j/ext/udc/UdcConstants.java
+++ b/community/udc/src/main/java/org/neo4j/ext/udc/UdcConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/udc/src/main/java/org/neo4j/ext/udc/UdcSettings.java
+++ b/community/udc/src/main/java/org/neo4j/ext/udc/UdcSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/udc/src/main/java/org/neo4j/ext/udc/impl/DefaultUdcInformationCollector.java
+++ b/community/udc/src/main/java/org/neo4j/ext/udc/impl/DefaultUdcInformationCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/udc/src/main/java/org/neo4j/ext/udc/impl/Pinger.java
+++ b/community/udc/src/main/java/org/neo4j/ext/udc/impl/Pinger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/udc/src/main/java/org/neo4j/ext/udc/impl/UdcInformationCollector.java
+++ b/community/udc/src/main/java/org/neo4j/ext/udc/impl/UdcInformationCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/udc/src/main/java/org/neo4j/ext/udc/impl/UdcKernelExtension.java
+++ b/community/udc/src/main/java/org/neo4j/ext/udc/impl/UdcKernelExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/udc/src/main/java/org/neo4j/ext/udc/impl/UdcKernelExtensionFactory.java
+++ b/community/udc/src/main/java/org/neo4j/ext/udc/impl/UdcKernelExtensionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/udc/src/main/java/org/neo4j/ext/udc/impl/UdcTimerTask.java
+++ b/community/udc/src/main/java/org/neo4j/ext/udc/impl/UdcTimerTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/udc/src/test/java/org/neo4j/ext/udc/UdcSettingsIT.java
+++ b/community/udc/src/test/java/org/neo4j/ext/udc/UdcSettingsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/udc/src/test/java/org/neo4j/ext/udc/UdcSettingsTest.java
+++ b/community/udc/src/test/java/org/neo4j/ext/udc/UdcSettingsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/udc/src/test/java/org/neo4j/ext/udc/impl/DefaultUdcInformationCollectorTest.java
+++ b/community/udc/src/test/java/org/neo4j/ext/udc/impl/DefaultUdcInformationCollectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/udc/src/test/java/org/neo4j/ext/udc/impl/PingerHandler.java
+++ b/community/udc/src/test/java/org/neo4j/ext/udc/impl/PingerHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/udc/src/test/java/org/neo4j/ext/udc/impl/PingerTest.java
+++ b/community/udc/src/test/java/org/neo4j/ext/udc/impl/PingerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/udc/src/test/java/org/neo4j/ext/udc/impl/TestUdcKernelExtensionFactory.java
+++ b/community/udc/src/test/java/org/neo4j/ext/udc/impl/TestUdcKernelExtensionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/unsafe/NOTICE.txt
+++ b/community/unsafe/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/community/unsafe/src/main/java/org/neo4j/io/os/OsBeanUtil.java
+++ b/community/unsafe/src/main/java/org/neo4j/io/os/OsBeanUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/unsafe/src/main/java/org/neo4j/unsafe/impl/internal/dragons/NativeMemoryAllocationRefusedError.java
+++ b/community/unsafe/src/main/java/org/neo4j/unsafe/impl/internal/dragons/NativeMemoryAllocationRefusedError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/unsafe/src/main/java/org/neo4j/unsafe/impl/internal/dragons/UnsafeUtil.java
+++ b/community/unsafe/src/main/java/org/neo4j/unsafe/impl/internal/dragons/UnsafeUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/unsafe/src/test/java/org/neo4j/unsafe/impl/internal/dragons/UnsafeUtilTest.java
+++ b/community/unsafe/src/test/java/org/neo4j/unsafe/impl/internal/dragons/UnsafeUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/NOTICE.txt
+++ b/community/values/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/community/values/src/main/java/org/neo4j/values/AnyValue.java
+++ b/community/values/src/main/java/org/neo4j/values/AnyValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/AnyValueComparator.java
+++ b/community/values/src/main/java/org/neo4j/values/AnyValueComparator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/AnyValueWriter.java
+++ b/community/values/src/main/java/org/neo4j/values/AnyValueWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/AnyValues.java
+++ b/community/values/src/main/java/org/neo4j/values/AnyValues.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/Comparison.java
+++ b/community/values/src/main/java/org/neo4j/values/Comparison.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/SequenceValue.java
+++ b/community/values/src/main/java/org/neo4j/values/SequenceValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/StructureBuilder.java
+++ b/community/values/src/main/java/org/neo4j/values/StructureBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/TernaryComparator.java
+++ b/community/values/src/main/java/org/neo4j/values/TernaryComparator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/ValueMapper.java
+++ b/community/values/src/main/java/org/neo4j/values/ValueMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/VirtualValue.java
+++ b/community/values/src/main/java/org/neo4j/values/VirtualValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/ArrayValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/ArrayValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/BooleanArray.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/BooleanArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/BooleanValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/BooleanValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/ByteArray.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/ByteArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/ByteValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/ByteValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/CRSCalculator.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/CRSCalculator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/CRSTable.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/CRSTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/CSVHeaderInformation.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/CSVHeaderInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/CharArray.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/CharArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/CharValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/CharValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/Comparison.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/Comparison.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/CoordinateReferenceSystem.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/CoordinateReferenceSystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/DateArray.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/DateArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/DateTimeArray.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/DateTimeArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/DateTimeValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/DateTimeValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/DateValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/DateValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/DoubleArray.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/DoubleArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/DoubleValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/DoubleValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/DurationArray.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/DurationArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/DurationBuilder.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/DurationBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/DurationFields.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/DurationFields.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/DurationValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/DurationValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/FloatArray.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/FloatArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/FloatValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/FloatValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/FloatingPointArray.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/FloatingPointArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/FloatingPointValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/FloatingPointValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/IntArray.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/IntArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/IntValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/IntValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/IntegralArray.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/IntegralArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/IntegralValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/IntegralValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/LocalDateTimeArray.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/LocalDateTimeArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/LocalDateTimeValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/LocalDateTimeValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/LocalTimeArray.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/LocalTimeArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/LocalTimeValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/LocalTimeValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/LongArray.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/LongArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/LongValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/LongValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/Neo4JTemporalField.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/Neo4JTemporalField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/NoValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/NoValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/NonPrimitiveArray.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/NonPrimitiveArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/NumberArray.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/NumberArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/NumberType.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/NumberType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/NumberValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/NumberValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/NumberValues.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/NumberValues.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/PointArray.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/PointArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/PointFields.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/PointFields.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/PointValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/PointValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/PrimitiveArrayValues.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/PrimitiveArrayValues.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/PrimitiveArrayWriting.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/PrimitiveArrayWriting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/ScalarValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/ScalarValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/ShortArray.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/ShortArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/ShortValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/ShortValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/StringArray.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/StringArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/StringValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/StringValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/StringWrappingStringValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/StringWrappingStringValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/TemporalArray.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/TemporalArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/TemporalValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/TemporalValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/TextArray.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/TextArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/TextValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/TextValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/TextValues.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/TextValues.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/TimeArray.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/TimeArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/TimeValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/TimeValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/TimeZones.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/TimeZones.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/UTF8StringValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/UTF8StringValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/Value.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/Value.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/ValueCategory.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/ValueCategory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/ValueComparator.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/ValueComparator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/ValueGroup.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/ValueGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/ValueTuple.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/ValueTuple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/ValueWriter.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/ValueWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/storable/Values.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/Values.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/utils/InvalidValuesArgumentException.java
+++ b/community/values/src/main/java/org/neo4j/values/utils/InvalidValuesArgumentException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/utils/PrettyPrinter.java
+++ b/community/values/src/main/java/org/neo4j/values/utils/PrettyPrinter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/utils/TemporalArithmeticException.java
+++ b/community/values/src/main/java/org/neo4j/values/utils/TemporalArithmeticException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/utils/TemporalParseException.java
+++ b/community/values/src/main/java/org/neo4j/values/utils/TemporalParseException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/utils/TemporalUtil.java
+++ b/community/values/src/main/java/org/neo4j/values/utils/TemporalUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/utils/UnsupportedTemporalUnitException.java
+++ b/community/values/src/main/java/org/neo4j/values/utils/UnsupportedTemporalUnitException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/utils/ValueMath.java
+++ b/community/values/src/main/java/org/neo4j/values/utils/ValueMath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/utils/ValuesException.java
+++ b/community/values/src/main/java/org/neo4j/values/utils/ValuesException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/virtual/ArrayHelpers.java
+++ b/community/values/src/main/java/org/neo4j/values/virtual/ArrayHelpers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/virtual/ErrorValue.java
+++ b/community/values/src/main/java/org/neo4j/values/virtual/ErrorValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/virtual/ListValue.java
+++ b/community/values/src/main/java/org/neo4j/values/virtual/ListValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/virtual/MapValue.java
+++ b/community/values/src/main/java/org/neo4j/values/virtual/MapValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/virtual/NodeReference.java
+++ b/community/values/src/main/java/org/neo4j/values/virtual/NodeReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/virtual/NodeValue.java
+++ b/community/values/src/main/java/org/neo4j/values/virtual/NodeValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/virtual/PathValue.java
+++ b/community/values/src/main/java/org/neo4j/values/virtual/PathValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/virtual/RelationshipReference.java
+++ b/community/values/src/main/java/org/neo4j/values/virtual/RelationshipReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/virtual/RelationshipValue.java
+++ b/community/values/src/main/java/org/neo4j/values/virtual/RelationshipValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/virtual/VirtualNodeValue.java
+++ b/community/values/src/main/java/org/neo4j/values/virtual/VirtualNodeValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/virtual/VirtualRelationshipValue.java
+++ b/community/values/src/main/java/org/neo4j/values/virtual/VirtualRelationshipValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/virtual/VirtualValueGroup.java
+++ b/community/values/src/main/java/org/neo4j/values/virtual/VirtualValueGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/main/java/org/neo4j/values/virtual/VirtualValues.java
+++ b/community/values/src/main/java/org/neo4j/values/virtual/VirtualValues.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/test/java/org/neo4j/values/AnyValueComparatorTest.java
+++ b/community/values/src/test/java/org/neo4j/values/AnyValueComparatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/test/java/org/neo4j/values/AnyValuesTest.java
+++ b/community/values/src/test/java/org/neo4j/values/AnyValuesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/test/java/org/neo4j/values/BufferAnyValueWriter.java
+++ b/community/values/src/test/java/org/neo4j/values/BufferAnyValueWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/test/java/org/neo4j/values/MyVirtualValue.java
+++ b/community/values/src/test/java/org/neo4j/values/MyVirtualValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/test/java/org/neo4j/values/ValueMapperTest.java
+++ b/community/values/src/test/java/org/neo4j/values/ValueMapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/test/java/org/neo4j/values/storable/AssertingStructureBuilder.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/AssertingStructureBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/test/java/org/neo4j/values/storable/BufferValueWriter.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/BufferValueWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/test/java/org/neo4j/values/storable/CharValueTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/CharValueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/test/java/org/neo4j/values/storable/CoordinateReferenceSystemTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/CoordinateReferenceSystemTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/test/java/org/neo4j/values/storable/DateTimeValueTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/DateTimeValueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/test/java/org/neo4j/values/storable/DateValueTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/DateValueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/test/java/org/neo4j/values/storable/DurationBuilderTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/DurationBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/test/java/org/neo4j/values/storable/DurationValueTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/DurationValueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/test/java/org/neo4j/values/storable/FrozenClockRule.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/FrozenClockRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/test/java/org/neo4j/values/storable/InputMappingStructureBuilder.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/InputMappingStructureBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/test/java/org/neo4j/values/storable/LocalDateTimeValueTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/LocalDateTimeValueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/test/java/org/neo4j/values/storable/LocalTimeValueTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/LocalTimeValueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/test/java/org/neo4j/values/storable/NumberValueMathTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/NumberValueMathTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/test/java/org/neo4j/values/storable/NumberValuesTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/NumberValuesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/test/java/org/neo4j/values/storable/PointTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/PointTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/test/java/org/neo4j/values/storable/StringsLibrary.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/StringsLibrary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/test/java/org/neo4j/values/storable/TextValueTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/TextValueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/test/java/org/neo4j/values/storable/ThrowingValueWriter.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/ThrowingValueWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/test/java/org/neo4j/values/storable/ThrowingValueWriterTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/ThrowingValueWriterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/test/java/org/neo4j/values/storable/TimeValueTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/TimeValueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/test/java/org/neo4j/values/storable/TimeZonesTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/TimeZonesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/test/java/org/neo4j/values/storable/UTF8StringValueTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/UTF8StringValueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/test/java/org/neo4j/values/storable/ValueAsObjectCopyTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/ValueAsObjectCopyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/test/java/org/neo4j/values/storable/ValueComparisonTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/ValueComparisonTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/test/java/org/neo4j/values/storable/ValueEqualityTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/ValueEqualityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/test/java/org/neo4j/values/storable/ValueTupleTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/ValueTupleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/test/java/org/neo4j/values/storable/ValueWriteToTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/ValueWriteToTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/test/java/org/neo4j/values/storable/ValuesTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/ValuesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/test/java/org/neo4j/values/utils/AnyValueTestUtil.java
+++ b/community/values/src/test/java/org/neo4j/values/utils/AnyValueTestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/test/java/org/neo4j/values/utils/PrettyPrinterTest.java
+++ b/community/values/src/test/java/org/neo4j/values/utils/PrettyPrinterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/test/java/org/neo4j/values/utils/TemporalUtilTest.java
+++ b/community/values/src/test/java/org/neo4j/values/utils/TemporalUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/test/java/org/neo4j/values/virtual/ConcatListTest.java
+++ b/community/values/src/test/java/org/neo4j/values/virtual/ConcatListTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/test/java/org/neo4j/values/virtual/DropNoValuesListValueTest.java
+++ b/community/values/src/test/java/org/neo4j/values/virtual/DropNoValuesListValueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/test/java/org/neo4j/values/virtual/GraphElementValueTest.java
+++ b/community/values/src/test/java/org/neo4j/values/virtual/GraphElementValueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/test/java/org/neo4j/values/virtual/IntegralRangeListValueTest.java
+++ b/community/values/src/test/java/org/neo4j/values/virtual/IntegralRangeListValueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/test/java/org/neo4j/values/virtual/ListSliceTest.java
+++ b/community/values/src/test/java/org/neo4j/values/virtual/ListSliceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/test/java/org/neo4j/values/virtual/ListTest.java
+++ b/community/values/src/test/java/org/neo4j/values/virtual/ListTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/test/java/org/neo4j/values/virtual/MapTest.java
+++ b/community/values/src/test/java/org/neo4j/values/virtual/MapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/test/java/org/neo4j/values/virtual/ReversedListTest.java
+++ b/community/values/src/test/java/org/neo4j/values/virtual/ReversedListTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/test/java/org/neo4j/values/virtual/VirtualValueTestUtil.java
+++ b/community/values/src/test/java/org/neo4j/values/virtual/VirtualValueTestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/community/values/src/test/java/org/neo4j/values/virtual/VirtualValueWriteToTest.java
+++ b/community/values/src/test/java/org/neo4j/values/virtual/VirtualValueWriteToTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB.

--- a/enterprise/auth-plugin-api/NOTICE.txt
+++ b/enterprise/auth-plugin-api/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/enterprise/auth-plugin-api/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/api/AuthProviderOperations.java
+++ b/enterprise/auth-plugin-api/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/api/AuthProviderOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/auth-plugin-api/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/api/AuthToken.java
+++ b/enterprise/auth-plugin-api/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/api/AuthToken.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/auth-plugin-api/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/api/AuthenticationException.java
+++ b/enterprise/auth-plugin-api/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/api/AuthenticationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/auth-plugin-api/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/api/AuthorizationExpiredException.java
+++ b/enterprise/auth-plugin-api/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/api/AuthorizationExpiredException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/auth-plugin-api/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/api/PredefinedRoles.java
+++ b/enterprise/auth-plugin-api/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/api/PredefinedRoles.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/auth-plugin-api/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/spi/AuthInfo.java
+++ b/enterprise/auth-plugin-api/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/spi/AuthInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/auth-plugin-api/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/spi/AuthPlugin.java
+++ b/enterprise/auth-plugin-api/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/spi/AuthPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/auth-plugin-api/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/spi/AuthProviderLifecycle.java
+++ b/enterprise/auth-plugin-api/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/spi/AuthProviderLifecycle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/auth-plugin-api/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/spi/AuthenticationInfo.java
+++ b/enterprise/auth-plugin-api/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/spi/AuthenticationInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/auth-plugin-api/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/spi/AuthenticationPlugin.java
+++ b/enterprise/auth-plugin-api/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/spi/AuthenticationPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/auth-plugin-api/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/spi/AuthorizationInfo.java
+++ b/enterprise/auth-plugin-api/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/spi/AuthorizationInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/auth-plugin-api/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/spi/AuthorizationPlugin.java
+++ b/enterprise/auth-plugin-api/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/spi/AuthorizationPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/auth-plugin-api/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/spi/CacheableAuthInfo.java
+++ b/enterprise/auth-plugin-api/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/spi/CacheableAuthInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/auth-plugin-api/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/spi/CacheableAuthenticationInfo.java
+++ b/enterprise/auth-plugin-api/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/spi/CacheableAuthenticationInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/auth-plugin-api/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/spi/CustomCacheableAuthenticationInfo.java
+++ b/enterprise/auth-plugin-api/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/spi/CustomCacheableAuthenticationInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/NOTICE.txt
+++ b/enterprise/backup/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/enterprise/backup/src/main/java/org/neo4j/OnlineBackupCommandSection.java
+++ b/enterprise/backup/src/main/java/org/neo4j/OnlineBackupCommandSection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/main/java/org/neo4j/backup/BackupExtensionService.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/BackupExtensionService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/main/java/org/neo4j/backup/BackupTool.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/BackupTool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/main/java/org/neo4j/backup/IncrementalBackupNotPossibleException.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/IncrementalBackupNotPossibleException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackup.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupExtensionFactory.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupExtensionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupKernelExtension.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupKernelExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupSettings.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/main/java/org/neo4j/backup/TheBackupInterface.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/TheBackupInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/main/java/org/neo4j/backup/impl/AddressResolver.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/impl/AddressResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/main/java/org/neo4j/backup/impl/BackupClient.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/impl/BackupClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/main/java/org/neo4j/backup/impl/BackupCopyService.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/impl/BackupCopyService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/main/java/org/neo4j/backup/impl/BackupDelegator.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/impl/BackupDelegator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/main/java/org/neo4j/backup/impl/BackupImpl.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/impl/BackupImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/main/java/org/neo4j/backup/impl/BackupModule.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/impl/BackupModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/main/java/org/neo4j/backup/impl/BackupOutcome.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/impl/BackupOutcome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/main/java/org/neo4j/backup/impl/BackupOutputMonitor.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/impl/BackupOutputMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/main/java/org/neo4j/backup/impl/BackupProtocolService.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/impl/BackupProtocolService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/main/java/org/neo4j/backup/impl/BackupRecoveryService.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/impl/BackupRecoveryService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/main/java/org/neo4j/backup/impl/BackupServer.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/impl/BackupServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/main/java/org/neo4j/backup/impl/BackupStageOutcome.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/impl/BackupStageOutcome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/main/java/org/neo4j/backup/impl/BackupStrategy.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/impl/BackupStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/main/java/org/neo4j/backup/impl/BackupStrategyCoordinator.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/impl/BackupStrategyCoordinator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/main/java/org/neo4j/backup/impl/BackupStrategyCoordinatorFactory.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/impl/BackupStrategyCoordinatorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/main/java/org/neo4j/backup/impl/BackupStrategyOutcome.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/impl/BackupStrategyOutcome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/main/java/org/neo4j/backup/impl/BackupStrategyWrapper.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/impl/BackupStrategyWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/main/java/org/neo4j/backup/impl/BackupSupportingClasses.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/impl/BackupSupportingClasses.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/main/java/org/neo4j/backup/impl/BackupSupportingClassesFactory.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/impl/BackupSupportingClassesFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/main/java/org/neo4j/backup/impl/BackupSupportingClassesFactoryProvider.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/impl/BackupSupportingClassesFactoryProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/main/java/org/neo4j/backup/impl/BufferReusingChunkingChannelBuffer.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/impl/BufferReusingChunkingChannelBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/main/java/org/neo4j/backup/impl/CausalClusteringBackupStrategy.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/impl/CausalClusteringBackupStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/main/java/org/neo4j/backup/impl/ConsistencyCheck.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/impl/ConsistencyCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/main/java/org/neo4j/backup/impl/ConsistencyCheckFailedException.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/impl/ConsistencyCheckFailedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/main/java/org/neo4j/backup/impl/Fallible.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/impl/Fallible.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/main/java/org/neo4j/backup/impl/HaBackupStrategy.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/impl/HaBackupStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/main/java/org/neo4j/backup/impl/OnlineBackupCommand.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/impl/OnlineBackupCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/main/java/org/neo4j/backup/impl/OnlineBackupCommandBuilder.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/impl/OnlineBackupCommandBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/main/java/org/neo4j/backup/impl/OnlineBackupCommandProvider.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/impl/OnlineBackupCommandProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/main/java/org/neo4j/backup/impl/OnlineBackupContext.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/impl/OnlineBackupContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/main/java/org/neo4j/backup/impl/OnlineBackupContextBuilder.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/impl/OnlineBackupContextBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/main/java/org/neo4j/backup/impl/OnlineBackupRequiredArguments.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/impl/OnlineBackupRequiredArguments.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/main/java/org/neo4j/backup/impl/OpenEnterpriseBackupSupportingClassesFactory.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/impl/OpenEnterpriseBackupSupportingClassesFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/main/java/org/neo4j/backup/impl/OpenEnterpriseBackupSupportingClassesFactoryProvider.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/impl/OpenEnterpriseBackupSupportingClassesFactoryProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/main/java/org/neo4j/backup/impl/SelectedBackupProtocol.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/impl/SelectedBackupProtocol.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/main/java/org/neo4j/backup/impl/StoreCopyResponsePacker.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/impl/StoreCopyResponsePacker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/main/java/org/neo4j/backup/impl/StrategyResolverService.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/impl/StrategyResolverService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/main/java/org/neo4j/restore/RestoreDatabaseCli.java
+++ b/enterprise/backup/src/main/java/org/neo4j/restore/RestoreDatabaseCli.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/main/java/org/neo4j/restore/RestoreDatabaseCliProvider.java
+++ b/enterprise/backup/src/main/java/org/neo4j/restore/RestoreDatabaseCliProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/main/java/org/neo4j/restore/RestoreDatabaseCommand.java
+++ b/enterprise/backup/src/main/java/org/neo4j/restore/RestoreDatabaseCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/test/java/org/neo4j/backup/BackupIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/BackupIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/test/java/org/neo4j/backup/BackupToolCmdArgumentsAcceptanceTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/BackupToolCmdArgumentsAcceptanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/test/java/org/neo4j/backup/BackupToolIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/BackupToolIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/test/java/org/neo4j/backup/BackupToolTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/BackupToolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/test/java/org/neo4j/backup/BackupToolUrisTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/BackupToolUrisTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/test/java/org/neo4j/backup/EmbeddedServer.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/EmbeddedServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/test/java/org/neo4j/backup/ExceptionMatchers.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/ExceptionMatchers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/test/java/org/neo4j/backup/IncrementalBackupIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/IncrementalBackupIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/test/java/org/neo4j/backup/OnlineBackupExtensionIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/OnlineBackupExtensionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/test/java/org/neo4j/backup/ServerInterface.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/ServerInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/test/java/org/neo4j/backup/TestConfiguration.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/TestConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/test/java/org/neo4j/backup/impl/AddressResolverTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/impl/AddressResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/test/java/org/neo4j/backup/impl/BackupCopyServiceTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/impl/BackupCopyServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/test/java/org/neo4j/backup/impl/BackupDelegatorTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/impl/BackupDelegatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/test/java/org/neo4j/backup/impl/BackupHelpOutput.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/impl/BackupHelpOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/test/java/org/neo4j/backup/impl/BackupImplTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/impl/BackupImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/test/java/org/neo4j/backup/impl/BackupOutputMonitorTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/impl/BackupOutputMonitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/test/java/org/neo4j/backup/impl/BackupProtocolIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/impl/BackupProtocolIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/test/java/org/neo4j/backup/impl/BackupProtocolServiceIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/impl/BackupProtocolServiceIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/test/java/org/neo4j/backup/impl/BackupProtocolServiceStrategyTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/impl/BackupProtocolServiceStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/test/java/org/neo4j/backup/impl/BackupStrategyCoordinatorTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/impl/BackupStrategyCoordinatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/test/java/org/neo4j/backup/impl/BackupStrategyWrapperTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/impl/BackupStrategyWrapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/test/java/org/neo4j/backup/impl/BackupSupportingClassesFactoryProviderTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/impl/BackupSupportingClassesFactoryProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/test/java/org/neo4j/backup/impl/BufferReusingChunkingChannelBufferTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/impl/BufferReusingChunkingChannelBufferTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/test/java/org/neo4j/backup/impl/CausalClusteringBackupStrategyTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/impl/CausalClusteringBackupStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/test/java/org/neo4j/backup/impl/OnlineBackupCommandCcIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/impl/OnlineBackupCommandCcIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/test/java/org/neo4j/backup/impl/OnlineBackupCommandHaIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/impl/OnlineBackupCommandHaIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/test/java/org/neo4j/backup/impl/OnlineBackupCommandProviderTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/impl/OnlineBackupCommandProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/test/java/org/neo4j/backup/impl/OnlineBackupCommandTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/impl/OnlineBackupCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/test/java/org/neo4j/backup/impl/OnlineBackupContextBuilderTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/impl/OnlineBackupContextBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/test/java/org/neo4j/backup/impl/StrategyResolverServiceTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/impl/StrategyResolverServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/test/java/org/neo4j/causalclustering/BackupCoreIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/causalclustering/BackupCoreIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/test/java/org/neo4j/causalclustering/BackupReadReplicaIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/causalclustering/BackupReadReplicaIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/test/java/org/neo4j/causalclustering/BackupUtil.java
+++ b/enterprise/backup/src/test/java/org/neo4j/causalclustering/BackupUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/test/java/org/neo4j/causalclustering/ClusterHelper.java
+++ b/enterprise/backup/src/test/java/org/neo4j/causalclustering/ClusterHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/test/java/org/neo4j/causalclustering/ClusterSeedingIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/causalclustering/ClusterSeedingIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/test/java/org/neo4j/causalclustering/FileCopyDetector.java
+++ b/enterprise/backup/src/test/java/org/neo4j/causalclustering/FileCopyDetector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/test/java/org/neo4j/causalclustering/NewMemberSeedingIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/causalclustering/NewMemberSeedingIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/test/java/org/neo4j/causalclustering/backup_stores/AbstractStoreGenerator.java
+++ b/enterprise/backup/src/test/java/org/neo4j/causalclustering/backup_stores/AbstractStoreGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/test/java/org/neo4j/causalclustering/backup_stores/BackupStore.java
+++ b/enterprise/backup/src/test/java/org/neo4j/causalclustering/backup_stores/BackupStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/test/java/org/neo4j/causalclustering/backup_stores/BackupStoreWithSomeData.java
+++ b/enterprise/backup/src/test/java/org/neo4j/causalclustering/backup_stores/BackupStoreWithSomeData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/test/java/org/neo4j/causalclustering/backup_stores/BackupStoreWithSomeDataButNoTransactionLogs.java
+++ b/enterprise/backup/src/test/java/org/neo4j/causalclustering/backup_stores/BackupStoreWithSomeDataButNoTransactionLogs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/test/java/org/neo4j/causalclustering/backup_stores/EmptyBackupStore.java
+++ b/enterprise/backup/src/test/java/org/neo4j/causalclustering/backup_stores/EmptyBackupStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/test/java/org/neo4j/causalclustering/backup_stores/NoStore.java
+++ b/enterprise/backup/src/test/java/org/neo4j/causalclustering/backup_stores/NoStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/test/java/org/neo4j/causalclustering/cluster_load/ClusterLoad.java
+++ b/enterprise/backup/src/test/java/org/neo4j/causalclustering/cluster_load/ClusterLoad.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/test/java/org/neo4j/causalclustering/cluster_load/NoLoad.java
+++ b/enterprise/backup/src/test/java/org/neo4j/causalclustering/cluster_load/NoLoad.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/test/java/org/neo4j/causalclustering/cluster_load/SmallBurst.java
+++ b/enterprise/backup/src/test/java/org/neo4j/causalclustering/cluster_load/SmallBurst.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/test/java/org/neo4j/commandline/admin/BackupUsageTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/commandline/admin/BackupUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/backup/src/test/java/org/neo4j/restore/RestoreDatabaseCommandIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/restore/RestoreDatabaseCommandIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/NOTICE.txt
+++ b/enterprise/causal-clustering/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/ReplicationModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/ReplicationModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/SessionTracker.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/SessionTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/VersionPrepender.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/VersionPrepender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchUpChannelPool.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchUpChannelPool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchUpClient.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchUpClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchUpClientException.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchUpClientException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchUpProtocolViolationException.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchUpProtocolViolationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchUpResponseAdaptor.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchUpResponseAdaptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchUpResponseCallback.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchUpResponseCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchUpResponseHandler.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchUpResponseHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchupAddressProvider.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchupAddressProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchupAddressResolutionException.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchupAddressResolutionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchupClientBuilder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchupClientBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchupClientProtocol.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchupClientProtocol.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchupProtocolClientInstaller.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchupProtocolClientInstaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchupProtocolServerInstaller.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchupProtocolServerInstaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchupResult.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchupResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchupServerBuilder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchupServerBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchupServerHandler.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchupServerHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchupServerProtocol.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchupServerProtocol.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CheckpointerSupplier.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CheckpointerSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/ClientMessageTypeHandler.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/ClientMessageTypeHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/Protocol.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/Protocol.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/RegularCatchupServerHandler.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/RegularCatchupServerHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/RequestDecoderDispatcher.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/RequestDecoderDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/RequestMessageType.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/RequestMessageType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/RequestMessageTypeEncoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/RequestMessageTypeEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/ResponseMessageType.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/ResponseMessageType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/ResponseMessageTypeEncoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/ResponseMessageTypeEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/ServerMessageTypeHandler.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/ServerMessageTypeHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/SimpleRequestDecoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/SimpleRequestDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/StoreListingResponseHandler.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/StoreListingResponseHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/TimeoutLoop.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/TimeoutLoop.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/TrackingResponseHandler.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/TrackingResponseHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/TxPullRequestResult.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/TxPullRequestResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/CloseablesListener.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/CloseablesListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/CommitState.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/CommitState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/CommitStateHelper.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/CommitStateHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/CopiedStoreRecovery.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/CopiedStoreRecovery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/DataSourceChecks.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/DataSourceChecks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/DatabaseShutdownException.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/DatabaseShutdownException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/FileChunk.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/FileChunk.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/FileChunkDecoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/FileChunkDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/FileChunkEncoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/FileChunkEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/FileChunkHandler.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/FileChunkHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/FileHeader.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/FileHeader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/FileHeaderDecoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/FileHeaderDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/FileHeaderEncoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/FileHeaderEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/FileHeaderHandler.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/FileHeaderHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/FileSender.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/FileSender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/GetIndexFilesRequest.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/GetIndexFilesRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/GetStoreFileRequest.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/GetStoreFileRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/GetStoreIdRequest.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/GetStoreIdRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/GetStoreIdRequestEncoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/GetStoreIdRequestEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/GetStoreIdRequestHandler.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/GetStoreIdRequestHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/GetStoreIdResponse.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/GetStoreIdResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/GetStoreIdResponseDecoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/GetStoreIdResponseDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/GetStoreIdResponseEncoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/GetStoreIdResponseEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/GetStoreIdResponseHandler.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/GetStoreIdResponseHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/LocalDatabase.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/LocalDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/MaximumTotalTime.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/MaximumTotalTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/PrepareStoreCopyFiles.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/PrepareStoreCopyFiles.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/PrepareStoreCopyFilesProvider.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/PrepareStoreCopyFilesProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/PrepareStoreCopyRequest.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/PrepareStoreCopyRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/PrepareStoreCopyRequestDecoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/PrepareStoreCopyRequestDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/PrepareStoreCopyRequestEncoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/PrepareStoreCopyRequestEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/PrepareStoreCopyRequestHandler.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/PrepareStoreCopyRequestHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/PrepareStoreCopyResponse.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/PrepareStoreCopyResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/RemoteStore.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/RemoteStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreCopyClient.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreCopyClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreCopyFailedException.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreCopyFailedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreCopyFinishedResponse.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreCopyFinishedResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreCopyFinishedResponseDecoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreCopyFinishedResponseDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreCopyFinishedResponseEncoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreCopyFinishedResponseEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreCopyFinishedResponseHandler.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreCopyFinishedResponseHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreCopyProcess.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreCopyProcess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreCopyRequestHandler.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreCopyRequestHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreCopyResponseAdaptors.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreCopyResponseAdaptors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreFileReceiver.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreFileReceiver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreFileStream.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreFileStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreFileStreamProvider.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreFileStreamProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreFileStreamingProtocol.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreFileStreamingProtocol.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreFiles.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreFiles.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreIdDownloadFailedException.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreIdDownloadFailedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreResource.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreResourceStreamFactory.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreResourceStreamFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreStreamingProcess.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreStreamingProcess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StreamToDisk.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StreamToDisk.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StreamToDiskProvider.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StreamToDiskProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/TemporaryStoreDirectory.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/TemporaryStoreDirectory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/TerminationCondition.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/TerminationCondition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/BatchingTxApplier.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/BatchingTxApplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/CatchupPollingProcess.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/CatchupPollingProcess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/ChunkedTransactionStream.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/ChunkedTransactionStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/FileCopyMonitor.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/FileCopyMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/PullRequestMonitor.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/PullRequestMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TransactionApplier.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TransactionApplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TransactionLogCatchUpFactory.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TransactionLogCatchUpFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TransactionLogCatchUpWriter.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TransactionLogCatchUpWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TxPullClient.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TxPullClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TxPullRequest.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TxPullRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TxPullRequestDecoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TxPullRequestDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TxPullRequestEncoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TxPullRequestEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TxPullRequestHandler.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TxPullRequestHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TxPullRequestsMonitor.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TxPullRequestsMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TxPullResponse.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TxPullResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TxPullResponseDecoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TxPullResponseDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TxPullResponseEncoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TxPullResponseEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TxPullResponseHandler.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TxPullResponseHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TxPullResponseListener.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TxPullResponseListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TxRetryMonitor.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TxRetryMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TxStreamCompleteListener.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TxStreamCompleteListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TxStreamFinishedResponse.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TxStreamFinishedResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TxStreamFinishedResponseDecoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TxStreamFinishedResponseDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TxStreamFinishedResponseEncoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TxStreamFinishedResponseEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TxStreamFinishedResponseHandler.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TxStreamFinishedResponseHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TxStreamListener.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TxStreamListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/BatchingMessageHandler.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/BatchingMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/CausalClusterConfigurationValidator.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/CausalClusterConfigurationValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/CausalClusteringSettings.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/CausalClusteringSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/ClusterBindingHandler.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/ClusterBindingHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/CoreGraphDatabase.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/CoreGraphDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/EnterpriseCoreEditionModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/EnterpriseCoreEditionModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/IdentityModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/IdentityModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/LeaderCanWrite.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/LeaderCanWrite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/OpenEnterpriseCoreEditionModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/OpenEnterpriseCoreEditionModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/OpenEnterpriseCoreGraphDatabase.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/OpenEnterpriseCoreGraphDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/RaftServerModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/RaftServerModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/SupportedProtocolCreator.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/SupportedProtocolCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/TransactionBackupServiceAddressResolver.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/TransactionBackupServiceAddressResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/TransactionBackupServiceProvider.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/TransactionBackupServiceProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/ConsensusModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/ConsensusModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/ContinuousJob.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/ContinuousJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/CoreMetaData.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/CoreMetaData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/Followers.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/Followers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/LeaderAvailabilityHandler.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/LeaderAvailabilityHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/LeaderAvailabilityTimers.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/LeaderAvailabilityTimers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/LeaderContext.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/LeaderContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/LeaderInfo.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/LeaderInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/LeaderListener.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/LeaderListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/LeaderLocator.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/LeaderLocator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/LeaderNotFoundMonitor.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/LeaderNotFoundMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/MajorityIncludingSelfQuorum.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/MajorityIncludingSelfQuorum.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/NewLeaderBarrier.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/NewLeaderBarrier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/NoLeaderFoundException.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/NoLeaderFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/RaftMachine.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/RaftMachine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/RaftMessageHandler.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/RaftMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/RaftMessageMonitoringHandler.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/RaftMessageMonitoringHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/RaftMessageNettyHandler.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/RaftMessageNettyHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/RaftMessageProcessingMonitor.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/RaftMessageProcessingMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/RaftMessages.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/RaftMessages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/RaftProtocolClientInstaller.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/RaftProtocolClientInstaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/RaftProtocolServerInstaller.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/RaftProtocolServerInstaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/DelegatingRaftLog.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/DelegatingRaftLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/EntryRecord.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/EntryRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/InMemoryRaftLog.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/InMemoryRaftLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/LogPosition.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/LogPosition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/MonitoredRaftLog.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/MonitoredRaftLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/RaftLog.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/RaftLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/RaftLogCursor.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/RaftLogCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/RaftLogEntry.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/RaftLogEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/RaftLogMetadataCache.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/RaftLogMetadataCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/ReadableRaftLog.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/ReadableRaftLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/cache/CircularBuffer.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/cache/CircularBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/cache/ConsecutiveCache.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/cache/ConsecutiveCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/cache/ConsecutiveInFlightCache.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/cache/ConsecutiveInFlightCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/cache/InFlightCache.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/cache/InFlightCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/cache/InFlightCacheFactory.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/cache/InFlightCacheFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/cache/InFlightCacheMonitor.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/cache/InFlightCacheMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/cache/UnboundedInFlightCache.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/cache/UnboundedInFlightCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/cache/VoidInFlightCache.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/cache/VoidInFlightCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/debug/LogPrinter.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/debug/LogPrinter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/monitoring/RaftLogAppendIndexMonitor.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/monitoring/RaftLogAppendIndexMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/monitoring/RaftLogCommitIndexMonitor.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/monitoring/RaftLogCommitIndexMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/monitoring/RaftTermMonitor.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/monitoring/RaftTermMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/pruning/PruningScheduler.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/pruning/PruningScheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/segmented/CoreLogPruningStrategy.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/segmented/CoreLogPruningStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/segmented/CoreLogPruningStrategyFactory.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/segmented/CoreLogPruningStrategyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/segmented/DamagedLogStorageException.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/segmented/DamagedLogStorageException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/segmented/DisposedException.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/segmented/DisposedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/segmented/DumpSegmentedRaftLog.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/segmented/DumpSegmentedRaftLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/segmented/EntryBasedLogPruningStrategy.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/segmented/EntryBasedLogPruningStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/segmented/EntryCursor.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/segmented/EntryCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/segmented/EntryRecordCursor.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/segmented/EntryRecordCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/segmented/FileNames.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/segmented/FileNames.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/segmented/InFlightMap.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/segmented/InFlightMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/segmented/NoPruningPruningStrategy.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/segmented/NoPruningPruningStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/segmented/OpenEndRangeMap.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/segmented/OpenEndRangeMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/segmented/PositionCache.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/segmented/PositionCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/segmented/Reader.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/segmented/Reader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/segmented/ReaderPool.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/segmented/ReaderPool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/segmented/RecoveryProtocol.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/segmented/RecoveryProtocol.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/segmented/ReferenceCounter.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/segmented/ReferenceCounter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/segmented/SegmentFile.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/segmented/SegmentFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/segmented/SegmentHeader.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/segmented/SegmentHeader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/segmented/SegmentedRaftLog.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/segmented/SegmentedRaftLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/segmented/SegmentedRaftLogCursor.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/segmented/SegmentedRaftLogCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/segmented/SegmentedRaftLogPruner.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/segmented/SegmentedRaftLogPruner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/segmented/Segments.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/segmented/Segments.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/segmented/SizeBasedLogPruningStrategy.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/segmented/SizeBasedLogPruningStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/segmented/State.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/segmented/State.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/segmented/Terms.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/segmented/Terms.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/membership/CatchupGoal.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/membership/CatchupGoal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/membership/CatchupGoalTracker.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/membership/CatchupGoalTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/membership/MemberIdSet.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/membership/MemberIdSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/membership/MemberIdSetBuilder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/membership/MemberIdSetBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/membership/MemberIdSetSerializer.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/membership/MemberIdSetSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/membership/MembershipEntry.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/membership/MembershipEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/membership/MembershipWaiter.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/membership/MembershipWaiter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/membership/MembershipWaiterLifecycle.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/membership/MembershipWaiterLifecycle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/membership/RaftGroup.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/membership/RaftGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/membership/RaftMembership.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/membership/RaftMembership.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/membership/RaftMembershipChanger.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/membership/RaftMembershipChanger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/membership/RaftMembershipManager.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/membership/RaftMembershipManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/membership/RaftMembershipState.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/membership/RaftMembershipState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/membership/RaftMembershipStateMachineEventHandler.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/membership/RaftMembershipStateMachineEventHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/outcome/AppendLogEntry.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/outcome/AppendLogEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/outcome/BatchAppendLogEntries.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/outcome/BatchAppendLogEntries.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/outcome/ConsensusOutcome.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/outcome/ConsensusOutcome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/outcome/Messages.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/outcome/Messages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/outcome/Outcome.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/outcome/Outcome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/outcome/PruneLogCommand.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/outcome/PruneLogCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/outcome/RaftLogCommand.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/outcome/RaftLogCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/outcome/ShipCommand.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/outcome/ShipCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/outcome/TruncateLogCommand.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/outcome/TruncateLogCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/roles/Appending.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/roles/Appending.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/roles/Candidate.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/roles/Candidate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/roles/Election.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/roles/Election.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/roles/Follower.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/roles/Follower.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/roles/Heart.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/roles/Heart.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/roles/Leader.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/roles/Leader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/roles/Pruning.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/roles/Pruning.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/roles/Role.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/roles/Role.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/roles/Voting.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/roles/Voting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/roles/follower/FollowerState.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/roles/follower/FollowerState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/roles/follower/FollowerStates.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/roles/follower/FollowerStates.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/schedule/Delay.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/schedule/Delay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/schedule/FixedTimeout.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/schedule/FixedTimeout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/schedule/Timeout.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/schedule/Timeout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/schedule/TimeoutFactory.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/schedule/TimeoutFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/schedule/TimeoutHandler.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/schedule/TimeoutHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/schedule/Timer.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/schedule/Timer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/schedule/TimerService.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/schedule/TimerService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/schedule/UniformRandomTimeout.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/schedule/UniformRandomTimeout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/shipping/RaftLogShipper.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/shipping/RaftLogShipper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/shipping/RaftLogShippingManager.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/shipping/RaftLogShippingManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/state/ExposedRaftState.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/state/ExposedRaftState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/state/RaftState.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/state/RaftState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/state/ReadableRaftState.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/state/ReadableRaftState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/term/MonitoredTermStateStorage.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/term/MonitoredTermStateStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/term/TermState.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/term/TermState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/vote/VoteState.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/vote/VoteState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/replication/BenchmarkResult.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/replication/BenchmarkResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/replication/DistributedOperation.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/replication/DistributedOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/replication/Progress.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/replication/Progress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/replication/ProgressTracker.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/replication/ProgressTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/replication/ProgressTrackerImpl.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/replication/ProgressTrackerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/replication/RaftReplicator.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/replication/RaftReplicator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/replication/ReplicatedContent.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/replication/ReplicatedContent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/replication/ReplicationBenchmarkProcedure.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/replication/ReplicationBenchmarkProcedure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/replication/Replicator.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/replication/Replicator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/replication/SendToMyself.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/replication/SendToMyself.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/replication/Throttler.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/replication/Throttler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/replication/session/GlobalSession.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/replication/session/GlobalSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/replication/session/GlobalSessionTrackerState.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/replication/session/GlobalSessionTrackerState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/replication/session/LocalOperationId.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/replication/session/LocalOperationId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/replication/session/LocalSession.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/replication/session/LocalSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/replication/session/LocalSessionPool.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/replication/session/LocalSessionPool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/replication/session/OperationContext.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/replication/session/OperationContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/server/CoreServerModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/server/CoreServerModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/ClusterStateDirectory.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/ClusterStateDirectory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/ClusterStateException.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/ClusterStateException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/ClusteringModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/ClusteringModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/CommandApplicationProcess.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/CommandApplicationProcess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/CommandBatcher.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/CommandBatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/CommandDispatcher.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/CommandDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/CoreBootstrapper.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/CoreBootstrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/CoreLife.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/CoreLife.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/CoreSnapshotService.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/CoreSnapshotService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/CoreState.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/CoreState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/DumpClusterState.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/DumpClusterState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/InFlightLogEntryReader.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/InFlightLogEntryReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/LongIndexMarshal.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/LongIndexMarshal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/RaftLogPruner.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/RaftLogPruner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/RaftMessageApplier.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/RaftMessageApplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/Result.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/Result.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/StateRecoveryManager.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/StateRecoveryManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/CoreStateMachines.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/CoreStateMachines.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/CoreStateMachinesModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/CoreStateMachinesModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/StateMachine.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/StateMachine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/dummy/DummyMachine.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/dummy/DummyMachine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/dummy/DummyRequest.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/dummy/DummyRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/id/CommandIndexTracker.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/id/CommandIndexTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/id/FreeIdFilteredIdGenerator.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/id/FreeIdFilteredIdGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/id/FreeIdFilteredIdGeneratorFactory.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/id/FreeIdFilteredIdGeneratorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/id/IdAllocation.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/id/IdAllocation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/id/IdAllocationState.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/id/IdAllocationState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/id/IdGenerationException.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/id/IdGenerationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/id/IdReusabilityCondition.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/id/IdReusabilityCondition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/id/ReplicatedIdAllocationRequest.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/id/ReplicatedIdAllocationRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/id/ReplicatedIdAllocationRequestSerializer.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/id/ReplicatedIdAllocationRequestSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/id/ReplicatedIdAllocationStateMachine.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/id/ReplicatedIdAllocationStateMachine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/id/ReplicatedIdGenerator.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/id/ReplicatedIdGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/id/ReplicatedIdGeneratorFactory.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/id/ReplicatedIdGeneratorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/id/ReplicatedIdRangeAcquirer.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/id/ReplicatedIdRangeAcquirer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/id/UnallocatedIds.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/id/UnallocatedIds.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/locks/LeaderOnlyLockManager.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/locks/LeaderOnlyLockManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/locks/LockToken.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/locks/LockToken.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/locks/ReplicatedLockTokenRequest.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/locks/ReplicatedLockTokenRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/locks/ReplicatedLockTokenSerializer.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/locks/ReplicatedLockTokenSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/locks/ReplicatedLockTokenState.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/locks/ReplicatedLockTokenState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/locks/ReplicatedLockTokenStateMachine.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/locks/ReplicatedLockTokenStateMachine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/token/ReplicatedLabelTokenHolder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/token/ReplicatedLabelTokenHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/token/ReplicatedPropertyKeyTokenHolder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/token/ReplicatedPropertyKeyTokenHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/token/ReplicatedRelationshipTypeTokenHolder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/token/ReplicatedRelationshipTypeTokenHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/token/ReplicatedTokenHolder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/token/ReplicatedTokenHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/token/ReplicatedTokenRequest.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/token/ReplicatedTokenRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/token/ReplicatedTokenRequestSerializer.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/token/ReplicatedTokenRequestSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/token/ReplicatedTokenStateMachine.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/token/ReplicatedTokenStateMachine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/token/TokenRegistry.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/token/TokenRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/token/TokenType.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/token/TokenType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/tx/CoreReplicatedContent.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/tx/CoreReplicatedContent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/tx/LastCommittedIndexFinder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/tx/LastCommittedIndexFinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/tx/LogIndexTxHeaderEncoding.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/tx/LogIndexTxHeaderEncoding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/tx/RecoverConsensusLogIndex.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/tx/RecoverConsensusLogIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/tx/ReplayableCommitProcess.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/tx/ReplayableCommitProcess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/tx/ReplicatedTransaction.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/tx/ReplicatedTransaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/tx/ReplicatedTransactionCommitProcess.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/tx/ReplicatedTransactionCommitProcess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/tx/ReplicatedTransactionFactory.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/tx/ReplicatedTransactionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/tx/ReplicatedTransactionSerializer.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/tx/ReplicatedTransactionSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/tx/ReplicatedTransactionStateMachine.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/tx/ReplicatedTransactionStateMachine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/tx/TransactionCounter.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/tx/TransactionCounter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/CoreSnapshot.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/CoreSnapshot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/CoreSnapshotDecoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/CoreSnapshotDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/CoreSnapshotEncoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/CoreSnapshotEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/CoreSnapshotListener.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/CoreSnapshotListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/CoreSnapshotRequest.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/CoreSnapshotRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/CoreSnapshotRequestEncoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/CoreSnapshotRequestEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/CoreSnapshotRequestHandler.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/CoreSnapshotRequestHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/CoreSnapshotResponseHandler.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/CoreSnapshotResponseHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/CoreStateDownloader.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/CoreStateDownloader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/CoreStateDownloaderService.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/CoreStateDownloaderService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/CoreStateType.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/CoreStateType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/PersistentSnapshotDownloader.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/PersistentSnapshotDownloader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/RaftCoreState.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/RaftCoreState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/TopologyLookupException.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/TopologyLookupException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/storage/DurableStateStorage.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/storage/DurableStateStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/storage/DurableStateStorageImporter.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/storage/DurableStateStorageImporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/storage/InMemoryStateStorage.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/storage/InMemoryStateStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/storage/SafeChannelMarshal.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/storage/SafeChannelMarshal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/storage/SafeStateMarshal.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/storage/SafeStateMarshal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/storage/SimpleFileStorage.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/storage/SimpleFileStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/storage/SimpleStorage.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/storage/SimpleStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/storage/StateMarshal.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/storage/StateMarshal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/storage/StateStorage.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/storage/StateStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/diagnostics/ClusterDiagnosticsOfflineReportProvider.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/diagnostics/ClusterDiagnosticsOfflineReportProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/AbstractTopologyService.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/AbstractTopologyService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/CatchupServerAddress.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/CatchupServerAddress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/ClientConnector.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/ClientConnector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/ClientConnectorAddresses.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/ClientConnectorAddresses.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/ClusterTopology.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/ClusterTopology.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/CoreServerInfo.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/CoreServerInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/CoreTopology.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/CoreTopology.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/CoreTopologyListenerService.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/CoreTopologyListenerService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/CoreTopologyService.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/CoreTopologyService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/Difference.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/Difference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/DiscoveryServerInfo.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/DiscoveryServerInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/DiscoveryServiceFactory.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/DiscoveryServiceFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/DnsHostnameResolver.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/DnsHostnameResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/DomainNameResolver.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/DomainNameResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/DomainNameResolverImpl.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/DomainNameResolverImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/GroupedServer.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/GroupedServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastClient.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastClientConnector.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastClientConnector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastClusterTopology.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastClusterTopology.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastConnector.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastConnector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastCoreTopologyService.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastCoreTopologyService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastDiscoveryServiceFactory.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastDiscoveryServiceFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastInstanceNotActiveException.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastInstanceNotActiveException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastLogger.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastLogging.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastLogging.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HostnameResolver.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HostnameResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/MapDomainNameResolver.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/MapDomainNameResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/MultiRetryStrategy.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/MultiRetryStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/NoOpHostnameResolver.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/NoOpHostnameResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/NoRetriesStrategy.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/NoRetriesStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/RaftCoreTopologyConnector.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/RaftCoreTopologyConnector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/ReadReplicaInfo.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/ReadReplicaInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/ReadReplicaTopology.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/ReadReplicaTopology.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/ResolutionResolverFactory.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/ResolutionResolverFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/RetryStrategy.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/RetryStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/RobustHazelcastWrapper.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/RobustHazelcastWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/RoleInfo.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/RoleInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/SecureHazelcastClientConnector.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/SecureHazelcastClientConnector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/SecureHazelcastConfiguration.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/SecureHazelcastConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/SecureHazelcastContextFactory.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/SecureHazelcastContextFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/SecureHazelcastCoreTopologyService.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/SecureHazelcastCoreTopologyService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/SecureHazelcastDiscoveryServiceFactory.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/SecureHazelcastDiscoveryServiceFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/SrvHostnameResolver.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/SrvHostnameResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/SrvRecordResolver.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/SrvRecordResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/SrvRecordResolverImpl.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/SrvRecordResolverImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/Topology.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/Topology.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/TopologyDifference.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/TopologyDifference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/TopologyService.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/TopologyService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/TopologyServiceMultiRetryStrategy.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/TopologyServiceMultiRetryStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/TopologyServiceNoRetriesStrategy.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/TopologyServiceNoRetriesStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/TopologyServiceRetryStrategy.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/TopologyServiceRetryStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/UnknownHostException.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/UnknownHostException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/procedures/ClusterOverviewProcedure.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/procedures/ClusterOverviewProcedure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/procedures/CoreRoleProcedure.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/procedures/CoreRoleProcedure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/procedures/InstalledProtocolsProcedure.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/procedures/InstalledProtocolsProcedure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/procedures/ReadReplicaRoleProcedure.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/procedures/ReadReplicaRoleProcedure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/procedures/RoleProcedure.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/procedures/RoleProcedure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/handlers/DuplexPipelineWrapperFactory.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/handlers/DuplexPipelineWrapperFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/handlers/ExceptionLoggingHandler.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/handlers/ExceptionLoggingHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/handlers/ExceptionMonitoringHandler.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/handlers/ExceptionMonitoringHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/handlers/ExceptionSwallowingHandler.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/handlers/ExceptionSwallowingHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/handlers/PipelineWrapper.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/handlers/PipelineWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/handlers/SecureClientPipelineWrapper.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/handlers/SecureClientPipelineWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/handlers/SecurePipelineWrapperFactory.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/handlers/SecurePipelineWrapperFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/handlers/SecureServerPipelineWrapper.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/handlers/SecureServerPipelineWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/handlers/VoidPipelineWrapperFactory.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/handlers/VoidPipelineWrapperFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/helper/CompositeSuspendable.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/helper/CompositeSuspendable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/helper/ConstantTimeTimeoutStrategy.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/helper/ConstantTimeTimeoutStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/helper/ErrorHandler.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/helper/ErrorHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/helper/ExponentialBackoffStrategy.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/helper/ExponentialBackoffStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/helper/RobustJobSchedulerWrapper.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/helper/RobustJobSchedulerWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/helper/StatUtil.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/helper/StatUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/helper/Suspendable.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/helper/Suspendable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/helper/SuspendableLifeCycle.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/helper/SuspendableLifeCycle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/helper/TimeoutStrategy.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/helper/TimeoutStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/helper/VolatileFuture.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/helper/VolatileFuture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/identity/BindingException.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/identity/BindingException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/identity/BoundState.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/identity/BoundState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/identity/ClusterBinder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/identity/ClusterBinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/identity/ClusterId.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/identity/ClusterId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/identity/DatabaseName.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/identity/DatabaseName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/identity/MemberId.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/identity/MemberId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/identity/StoreId.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/identity/StoreId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/logging/BetterMessageLogger.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/logging/BetterMessageLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/logging/MessageLogger.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/logging/MessageLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/logging/NullMessageLogger.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/logging/NullMessageLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/management/CausalClusteringBean.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/management/CausalClusteringBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/CatchUpRequest.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/CatchUpRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/Channel.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/Channel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/ComposableMessageHandler.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/ComposableMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/CoreReplicatedContentMarshal.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/CoreReplicatedContentMarshal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/EndOfStreamException.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/EndOfStreamException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/IdleChannelReaperHandler.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/IdleChannelReaperHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/Inbound.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/Inbound.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/LifecycleMessageHandler.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/LifecycleMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/LoggingInbound.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/LoggingInbound.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/LoggingOutbound.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/LoggingOutbound.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/Message.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/Message.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/MessageGate.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/MessageGate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/MessageTooBigException.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/MessageTooBigException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/NetworkFlushableByteBuf.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/NetworkFlushableByteBuf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/NetworkFlushableChannelNetty4.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/NetworkFlushableChannelNetty4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/NetworkReadableClosableChannelNetty4.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/NetworkReadableClosableChannelNetty4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/Outbound.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/Outbound.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/RaftOutbound.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/RaftOutbound.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/ReconnectingChannel.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/ReconnectingChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/ReconnectingChannels.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/ReconnectingChannels.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/SenderService.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/SenderService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/SimpleNettyChannel.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/SimpleNettyChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/StoreCopyRequest.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/StoreCopyRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/address/UnknownAddressMonitor.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/address/UnknownAddressMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/marshalling/ByteBufferMarshal.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/marshalling/ByteBufferMarshal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/marshalling/ChannelMarshal.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/marshalling/ChannelMarshal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/marshalling/RaftMessageDecoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/marshalling/RaftMessageDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/marshalling/RaftMessageEncoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/marshalling/RaftMessageEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/marshalling/StringMarshal.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/marshalling/StringMarshal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/marshalling/storeid/StoreIdMarshal.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/marshalling/storeid/StoreIdMarshal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/net/ChildInitializer.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/net/ChildInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/net/InstalledProtocolHandler.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/net/InstalledProtocolHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/net/Server.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/net/Server.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/ClientNettyPipelineBuilder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/ClientNettyPipelineBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/ModifierProtocolInstaller.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/ModifierProtocolInstaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/NettyPipelineBuilder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/NettyPipelineBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/NettyPipelineBuilderFactory.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/NettyPipelineBuilderFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/Protocol.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/Protocol.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/ProtocolInstaller.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/ProtocolInstaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/ProtocolInstallerRepository.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/ProtocolInstallerRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/ServerNettyPipelineBuilder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/ServerNettyPipelineBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/ApplicationProtocolRepository.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/ApplicationProtocolRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/ApplicationProtocolRequest.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/ApplicationProtocolRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/ApplicationProtocolResponse.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/ApplicationProtocolResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/ApplicationProtocolSelection.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/ApplicationProtocolSelection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/ApplicationSupportedProtocols.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/ApplicationSupportedProtocols.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/BaseProtocolRequest.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/BaseProtocolRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/BaseProtocolResponse.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/BaseProtocolResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/ClientHandshakeException.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/ClientHandshakeException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/ClientHandshakeFinishedEvent.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/ClientHandshakeFinishedEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/ClientMessage.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/ClientMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/ClientMessageDecoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/ClientMessageDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/ClientMessageEncoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/ClientMessageEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/ClientMessageHandler.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/ClientMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/GateEvent.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/GateEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/HandshakeClient.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/HandshakeClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/HandshakeClientInitializer.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/HandshakeClientInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/HandshakeServer.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/HandshakeServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/HandshakeServerInitializer.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/HandshakeServerInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/InitialMagicMessage.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/InitialMagicMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/ModifierProtocolRepository.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/ModifierProtocolRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/ModifierProtocolRequest.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/ModifierProtocolRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/ModifierProtocolResponse.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/ModifierProtocolResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/ModifierProtocolSelection.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/ModifierProtocolSelection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/ModifierSupportedProtocols.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/ModifierSupportedProtocols.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/NettyHandshakeClient.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/NettyHandshakeClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/NettyHandshakeServer.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/NettyHandshakeServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/ProtocolRepository.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/ProtocolRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/ProtocolSelection.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/ProtocolSelection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/ProtocolStack.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/ProtocolStack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/ServerHandshakeException.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/ServerHandshakeException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/ServerHandshakeFinishedEvent.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/ServerHandshakeFinishedEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/ServerMessage.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/ServerMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/ServerMessageDecoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/ServerMessageDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/ServerMessageEncoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/ServerMessageEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/ServerMessageHandler.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/ServerMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/StatusCode.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/StatusCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/SupportedProtocols.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/SupportedProtocols.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/SwitchOverRequest.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/SwitchOverRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/SwitchOverResponse.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/SwitchOverResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/EnterpriseReadReplicaEditionModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/EnterpriseReadReplicaEditionModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/OpenEnterpriseReadReplicaEditionModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/OpenEnterpriseReadReplicaEditionModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/OpenEnterpriseReadReplicaGraphDatabase.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/OpenEnterpriseReadReplicaGraphDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/ReadReplicaGraphDatabase.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/ReadReplicaGraphDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/ReadReplicaLockManager.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/ReadReplicaLockManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/ReadReplicaStartupProcess.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/ReadReplicaStartupProcess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/WaitForUpToDateStore.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/WaitForUpToDateStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/Endpoint.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/Endpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/Role.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/Role.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/RoutingResult.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/RoutingResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/Util.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/Util.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/load_balancing/LoadBalancingPlugin.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/load_balancing/LoadBalancingPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/load_balancing/LoadBalancingPluginLoader.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/load_balancing/LoadBalancingPluginLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/load_balancing/LoadBalancingProcessor.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/load_balancing/LoadBalancingProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/load_balancing/LoadBalancingResult.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/load_balancing/LoadBalancingResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/load_balancing/filters/Filter.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/load_balancing/filters/Filter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/load_balancing/filters/FilterChain.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/load_balancing/filters/FilterChain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/load_balancing/filters/FirstValidRule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/load_balancing/filters/FirstValidRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/load_balancing/filters/IdentityFilter.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/load_balancing/filters/IdentityFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/load_balancing/filters/MinimumCountFilter.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/load_balancing/filters/MinimumCountFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/load_balancing/plugins/ServerShufflingProcessor.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/load_balancing/plugins/ServerShufflingProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/load_balancing/plugins/server_policies/AnyGroupFilter.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/load_balancing/plugins/server_policies/AnyGroupFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/load_balancing/plugins/server_policies/FilterConfigParser.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/load_balancing/plugins/server_policies/FilterConfigParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/load_balancing/plugins/server_policies/FilteringPolicy.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/load_balancing/plugins/server_policies/FilteringPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/load_balancing/plugins/server_policies/FilteringPolicyLoader.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/load_balancing/plugins/server_policies/FilteringPolicyLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/load_balancing/plugins/server_policies/HaltFilter.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/load_balancing/plugins/server_policies/HaltFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/load_balancing/plugins/server_policies/InvalidFilterSpecification.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/load_balancing/plugins/server_policies/InvalidFilterSpecification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/load_balancing/plugins/server_policies/Policies.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/load_balancing/plugins/server_policies/Policies.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/load_balancing/plugins/server_policies/Policy.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/load_balancing/plugins/server_policies/Policy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/load_balancing/plugins/server_policies/ServerInfo.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/load_balancing/plugins/server_policies/ServerInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/load_balancing/plugins/server_policies/ServerPoliciesPlugin.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/load_balancing/plugins/server_policies/ServerPoliciesPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/load_balancing/procedure/GetServersProcedureForMultiDC.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/load_balancing/procedure/GetServersProcedureForMultiDC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/load_balancing/procedure/GetServersProcedureForSingleDC.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/load_balancing/procedure/GetServersProcedureForSingleDC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/load_balancing/procedure/LegacyGetServersProcedure.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/load_balancing/procedure/LegacyGetServersProcedure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/load_balancing/procedure/ParameterNames.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/load_balancing/procedure/ParameterNames.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/load_balancing/procedure/ProcedureNames.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/load_balancing/procedure/ProcedureNames.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/load_balancing/procedure/ResultFormatV1.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/load_balancing/procedure/ResultFormatV1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/multi_cluster/MultiClusterRoutingResult.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/multi_cluster/MultiClusterRoutingResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/multi_cluster/procedure/GetRoutersForAllDatabasesProcedure.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/multi_cluster/procedure/GetRoutersForAllDatabasesProcedure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/multi_cluster/procedure/GetRoutersForDatabaseProcedure.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/multi_cluster/procedure/GetRoutersForDatabaseProcedure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/multi_cluster/procedure/MultiClusterRoutingResultFormat.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/multi_cluster/procedure/MultiClusterRoutingResultFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/multi_cluster/procedure/ParameterNames.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/multi_cluster/procedure/ParameterNames.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/multi_cluster/procedure/ProcedureNames.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/multi_cluster/procedure/ProcedureNames.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/procedure/ProcedureNamesEnum.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/procedure/ProcedureNamesEnum.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/procedure/RoutingResultFormatHelper.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/procedure/RoutingResultFormatHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/upstream/NoOpUpstreamDatabaseStrategiesLoader.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/upstream/NoOpUpstreamDatabaseStrategiesLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/upstream/UpstreamDatabaseSelectionException.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/upstream/UpstreamDatabaseSelectionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/upstream/UpstreamDatabaseSelectionStrategy.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/upstream/UpstreamDatabaseSelectionStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/upstream/UpstreamDatabaseStrategiesLoader.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/upstream/UpstreamDatabaseStrategiesLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/upstream/UpstreamDatabaseStrategySelector.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/upstream/UpstreamDatabaseStrategySelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/upstream/strategies/ConnectRandomlyToServerGroupImpl.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/upstream/strategies/ConnectRandomlyToServerGroupImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/upstream/strategies/ConnectRandomlyToServerGroupStrategy.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/upstream/strategies/ConnectRandomlyToServerGroupStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/upstream/strategies/ConnectRandomlyWithinServerGroupStrategy.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/upstream/strategies/ConnectRandomlyWithinServerGroupStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/upstream/strategies/ConnectToRandomCoreServerStrategy.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/upstream/strategies/ConnectToRandomCoreServerStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/upstream/strategies/LeaderOnlyStrategy.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/upstream/strategies/LeaderOnlyStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/upstream/strategies/TypicallyConnectToRandomReadReplicaStrategy.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/upstream/strategies/TypicallyConnectToRandomReadReplicaStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/upstream/strategies/UserDefinedConfigurationStrategy.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/upstream/strategies/UserDefinedConfigurationStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/commandline/dbms/ClusteringCommandSection.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/commandline/dbms/ClusteringCommandSection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/commandline/dbms/UnbindFromClusterCommand.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/commandline/dbms/UnbindFromClusterCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/commandline/dbms/UnbindFromClusterCommandProvider.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/commandline/dbms/UnbindFromClusterCommandProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/TestStoreId.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/TestStoreId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/backup/RestoreClusterUtils.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/backup/RestoreClusterUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/CatchUpChannelPoolTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/CatchUpChannelPoolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/CatchUpClientIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/CatchUpClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/RequestDecoderDispatcherTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/RequestDecoderDispatcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/RequestMessageTypeTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/RequestMessageTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/ResponseMessageTypeTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/ResponseMessageTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/TimeoutLoopTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/TimeoutLoopTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/CatchupServerIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/CatchupServerIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/CloseablesListenerTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/CloseablesListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/CopiedStoreRecoveryTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/CopiedStoreRecoveryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/FakeCatchupServer.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/FakeCatchupServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/FakeFile.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/FakeFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/FileSenderTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/FileSenderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/GetIndexFilesRequestMarshalTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/GetIndexFilesRequestMarshalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/GetStoreFileMarshalTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/GetStoreFileMarshalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/InMemoryStoreStreamProvider.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/InMemoryStoreStreamProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/LocalDatabaseTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/LocalDatabaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/MaximumTotalTimeTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/MaximumTotalTimeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/PrepareStoreCopyFilesTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/PrepareStoreCopyFilesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/PrepareStoreCopyRequestHandlerTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/PrepareStoreCopyRequestHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/PrepareStoreCopyRequestMarshalTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/PrepareStoreCopyRequestMarshalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/PrepareStoreCopyResponseMarshalTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/PrepareStoreCopyResponseMarshalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/PrepareStoreCopyResponseTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/PrepareStoreCopyResponseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/RemoteStoreTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/RemoteStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/SimpleCatchupClient.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/SimpleCatchupClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/StoreCopyClientIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/StoreCopyClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/StoreCopyClientTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/StoreCopyClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/StoreCopyFinishedResponseEncodeDecodeTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/StoreCopyFinishedResponseEncodeDecodeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/StoreCopyFinishedResponseTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/StoreCopyFinishedResponseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/StoreCopyRequestHandlerTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/StoreCopyRequestHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/StoreFileStreamingProtocolTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/StoreFileStreamingProtocolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/StoreFilesTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/StoreFilesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/StoreFilesWithRealFileSystemTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/StoreFilesWithRealFileSystemTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/StoreStreamingProcessTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/StoreStreamingProcessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/StreamToDiskTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/StreamToDiskTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/TestCatchupServer.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/TestCatchupServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/tx/BatchingTxApplierTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/tx/BatchingTxApplierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/tx/CatchupPollingProcessTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/tx/CatchupPollingProcessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/tx/ChunkedTransactionStreamTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/tx/ChunkedTransactionStreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/tx/TransactionLogCatchUpWriterTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/tx/TransactionLogCatchUpWriterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/tx/TxPullRequestEncodeDecodeTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/tx/TxPullRequestEncodeDecodeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/tx/TxPullRequestHandlerTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/tx/TxPullRequestHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/tx/TxPullResponseEncodeDecodeTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/tx/TxPullResponseEncodeDecodeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/tx/TxStreamFinishedResponseEncodeDecodeTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/tx/TxStreamFinishedResponseEncodeDecodeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/BatchingMessageHandlerTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/BatchingMessageHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/CausalClusterConfigurationValidatorTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/CausalClusterConfigurationValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/CausalClusteringSettingsTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/CausalClusteringSettingsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/ClusterBindingHandlerTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/ClusterBindingHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/EnterpriseCoreEditionModuleIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/EnterpriseCoreEditionModuleIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/SupportedProtocolCreatorTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/SupportedProtocolCreatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/TransactionBackupServiceProviderTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/TransactionBackupServiceProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/CatchUpTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/CatchUpTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/ContinuousJobTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/ContinuousJobTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/DirectNetworking.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/DirectNetworking.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/HeartbeatBuilder.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/HeartbeatBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/LeaderAvailabilityHandlerTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/LeaderAvailabilityHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/MessageUtils.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/MessageUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/OutboundMessageCollector.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/OutboundMessageCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/QuorumStrategyTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/QuorumStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/RaftMachineBuilder.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/RaftMachineBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/RaftMachineTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/RaftMachineTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/RaftMessageMonitoringHandlerTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/RaftMessageMonitoringHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/RaftTestFixture.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/RaftTestFixture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/ReplicatedInteger.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/ReplicatedInteger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/ReplicatedString.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/ReplicatedString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/TestMessageBuilders.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/TestMessageBuilders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/election/DisconnectLeaderScenario.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/election/DisconnectLeaderScenario.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/election/ElectionPerformanceIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/election/ElectionPerformanceIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/election/ElectionUtil.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/election/ElectionUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/election/Fixture.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/election/Fixture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/explorer/ClusterSafetyViolations.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/explorer/ClusterSafetyViolations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/explorer/ClusterSafetyViolationsTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/explorer/ClusterSafetyViolationsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/explorer/ClusterState.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/explorer/ClusterState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/explorer/ComparableRaftLog.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/explorer/ComparableRaftLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/explorer/ComparableRaftState.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/explorer/ComparableRaftState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/explorer/ComparableRaftStateTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/explorer/ComparableRaftStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/explorer/action/Action.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/explorer/action/Action.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/explorer/action/DropMessage.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/explorer/action/DropMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/explorer/action/HeartbeatTimeout.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/explorer/action/HeartbeatTimeout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/explorer/action/NewEntry.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/explorer/action/NewEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/explorer/action/OutOfOrderDelivery.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/explorer/action/OutOfOrderDelivery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/explorer/action/OutOfOrderDeliveryTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/explorer/action/OutOfOrderDeliveryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/ConcurrentStressIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/ConcurrentStressIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/DummyRaftableContentSerializer.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/DummyRaftableContentSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/InMemoryRaftLogContractTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/InMemoryRaftLogContractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/MonitoredRaftLogTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/MonitoredRaftLogTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/RaftContentByteBufferMarshalTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/RaftContentByteBufferMarshalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/RaftLogContractTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/RaftLogContractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/RaftLogHelper.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/RaftLogHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/RaftLogMetadataCacheTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/RaftLogMetadataCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/RaftLogVerificationIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/RaftLogVerificationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/RaftMachineLogTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/RaftMachineLogTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/SegmentedRaftLogDurabilityTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/SegmentedRaftLogDurabilityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/VerifyingRaftLog.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/VerifyingRaftLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/cache/CircularBufferTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/cache/CircularBufferTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/cache/ConsecutiveCacheTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/cache/ConsecutiveCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/cache/ConsecutiveInFlightCacheTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/cache/ConsecutiveInFlightCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/debug/ReplayRaftLog.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/debug/ReplayRaftLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/inmemory/InMemoryConcurrentStressIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/inmemory/InMemoryConcurrentStressIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/pruning/PruningSchedulerTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/pruning/PruningSchedulerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/segmented/EntryBasedLogPruningStrategyTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/segmented/EntryBasedLogPruningStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/segmented/EntryCursorTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/segmented/EntryCursorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/segmented/FileNamesTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/segmented/FileNamesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/segmented/InFlightLogEntriesCacheTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/segmented/InFlightLogEntriesCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/segmented/NoPruningPruningStrategyTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/segmented/NoPruningPruningStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/segmented/OpenEndRangeMapTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/segmented/OpenEndRangeMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/segmented/PositionCacheTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/segmented/PositionCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/segmented/PruningStrategyTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/segmented/PruningStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/segmented/ReaderPoolTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/segmented/ReaderPoolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/segmented/ReaderTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/segmented/ReaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/segmented/RecoveryProtocolTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/segmented/RecoveryProtocolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/segmented/ReferenceCounterTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/segmented/ReferenceCounterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/segmented/SegmentFileTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/segmented/SegmentFileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/segmented/SegmentHeaderTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/segmented/SegmentHeaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/segmented/SegmentedConcurrentStressIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/segmented/SegmentedConcurrentStressIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/segmented/SegmentedRaftLogContractTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/segmented/SegmentedRaftLogContractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/segmented/SegmentedRaftLogCursorIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/segmented/SegmentedRaftLogCursorIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/segmented/SegmentedRaftLogPartialEntryRecoveryTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/segmented/SegmentedRaftLogPartialEntryRecoveryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/segmented/SegmentedRaftLogRotationTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/segmented/SegmentedRaftLogRotationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/segmented/SegmentedRaftLogRotationTruncationPruneTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/segmented/SegmentedRaftLogRotationTruncationPruneTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/segmented/SegmentedRaftLogVerificationIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/segmented/SegmentedRaftLogVerificationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/segmented/SegmentsTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/segmented/SegmentsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/segmented/SizeBasedLogPruningStrategyTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/segmented/SizeBasedLogPruningStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/segmented/TermsTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/segmented/TermsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/membership/CatchupGoalTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/membership/CatchupGoalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/membership/CatchupGoalTrackerTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/membership/CatchupGoalTrackerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/membership/MemberIdMarshalTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/membership/MemberIdMarshalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/membership/MembershipWaiterTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/membership/MembershipWaiterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/membership/RaftGroupMembershipTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/membership/RaftGroupMembershipTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/membership/RaftMembershipManagerTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/membership/RaftMembershipManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/membership/RaftMembershipStateRecoveryManagerTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/membership/RaftMembershipStateRecoveryManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/membership/RaftMembershipStateTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/membership/RaftMembershipStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/membership/RaftTestGroup.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/membership/RaftTestGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/outcome/BatchAppendLogEntriesTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/outcome/BatchAppendLogEntriesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/outcome/TruncateLogCommandTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/outcome/TruncateLogCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/roles/AppendEntriesMessageFlowTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/roles/AppendEntriesMessageFlowTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/roles/AppendEntriesRequestBuilder.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/roles/AppendEntriesRequestBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/roles/AppendEntriesRequestTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/roles/AppendEntriesRequestTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/roles/AppendEntriesResponseBuilder.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/roles/AppendEntriesResponseBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/roles/AppendingTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/roles/AppendingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/roles/CandidateTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/roles/CandidateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/roles/ElectionTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/roles/ElectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/roles/FollowerTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/roles/FollowerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/roles/HeartbeatTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/roles/HeartbeatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/roles/LeaderTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/roles/LeaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/roles/NonFollowerVoteRequestTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/roles/NonFollowerVoteRequestTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/roles/PreVoteRequestTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/roles/PreVoteRequestTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/roles/PruningTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/roles/PruningTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/roles/VoteRequestTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/roles/VoteRequestTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/schedule/CountingTimerService.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/schedule/CountingTimerService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/schedule/OnDemandTimerService.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/schedule/OnDemandTimerService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/schedule/TimerServiceTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/schedule/TimerServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/schedule/TimerTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/schedule/TimerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/shipping/RaftLogShipperTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/shipping/RaftLogShipperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/state/RaftStateBuilder.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/state/RaftStateBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/state/RaftStateTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/state/RaftStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/term/MonitoredTermStateStorageTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/term/MonitoredTermStateStorageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/term/TermStateTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/term/TermStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/vote/AnyVoteRequestBuilder.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/vote/AnyVoteRequestBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/vote/AnyVoteResponseBuilder.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/vote/AnyVoteResponseBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/vote/PreVoteRequestBuilder.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/vote/PreVoteRequestBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/vote/PreVoteResponseBuilder.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/vote/PreVoteResponseBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/vote/VoteRequestBuilder.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/vote/VoteRequestBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/vote/VoteResponseBuilder.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/vote/VoteResponseBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/vote/VoteStateTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/vote/VoteStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/vote/VotingTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/vote/VotingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/replication/CoreReplicatedContentMarshalTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/replication/CoreReplicatedContentMarshalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/replication/DirectReplicator.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/replication/DirectReplicator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/replication/ProgressTrackerImplTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/replication/ProgressTrackerImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/replication/RaftReplicatorTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/replication/RaftReplicatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/replication/ThrottlerTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/replication/ThrottlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/replication/session/LocalSessionPoolTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/replication/session/LocalSessionPoolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/ClusterStateDirectoryTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/ClusterStateDirectoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/CommandApplicationProcessTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/CommandApplicationProcessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/CoreBootstrapperIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/CoreBootstrapperIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/DumpClusterStateTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/DumpClusterStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/InFlightLogEntryReaderTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/InFlightLogEntryReaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/machines/CoreStateMachinesTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/machines/CoreStateMachinesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/machines/id/FreeIdFilteredIdGeneratorFactoryTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/machines/id/FreeIdFilteredIdGeneratorFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/machines/id/FreeIdFilteredIdGeneratorTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/machines/id/FreeIdFilteredIdGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/machines/id/IdAllocationStateTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/machines/id/IdAllocationStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/machines/id/IdReusabilityConditionTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/machines/id/IdReusabilityConditionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/machines/id/RebuildReplicatedIdGeneratorsTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/machines/id/RebuildReplicatedIdGeneratorsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/machines/id/ReplicatedIdAllocationStateMachineTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/machines/id/ReplicatedIdAllocationStateMachineTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/machines/id/ReplicatedIdGeneratorTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/machines/id/ReplicatedIdGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/machines/id/ReplicatedIdRangeAcquirerTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/machines/id/ReplicatedIdRangeAcquirerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/machines/id/StateRecoveryManagerTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/machines/id/StateRecoveryManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/machines/locks/LeaderOnlyLockManagerTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/machines/locks/LeaderOnlyLockManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/machines/locks/ReplicatedLockTokenStateMachineTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/machines/locks/ReplicatedLockTokenStateMachineTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/machines/token/ReplicatedTokenHolderTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/machines/token/ReplicatedTokenHolderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/machines/token/ReplicatedTokenStateMachineTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/machines/token/ReplicatedTokenStateMachineTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/machines/tx/CommitProcessStateMachineCollaborationTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/machines/tx/CommitProcessStateMachineCollaborationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/machines/tx/LogIndexTxHeaderEncodingTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/machines/tx/LogIndexTxHeaderEncodingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/machines/tx/ReplayableCommitProcessTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/machines/tx/ReplayableCommitProcessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/machines/tx/ReplicatedTransactionCommitProcessTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/machines/tx/ReplicatedTransactionCommitProcessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/machines/tx/ReplicatedTransactionStateMachineTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/machines/tx/ReplicatedTransactionStateMachineTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/snapshot/CoreStateDownloaderServiceTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/snapshot/CoreStateDownloaderServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/snapshot/CoreStateDownloaderTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/snapshot/CoreStateDownloaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/snapshot/NoTimeout.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/snapshot/NoTimeout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/snapshot/PersistentSnapshotDownloaderTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/snapshot/PersistentSnapshotDownloaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/storage/DurableStateStorageIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/storage/DurableStateStorageIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/storage/DurableStateStorageTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/storage/DurableStateStorageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/storage/SimpleStorageTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/storage/SimpleStorageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/ClientConnectorAddressesTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/ClientConnectorAddressesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/Cluster.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/Cluster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/ClusterMember.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/ClusterMember.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/CoreClusterMember.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/CoreClusterMember.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/DnsHostnameResolverTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/DnsHostnameResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/HazelcastClientTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/HazelcastClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/HazelcastClusterTopologyTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/HazelcastClusterTopologyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/IpFamily.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/IpFamily.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/MockSrvRecordResolver.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/MockSrvRecordResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/MultiRetryStrategyTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/MultiRetryStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/ReadReplica.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/ReadReplica.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/RobustHazelcastWrapperTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/RobustHazelcastWrapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/SharedDiscoveryCoreClient.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/SharedDiscoveryCoreClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/SharedDiscoveryReadReplicaClient.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/SharedDiscoveryReadReplicaClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/SharedDiscoveryService.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/SharedDiscoveryService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/SharedDiscoveryServiceFactory.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/SharedDiscoveryServiceFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/SharedDiscoveryServiceIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/SharedDiscoveryServiceIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/SrvHostnameResolverTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/SrvHostnameResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/TestTopology.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/TestTopology.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/TopologyTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/TopologyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/procedures/ClusterOverviewProcedureTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/procedures/ClusterOverviewProcedureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/procedures/InstalledProtocolsProcedureTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/procedures/InstalledProtocolsProcedureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/procedures/RoleProcedureTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/procedures/RoleProcedureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/helper/CompositeSuspendableTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/helper/CompositeSuspendableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/helper/CountingThrowingSuspendableLifeCycle.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/helper/CountingThrowingSuspendableLifeCycle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/helper/ErrorHandlerTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/helper/ErrorHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/helper/ExponentialBackoffStrategyTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/helper/ExponentialBackoffStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/helper/RobustJobSchedulerWrapperTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/helper/RobustJobSchedulerWrapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/helper/StateAwareSuspendableLifeCycle.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/helper/StateAwareSuspendableLifeCycle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/helper/SuspendableLifeCycleFailingTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/helper/SuspendableLifeCycleFailingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/helper/SuspendableLifeCycleLifeStateChangeTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/helper/SuspendableLifeCycleLifeStateChangeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/helper/SuspendableLifeCycleSuspendedStateChangeTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/helper/SuspendableLifeCycleSuspendedStateChangeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/helper/SuspendableLifecycleStateTestHelpers.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/helper/SuspendableLifecycleStateTestHelpers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/helpers/CausalClusteringTestHelpers.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/helpers/CausalClusteringTestHelpers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/helpers/DataCreator.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/helpers/DataCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/identity/ClusterBinderTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/identity/ClusterBinderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/identity/RaftTestMember.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/identity/RaftTestMember.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/identity/RaftTestMemberSetBuilder.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/identity/RaftTestMemberSetBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/management/CausalClusteringBeanTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/management/CausalClusteringBeanTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/messaging/IdleChannelReaperHandlerTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/messaging/IdleChannelReaperHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/messaging/MessageGateTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/messaging/MessageGateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/messaging/NetworkFlushableChannelNetty4Test.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/messaging/NetworkFlushableChannelNetty4Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/messaging/RaftMessageProcessingTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/messaging/RaftMessageProcessingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/messaging/ReconnectingChannelIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/messaging/ReconnectingChannelIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/messaging/ReconnectingChannelsTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/messaging/ReconnectingChannelsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/messaging/SenderServiceIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/messaging/SenderServiceIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/messaging/SimpleNettyChannelTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/messaging/SimpleNettyChannelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/messaging/TestNetwork.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/messaging/TestNetwork.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/messaging/address/UnknownAddressMonitorTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/messaging/address/UnknownAddressMonitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/messaging/marshalling/RaftMessageEncodingDecodingTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/messaging/marshalling/RaftMessageEncodingDecodingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/messaging/marshalling/StringMarshalTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/messaging/marshalling/StringMarshalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/net/ServerStateTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/net/ServerStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/protocol/NettyPipelineBuilderTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/protocol/NettyPipelineBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/protocol/ProtocolInstallerRepositoryTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/protocol/ProtocolInstallerRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/protocol/handshake/ApplicationProtocolRepositoryTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/protocol/handshake/ApplicationProtocolRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/protocol/handshake/ClientMessageEncodingTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/protocol/handshake/ClientMessageEncodingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/protocol/handshake/HandshakeClientEnsureMagicTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/protocol/handshake/HandshakeClientEnsureMagicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/protocol/handshake/HandshakeClientTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/protocol/handshake/HandshakeClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/protocol/handshake/HandshakeServerEnsureMagicTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/protocol/handshake/HandshakeServerEnsureMagicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/protocol/handshake/HandshakeServerTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/protocol/handshake/HandshakeServerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/protocol/handshake/InitialMagicMessageTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/protocol/handshake/InitialMagicMessageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/protocol/handshake/ModifierProtocolRepositoryTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/protocol/handshake/ModifierProtocolRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/protocol/handshake/NettyInstalledProtocolsIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/protocol/handshake/NettyInstalledProtocolsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/protocol/handshake/NettyProtocolHandshakeIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/protocol/handshake/NettyProtocolHandshakeIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/protocol/handshake/ProtocolHandshakeHappyTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/protocol/handshake/ProtocolHandshakeHappyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/protocol/handshake/ProtocolHandshakeSadTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/protocol/handshake/ProtocolHandshakeSadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/protocol/handshake/ServerMessageEncodingTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/protocol/handshake/ServerMessageEncodingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/protocol/handshake/SupportedProtocolsTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/protocol/handshake/SupportedProtocolsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/protocol/handshake/TestProtocols.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/protocol/handshake/TestProtocols.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/readreplica/EnterpriseReadReplicaEditionModuleTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/readreplica/EnterpriseReadReplicaEditionModuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/readreplica/ReadReplicaLockManagerTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/readreplica/ReadReplicaLockManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/readreplica/ReadReplicaStartupProcessTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/readreplica/ReadReplicaStartupProcessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/routing/load_balancing/LoadBalancingPluginLoaderTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/routing/load_balancing/LoadBalancingPluginLoaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/routing/load_balancing/filters/FilterChainTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/routing/load_balancing/filters/FilterChainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/routing/load_balancing/filters/FirstValidRuleTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/routing/load_balancing/filters/FirstValidRuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/routing/load_balancing/filters/IdentityFilterTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/routing/load_balancing/filters/IdentityFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/routing/load_balancing/filters/MinimumCountFilterTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/routing/load_balancing/filters/MinimumCountFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/routing/load_balancing/plugins/ServerShufflingProcessorTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/routing/load_balancing/plugins/ServerShufflingProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/routing/load_balancing/plugins/server_policies/AnyGroupFilterTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/routing/load_balancing/plugins/server_policies/AnyGroupFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/routing/load_balancing/plugins/server_policies/FilterBuilder.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/routing/load_balancing/plugins/server_policies/FilterBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/routing/load_balancing/plugins/server_policies/FilterConfigParserTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/routing/load_balancing/plugins/server_policies/FilterConfigParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/routing/load_balancing/plugins/server_policies/FilteringPolicyLoaderTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/routing/load_balancing/plugins/server_policies/FilteringPolicyLoaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/routing/load_balancing/plugins/server_policies/PoliciesTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/routing/load_balancing/plugins/server_policies/PoliciesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/routing/load_balancing/procedure/GetServersProcedureV1RoutingTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/routing/load_balancing/procedure/GetServersProcedureV1RoutingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/routing/load_balancing/procedure/GetServersProcedureV1Test.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/routing/load_balancing/procedure/GetServersProcedureV1Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/routing/load_balancing/procedure/GetServersProcedureV2Test.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/routing/load_balancing/procedure/GetServersProcedureV2Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/routing/load_balancing/procedure/ResultFormatV1Test.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/routing/load_balancing/procedure/ResultFormatV1Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/routing/multi_cluster/procedure/MultiClusterRoutingProcedureTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/routing/multi_cluster/procedure/MultiClusterRoutingProcedureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/routing/multi_cluster/procedure/MultiClusterRoutingResultFormatTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/routing/multi_cluster/procedure/MultiClusterRoutingResultFormatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/CausalClusteringProceduresIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/CausalClusteringProceduresIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/CausalClusteringRolesIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/CausalClusteringRolesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterBindingIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterBindingIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterCommunityToEnterpriseIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterCommunityToEnterpriseIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterCompressionIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterCompressionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterCustomLogLocationIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterCustomLogLocationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterDiscoveryIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterDiscoveryIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterFormationIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterFormationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterIdReuseIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterIdReuseIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterIpFamilyIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterIpFamilyIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterLeaderStepDownIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterLeaderStepDownIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterOverviewIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterOverviewIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterShutdownIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterShutdownIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ConnectionInfoIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ConnectionInfoIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ConsensusGroupSettingsIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ConsensusGroupSettingsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/CorePruningIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/CorePruningIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/CoreReplicationIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/CoreReplicationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/CoreToCoreCopySnapshotIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/CoreToCoreCopySnapshotIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/DiscoveryServiceType.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/DiscoveryServiceType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/InstalledProtocolsProcedureIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/InstalledProtocolsProcedureIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/MultiClusterRoutingIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/MultiClusterRoutingIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/MultiClusteringIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/MultiClusteringIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/PreElectionIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/PreElectionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ReadReplicaHierarchicalCatchupIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ReadReplicaHierarchicalCatchupIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ReadReplicaReplicationIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ReadReplicaReplicationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ReadReplicaStoreCopyIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ReadReplicaStoreCopyIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ReadReplicaToReadReplicaCatchupIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ReadReplicaToReadReplicaCatchupIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/RecoveryIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/RecoveryIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/RestartIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/RestartIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/SampleData.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/SampleData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ServerGroupsIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ServerGroupsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ServerPoliciesLoadBalancingIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ServerPoliciesLoadBalancingIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/TransactionLogRecoveryIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/TransactionLogRecoveryIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/UnavailableIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/UnavailableIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/WillNotBecomeLeaderIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/WillNotBecomeLeaderIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/upstream/UpstreamDatabaseStrategiesLoaderTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/upstream/UpstreamDatabaseStrategiesLoaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/upstream/UpstreamDatabaseStrategySelectorTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/upstream/UpstreamDatabaseStrategySelectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/upstream/strategies/ConnectRandomlyToServerGroupStrategyImplTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/upstream/strategies/ConnectRandomlyToServerGroupStrategyImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/upstream/strategies/ConnectRandomlyToServerGroupStrategyTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/upstream/strategies/ConnectRandomlyToServerGroupStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/upstream/strategies/ConnectRandomlyWithinServerGroupStrategyTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/upstream/strategies/ConnectRandomlyWithinServerGroupStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/upstream/strategies/ConnectToRandomCoreServerStrategyTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/upstream/strategies/ConnectToRandomCoreServerStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/upstream/strategies/TypicallyConnectToRandomReadReplicaStrategyTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/upstream/strategies/TypicallyConnectToRandomReadReplicaStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/upstream/strategies/UserDefinedConfigurationStrategyTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/upstream/strategies/UserDefinedConfigurationStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/commandline/dbms/UnbindFromClusterCommandTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/commandline/dbms/UnbindFromClusterCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/io/pagecache/impl/muninn/VersionContextTrackingIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/io/pagecache/impl/muninn/VersionContextTrackingIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/test/causalclustering/ClusterRule.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/test/causalclustering/ClusterRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/test/causalclustering/ClusterRuleIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/test/causalclustering/ClusterRuleIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/test/matchers/Matchers.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/test/matchers/Matchers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/NOTICE.txt
+++ b/enterprise/cluster/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/BindingListener.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/BindingListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/ClusterMonitor.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/ClusterMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/ClusterSettings.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/ClusterSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/DelayedDirectExecutor.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/DelayedDirectExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/ExecutorLifecycleAdapter.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/ExecutorLifecycleAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/InstanceId.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/InstanceId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/MultiPaxosServerFactory.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/MultiPaxosServerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/NetworkedServerFactory.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/NetworkedServerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/ProtocolServer.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/ProtocolServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/ProtocolServerFactory.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/ProtocolServerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/StateMachines.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/StateMachines.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/client/ClusterClient.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/client/ClusterClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/client/ClusterClientModule.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/client/ClusterClientModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/client/ClusterJoin.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/client/ClusterJoin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/com/BindingNotifier.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/com/BindingNotifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/com/ChannelOpenFailedException.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/com/ChannelOpenFailedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/com/NetworkReceiver.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/com/NetworkReceiver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/com/NetworkSender.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/com/NetworkSender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/com/message/Message.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/com/message/Message.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/com/message/MessageHolder.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/com/message/MessageHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/com/message/MessageProcessor.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/com/message/MessageProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/com/message/MessageSender.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/com/message/MessageSender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/com/message/MessageSource.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/com/message/MessageSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/com/message/MessageType.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/com/message/MessageType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/logging/AsyncLogging.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/logging/AsyncLogging.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/logging/NettyLoggerFactory.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/logging/NettyLoggerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/member/ClusterMemberAvailability.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/member/ClusterMemberAvailability.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/member/ClusterMemberEvents.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/member/ClusterMemberEvents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/member/ClusterMemberListener.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/member/ClusterMemberListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/member/paxos/MemberIsAvailable.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/member/paxos/MemberIsAvailable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/member/paxos/MemberIsUnavailable.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/member/paxos/MemberIsUnavailable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/member/paxos/PaxosClusterMemberAvailability.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/member/paxos/PaxosClusterMemberAvailability.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/member/paxos/PaxosClusterMemberEvents.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/member/paxos/PaxosClusterMemberEvents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/ConfigurationContext.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/ConfigurationContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/LoggingContext.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/LoggingContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/TimeoutsContext.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/TimeoutsContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/AtomicBroadcast.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/AtomicBroadcast.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/AtomicBroadcastListener.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/AtomicBroadcastListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/AtomicBroadcastSerializer.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/AtomicBroadcastSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/LenientObjectInputStream.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/LenientObjectInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/LenientObjectOutputStream.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/LenientObjectOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/ObjectInputStreamFactory.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/ObjectInputStreamFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/ObjectOutputStreamFactory.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/ObjectOutputStreamFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/ObjectStreamFactory.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/ObjectStreamFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/Payload.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/Payload.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/VersionMapper.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/VersionMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/AcceptorContext.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/AcceptorContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/AcceptorInstance.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/AcceptorInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/AcceptorInstanceStore.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/AcceptorInstanceStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/AcceptorMessage.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/AcceptorMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/AcceptorState.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/AcceptorState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/AtomicBroadcastContext.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/AtomicBroadcastContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/AtomicBroadcastMessage.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/AtomicBroadcastMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/AtomicBroadcastState.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/AtomicBroadcastState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/DefaultWinnerStrategy.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/DefaultWinnerStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/InMemoryAcceptorInstanceStore.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/InMemoryAcceptorInstanceStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/InstanceId.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/InstanceId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/LearnerContext.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/LearnerContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/LearnerMessage.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/LearnerMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/LearnerState.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/LearnerState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/PaxosInstance.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/PaxosInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/PaxosInstanceStore.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/PaxosInstanceStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/ProposerContext.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/ProposerContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/ProposerMessage.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/ProposerMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/ProposerState.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/ProposerState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/Vote.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/Vote.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/WinnerStrategy.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/WinnerStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/AbstractContextImpl.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/AbstractContextImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/AcceptorContextImpl.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/AcceptorContextImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/AtomicBroadcastContextImpl.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/AtomicBroadcastContextImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/ClusterContextImpl.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/ClusterContextImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/CommonContextState.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/CommonContextState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/ElectionContextImpl.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/ElectionContextImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/HeartbeatContextImpl.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/HeartbeatContextImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/LearnerContextImpl.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/LearnerContextImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/MultiPaxosContext.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/MultiPaxosContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/ProposerContextImpl.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/ProposerContextImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/cluster/Cluster.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/cluster/Cluster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/cluster/ClusterConfiguration.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/cluster/ClusterConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/cluster/ClusterContext.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/cluster/ClusterContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/cluster/ClusterEntryDeniedException.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/cluster/ClusterEntryDeniedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/cluster/ClusterListener.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/cluster/ClusterListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/cluster/ClusterMessage.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/cluster/ClusterMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/cluster/ClusterState.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/cluster/ClusterState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/election/ClusterLeaveReelectionListener.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/election/ClusterLeaveReelectionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/election/Election.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/election/Election.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/election/ElectionContext.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/election/ElectionContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/election/ElectionCredentials.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/election/ElectionCredentials.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/election/ElectionCredentialsProvider.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/election/ElectionCredentialsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/election/ElectionMessage.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/election/ElectionMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/election/ElectionRole.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/election/ElectionRole.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/election/ElectionState.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/election/ElectionState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/election/HeartbeatReelectionListener.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/election/HeartbeatReelectionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/election/NotElectableElectionCredentials.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/election/NotElectableElectionCredentials.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/election/NotElectableElectionCredentialsProvider.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/election/NotElectableElectionCredentialsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/election/ServerIdElectionCredentials.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/election/ServerIdElectionCredentials.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/election/ServerIdElectionCredentialsProvider.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/election/ServerIdElectionCredentialsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/heartbeat/Heartbeat.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/heartbeat/Heartbeat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatContext.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatIAmAliveProcessor.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatIAmAliveProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatJoinListener.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatJoinListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatLeftListener.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatLeftListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatListener.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatMessage.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatRefreshProcessor.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatRefreshProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatState.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/snapshot/Snapshot.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/snapshot/Snapshot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/snapshot/SnapshotContext.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/snapshot/SnapshotContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/snapshot/SnapshotMessage.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/snapshot/SnapshotMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/snapshot/SnapshotProvider.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/snapshot/SnapshotProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/snapshot/SnapshotState.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/snapshot/SnapshotState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/statemachine/State.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/statemachine/State.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/statemachine/StateMachine.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/statemachine/StateMachine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/statemachine/StateMachineConversations.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/statemachine/StateMachineConversations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/statemachine/StateMachineProxyFactory.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/statemachine/StateMachineProxyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/statemachine/StateMachineProxyHandler.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/statemachine/StateMachineProxyHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/statemachine/StateMachineRules.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/statemachine/StateMachineRules.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/statemachine/StateTransition.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/statemachine/StateTransition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/statemachine/StateTransitionListener.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/statemachine/StateTransitionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/statemachine/StateTransitionLogger.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/statemachine/StateTransitionLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/timeout/FixedTimeoutStrategy.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/timeout/FixedTimeoutStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/timeout/MessageTimeoutStrategy.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/timeout/MessageTimeoutStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/timeout/TimeoutStrategy.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/timeout/TimeoutStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/timeout/Timeouts.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/timeout/Timeouts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/util/Quorums.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/util/Quorums.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/main/java/org/neo4j/configuration/HaConfigurationValidator.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/configuration/HaConfigurationValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/ClusterAssertion.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/ClusterAssertion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/FixedNetworkLatencyStrategy.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/FixedNetworkLatencyStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/MultipleFailureLatencyStrategy.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/MultipleFailureLatencyStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/NetworkLatencyStrategy.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/NetworkLatencyStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/NetworkMock.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/NetworkMock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/RandomDropNetworkFailureLatencyStrategy.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/RandomDropNetworkFailureLatencyStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/ScriptableNetworkFailureLatencyStrategy.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/ScriptableNetworkFailureLatencyStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/StateMachinesTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/StateMachinesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/TestProtocolServer.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/TestProtocolServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/VerifyInstanceConfiguration.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/VerifyInstanceConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/client/Cluster.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/client/Cluster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/com/NetworkReceiverTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/com/NetworkReceiverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/com/message/MessageTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/com/message/MessageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/com/message/NetworkSenderReceiverIT.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/com/message/NetworkSenderReceiverIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/com/message/TrackingMessageHolder.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/com/message/TrackingMessageHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/logging/AsyncLoggingTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/logging/AsyncLoggingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/member/paxos/MemberIsUnavailableTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/member/paxos/MemberIsUnavailableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/MessageArgumentMatcher.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/MessageArgumentMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/LenientObjectInputStreamTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/LenientObjectInputStreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/LenientObjectOutputStreamTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/LenientObjectOutputStreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/AtomicBroadcastStateTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/AtomicBroadcastStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/ClusterProtocolAtomicbroadcastTestUtil.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/ClusterProtocolAtomicbroadcastTestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/DefaultWinnerStrategyTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/DefaultWinnerStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/LearnerContextTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/LearnerContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/LearnerStateTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/LearnerStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/MultiPaxosContextTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/MultiPaxosContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/MultiPaxosServer.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/MultiPaxosServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/MultiPaxosTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/MultiPaxosTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/PaxosInstanceStoreTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/PaxosInstanceStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/ProposerStateTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/ProposerStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/AtomicBroadcastContextImplTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/AtomicBroadcastContextImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/ClusterContextImplTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/ClusterContextImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/HeartbeatContextImplTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/HeartbeatContextImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/LearnerContextImplTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/LearnerContextImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/ProposerContextImplTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/ProposerContextImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/cluster/ClusterConfigurationTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/cluster/ClusterConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/cluster/ClusterContextTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/cluster/ClusterContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/cluster/ClusterHeartbeatTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/cluster/ClusterHeartbeatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/cluster/ClusterMembershipTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/cluster/ClusterMembershipTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/cluster/ClusterMockTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/cluster/ClusterMockTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/cluster/ClusterNetworkIT.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/cluster/ClusterNetworkIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/cluster/ClusterStateTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/cluster/ClusterStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/cluster/InstanceIdTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/cluster/InstanceIdTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/election/ElectionContextTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/election/ElectionContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/election/ElectionStateTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/election/ElectionStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/election/IntegerElectionCredentials.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/election/IntegerElectionCredentials.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatContextTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatIAmAliveProcessorTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatIAmAliveProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatStateTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/snapshot/SnapshotStateTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/snapshot/SnapshotStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/statemachine/StateTransitionLoggerTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/statemachine/StateTransitionLoggerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cluster/src/test/java/org/neo4j/configuration/HaConfigurationValidatorTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/configuration/HaConfigurationValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/NOTICE.txt
+++ b/enterprise/com/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/enterprise/com/src/main/java/org/neo4j/com/BlockLogBuffer.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/BlockLogBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/main/java/org/neo4j/com/BlockLogReader.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/BlockLogReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/main/java/org/neo4j/com/ChannelCloser.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/ChannelCloser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/main/java/org/neo4j/com/ChannelContext.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/ChannelContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/main/java/org/neo4j/com/ChunkingChannelBuffer.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/ChunkingChannelBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/main/java/org/neo4j/com/Client.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/main/java/org/neo4j/com/ComException.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/ComException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/main/java/org/neo4j/com/ComExceptionHandler.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/ComExceptionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/main/java/org/neo4j/com/CommittedTransactionSerializer.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/CommittedTransactionSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/main/java/org/neo4j/com/Connection.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/Connection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/main/java/org/neo4j/com/DechunkingChannelBuffer.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/DechunkingChannelBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/main/java/org/neo4j/com/Deserializer.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/Deserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/main/java/org/neo4j/com/IdleChannelReaper.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/IdleChannelReaper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/main/java/org/neo4j/com/IllegalProtocolVersionException.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/IllegalProtocolVersionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/main/java/org/neo4j/com/LoggingResourcePoolMonitor.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/LoggingResourcePoolMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/main/java/org/neo4j/com/MonitorChannelHandler.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/MonitorChannelHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/main/java/org/neo4j/com/NetworkFlushableChannel.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/NetworkFlushableChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/main/java/org/neo4j/com/NetworkReadableClosableChannel.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/NetworkReadableClosableChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/main/java/org/neo4j/com/ObjectSerializer.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/ObjectSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/main/java/org/neo4j/com/PortIterator.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/PortIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/main/java/org/neo4j/com/PortRangeSocketBinder.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/PortRangeSocketBinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/main/java/org/neo4j/com/Protocol.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/Protocol.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/main/java/org/neo4j/com/Protocol214.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/Protocol214.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/main/java/org/neo4j/com/Protocol310.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/Protocol310.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/main/java/org/neo4j/com/Protocol320.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/Protocol320.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/main/java/org/neo4j/com/ProtocolVersion.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/ProtocolVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/main/java/org/neo4j/com/RequestContext.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/RequestContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/main/java/org/neo4j/com/RequestType.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/RequestType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/main/java/org/neo4j/com/ResourcePool.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/ResourcePool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/main/java/org/neo4j/com/ResourceReleaser.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/ResourceReleaser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/main/java/org/neo4j/com/Response.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/Response.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/main/java/org/neo4j/com/Serializer.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/Serializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/main/java/org/neo4j/com/Server.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/Server.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/main/java/org/neo4j/com/ServerFailureException.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/ServerFailureException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/main/java/org/neo4j/com/ServerUtil.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/ServerUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/main/java/org/neo4j/com/TargetCaller.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/TargetCaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/main/java/org/neo4j/com/TransactionNotPresentOnMasterException.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/TransactionNotPresentOnMasterException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/main/java/org/neo4j/com/TransactionObligationResponse.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/TransactionObligationResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/main/java/org/neo4j/com/TransactionStream.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/TransactionStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/main/java/org/neo4j/com/TransactionStreamResponse.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/TransactionStreamResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/main/java/org/neo4j/com/TxChecksumVerifier.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/TxChecksumVerifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/main/java/org/neo4j/com/monitor/RequestMonitor.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/monitor/RequestMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/BatchingResponseHandler.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/BatchingResponseHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/ExternallyManagedPageCache.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/ExternallyManagedPageCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/FileMoveAction.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/FileMoveAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/FileMoveActionInformer.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/FileMoveActionInformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/FileMoveProvider.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/FileMoveProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/MoveAfterCopy.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/MoveAfterCopy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/ResponsePacker.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/ResponsePacker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/ResponseUnpacker.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/ResponseUnpacker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/StoreCopyClient.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/StoreCopyClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/StoreCopyClientMonitor.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/StoreCopyClientMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/StoreCopyServer.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/StoreCopyServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/StoreUtil.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/StoreUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/StoreWriter.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/StoreWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/ToFileStoreWriter.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/ToFileStoreWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/ToNetworkStoreWriter.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/ToNetworkStoreWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/TransactionBatchCommitter.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/TransactionBatchCommitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/TransactionCommittingResponseUnpacker.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/TransactionCommittingResponseUnpacker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/TransactionObligationFulfiller.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/TransactionObligationFulfiller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/test/java/org/neo4j/com/ChannelBufferWrapper.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/ChannelBufferWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/test/java/org/neo4j/com/ClientCrashingWriter.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/ClientCrashingWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/test/java/org/neo4j/com/CommunicationIT.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/CommunicationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/test/java/org/neo4j/com/DataProducer.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/DataProducer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/test/java/org/neo4j/com/FailingByteChannel.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/FailingByteChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/test/java/org/neo4j/com/FailingException.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/FailingException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/test/java/org/neo4j/com/IdleChannelReaperTest.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/IdleChannelReaperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/test/java/org/neo4j/com/KnownDataByteChannel.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/KnownDataByteChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/test/java/org/neo4j/com/LoggingResourcePoolMonitorTest.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/LoggingResourcePoolMonitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/test/java/org/neo4j/com/MadeUpClient.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/MadeUpClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/test/java/org/neo4j/com/MadeUpCommunicationInterface.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/MadeUpCommunicationInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/test/java/org/neo4j/com/MadeUpException.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/MadeUpException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/test/java/org/neo4j/com/MadeUpServer.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/MadeUpServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/test/java/org/neo4j/com/MadeUpServerImplementation.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/MadeUpServerImplementation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/test/java/org/neo4j/com/MadeUpServerProcess.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/MadeUpServerProcess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/test/java/org/neo4j/com/MadeUpWriter.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/MadeUpWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/test/java/org/neo4j/com/PortIteratorTest.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/PortIteratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/test/java/org/neo4j/com/PortRangeSocketBinderTest.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/PortRangeSocketBinderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/test/java/org/neo4j/com/ProtocolTest.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/ProtocolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/test/java/org/neo4j/com/RecordingChannel.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/RecordingChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/test/java/org/neo4j/com/ResourcePoolTest.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/ResourcePoolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/test/java/org/neo4j/com/ServerInterface.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/ServerInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/test/java/org/neo4j/com/ServerTest.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/ServerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/test/java/org/neo4j/com/StartupData.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/StartupData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/test/java/org/neo4j/com/StoreIdTestFactory.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/StoreIdTestFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/test/java/org/neo4j/com/TestSlaveContext.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/TestSlaveContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/test/java/org/neo4j/com/ToAssertionWriter.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/ToAssertionWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/test/java/org/neo4j/com/ToChannelBufferWriter.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/ToChannelBufferWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/test/java/org/neo4j/com/storecopy/FileMoveProviderTest.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/storecopy/FileMoveProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/test/java/org/neo4j/com/storecopy/ResponsePackerIT.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/storecopy/ResponsePackerIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/test/java/org/neo4j/com/storecopy/ResponsePackerTest.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/storecopy/ResponsePackerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/test/java/org/neo4j/com/storecopy/StoreCopyClientTest.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/storecopy/StoreCopyClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/test/java/org/neo4j/com/storecopy/ToFileStoreWriterTest.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/storecopy/ToFileStoreWriterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/test/java/org/neo4j/com/storecopy/TransactionBatchCommitterTest.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/storecopy/TransactionBatchCommitterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/com/src/test/java/org/neo4j/com/storecopy/TransactionCommittingResponseUnpackerTest.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/storecopy/TransactionCommittingResponseUnpackerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/NOTICE.txt
+++ b/enterprise/cypher/acceptance-spec-suite/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/java/org/neo4j/internal/cypher/acceptance/TestFunction.java
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/java/org/neo4j/internal/cypher/acceptance/TestFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/java/org/neo4j/internal/cypher/acceptance/TestProcedure.java
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/java/org/neo4j/internal/cypher/acceptance/TestProcedure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/java/org/neo4j/internal/cypher/acceptance/TestResourceProcedure.java
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/java/org/neo4j/internal/cypher/acceptance/TestResourceProcedure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/AggregationAcceptance.feature
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/AggregationAcceptance.feature
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/BuiltInProcedureAcceptance.feature
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/BuiltInProcedureAcceptance.feature
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/CaseExpression.feature
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/CaseExpression.feature
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/ConstraintAcceptance.feature
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/ConstraintAcceptance.feature
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/DeleteAcceptance.feature
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/DeleteAcceptance.feature
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/ExplainAcceptance.feature
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/ExplainAcceptance.feature
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/ForeachAcceptance.feature
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/ForeachAcceptance.feature
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/IndexAcceptance.feature
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/IndexAcceptance.feature
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/MatchAcceptance.feature
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/MatchAcceptance.feature
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/MergeLegacyAcceptance.feature
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/MergeLegacyAcceptance.feature
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/OperatorChaining.feature
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/OperatorChaining.feature
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/OptionalMatchAcceptance.feature
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/OptionalMatchAcceptance.feature
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/OrderByAcceptance.feature
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/OrderByAcceptance.feature
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/PatternExpressionAcceptance.feature
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/PatternExpressionAcceptance.feature
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/PatternPredicates.feature
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/PatternPredicates.feature
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/ProcedureCallAcceptance.feature
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/ProcedureCallAcceptance.feature
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/ReturnAcceptance.feature
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/ReturnAcceptance.feature
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/ShortestPathAcceptance.feature
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/ShortestPathAcceptance.feature
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/SkipLimitAcceptance.feature
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/SkipLimitAcceptance.feature
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/UnwindAcceptance.feature
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/UnwindAcceptance.feature
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/VarLengthAcceptance.feature
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/VarLengthAcceptance.feature
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/cypher/features/AcceptanceTests.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/cypher/features/AcceptanceTests.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/cypher/features/Compatibility23AcceptanceTests.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/cypher/features/Compatibility23AcceptanceTests.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/cypher/features/Compatibility31AcceptanceTests.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/cypher/features/Compatibility31AcceptanceTests.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/cypher/features/Compatibility33AcceptanceTests.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/cypher/features/Compatibility33AcceptanceTests.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/cypher/features/CostCompiledAcceptanceTests.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/cypher/features/CostCompiledAcceptanceTests.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/cypher/features/CostInterpretedAcceptanceTests.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/cypher/features/CostInterpretedAcceptanceTests.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/cypher/features/CostSlottedAcceptanceTests.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/cypher/features/CostSlottedAcceptanceTests.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/cypher/features/DefaultAcceptanceTests.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/cypher/features/DefaultAcceptanceTests.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/AggregationAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/AggregationAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/AggregationFunctionCallSupportAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/AggregationFunctionCallSupportAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/BuiltInFunctionsAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/BuiltInFunctionsAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/BuiltInProcedureAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/BuiltInProcedureAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CartesianProductNotificationAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CartesianProductNotificationAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CompositeIndexAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CompositeIndexAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CompositeNodeKeyConstraintAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CompositeNodeKeyConstraintAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CompositeUniquenessConstraintAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CompositeUniquenessConstraintAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CostPlannerAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CostPlannerAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CreateAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CreateAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CypherComparisonSupport.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CypherComparisonSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CypherCompilerStringCacheMonitoringAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CypherCompilerStringCacheMonitoringAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/DebugToStringTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/DebugToStringTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/DumpToStringAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/DumpToStringAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/EagerizationAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/EagerizationAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ExecutionEngineTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ExecutionEngineTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ExecutionResultAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ExecutionResultAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ExplainAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ExplainAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ExpressionAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ExpressionAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ForeachAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ForeachAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/FunctionCallSupportAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/FunctionCallSupportAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/GrammarStressIT.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/GrammarStressIT.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/HelpfulErrorMessagesTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/HelpfulErrorMessagesTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/HintAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/HintAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/IdAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/IdAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/IndexNestedLoopJoinAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/IndexNestedLoopJoinAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/IndexPersistenceAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/IndexPersistenceAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/IndexingTestSupport.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/IndexingTestSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/JoinAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/JoinAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/LdbcAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/LdbcAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/LdbcQueries.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/LdbcQueries.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ListExpressionAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ListExpressionAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/LoadCsvAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/LoadCsvAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/LoadCsvAcceptanceUserAgentTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/LoadCsvAcceptanceUserAgentTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/LoadCsvCompressionAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/LoadCsvCompressionAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/LoadCsvWithQuotesAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/LoadCsvWithQuotesAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ManualIndexProcsIT.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ManualIndexProcsIT.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAggregationsBackedByCountStoreAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAggregationsBackedByCountStoreAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchLongPatternAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchLongPatternAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MemoryPerformanceAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MemoryPerformanceAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MergeIntoPlanningAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MergeIntoPlanningAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MergeNodeAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MergeNodeAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MergeNodeCompatibilityAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MergeNodeCompatibilityAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MiscAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MiscAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MorselRuntimeAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MorselRuntimeAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MutatingIntegrationTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MutatingIntegrationTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NaNAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NaNAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/Neo4jValueComparisonTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/Neo4jValueComparisonTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NodeIndexContainsScanAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NodeIndexContainsScanAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NodeIndexEndsWithScanAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NodeIndexEndsWithScanAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NodeIndexScanAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NodeIndexScanAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NodeIndexSeekAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NodeIndexSeekAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NodeIndexSeekByRangeAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NodeIndexSeekByRangeAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NotificationAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NotificationAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NullAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NullAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NullListAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NullListAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ParameterValuesAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ParameterValuesAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/PatternComprehensionAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/PatternComprehensionAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/PatternExpressionImplementationAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/PatternExpressionImplementationAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/PeriodicCommitAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/PeriodicCommitAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/PreParsingAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/PreParsingAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ProcedureCallAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ProcedureCallAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ProcedureCallSupportAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ProcedureCallSupportAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ProceduresAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ProceduresAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ProfilerAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ProfilerAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/PruningVarExpandAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/PruningVarExpandAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/QueryEngineProceduresAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/QueryEngineProceduresAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/QueryPlanCompactionAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/QueryPlanCompactionAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/QueryPlanCompatibilityTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/QueryPlanCompatibilityTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ReflectiveProcedureCallAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ReflectiveProcedureCallAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/RemoveAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/RemoveAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ReverseAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ReverseAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SameQueryStressTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SameQueryStressTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SemanticCreateAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SemanticCreateAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SemanticDeleteAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SemanticDeleteAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SemanticErrorAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SemanticErrorAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SemanticMergeAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SemanticMergeAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SerializationAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SerializationAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SetAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SetAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathComplexQueryAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathComplexQueryAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathEdgeCasesAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathEdgeCasesAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathExhaustiveForbiddenAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathExhaustiveForbiddenAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathLongerAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathLongerAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathRelationshipUniquenessAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathRelationshipUniquenessAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathSameNodeAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathSameNodeAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SpatialDistanceAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SpatialDistanceAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SpatialFunctionsAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SpatialFunctionsAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SpatialIndexResultsAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SpatialIndexResultsAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SpatialUniqueConstraintValidationAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SpatialUniqueConstraintValidationAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/StartAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/StartAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/StartPointFindingAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/StartPointFindingAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/StartsWithImplementationAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/StartsWithImplementationAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/StoreIntegrationAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/StoreIntegrationAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/StringMatchingAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/StringMatchingAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SyntaxExceptionAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SyntaxExceptionAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/TemporalAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/TemporalAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/TemporalFunctionsAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/TemporalFunctionsAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/TemporalIndexAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/TemporalIndexAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/TemporalUniqueConstraintValidationAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/TemporalUniqueConstraintValidationAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/TestGraph.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/TestGraph.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/TextValueSpecification.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/TextValueSpecification.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/TimeZoneAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/TimeZoneAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ToStringAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ToStringAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/TriadicSelectionAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/TriadicSelectionAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/UnionAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/UnionAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/UniqueConstraintValidationAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/UniqueConstraintValidationAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/UniqueConstraintVerificationAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/UniqueConstraintVerificationAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/UniqueIndexAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/UniqueIndexAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/UniqueIndexUsageAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/UniqueIndexUsageAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/UniquenessAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/UniquenessAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/UpdateReportingAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/UpdateReportingAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/UsingAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/UsingAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/VarLengthExpandQueryPlanAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/VarLengthExpandQueryPlanAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/VarLengthPlanningTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/VarLengthPlanningTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/compatibility-spec-suite/NOTICE.txt
+++ b/enterprise/cypher/compatibility-spec-suite/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/enterprise/cypher/compatibility-spec-suite/src/test/scala/cypher/features/Compatibility23TCKTests.scala
+++ b/enterprise/cypher/compatibility-spec-suite/src/test/scala/cypher/features/Compatibility23TCKTests.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/compatibility-spec-suite/src/test/scala/cypher/features/Compatibility31TCKTests.scala
+++ b/enterprise/cypher/compatibility-spec-suite/src/test/scala/cypher/features/Compatibility31TCKTests.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/compatibility-spec-suite/src/test/scala/cypher/features/Compatibility33TCKTests.scala
+++ b/enterprise/cypher/compatibility-spec-suite/src/test/scala/cypher/features/Compatibility33TCKTests.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/compatibility-spec-suite/src/test/scala/cypher/features/CostCompiledTCKTests.scala
+++ b/enterprise/cypher/compatibility-spec-suite/src/test/scala/cypher/features/CostCompiledTCKTests.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/compatibility-spec-suite/src/test/scala/cypher/features/CostInterpretedTCKTests.scala
+++ b/enterprise/cypher/compatibility-spec-suite/src/test/scala/cypher/features/CostInterpretedTCKTests.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/compatibility-spec-suite/src/test/scala/cypher/features/CostSlottedTCKTests.scala
+++ b/enterprise/cypher/compatibility-spec-suite/src/test/scala/cypher/features/CostSlottedTCKTests.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/compatibility-spec-suite/src/test/scala/cypher/features/DefaultTCKTests.scala
+++ b/enterprise/cypher/compatibility-spec-suite/src/test/scala/cypher/features/DefaultTCKTests.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/compatibility-spec-suite/src/test/scala/cypher/features/TCKTests.scala
+++ b/enterprise/cypher/compatibility-spec-suite/src/test/scala/cypher/features/TCKTests.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/NOTICE.txt
+++ b/enterprise/cypher/cypher/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/enterprise/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/DefaultFullSortTable.java
+++ b/enterprise/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/DefaultFullSortTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/DefaultTopTable.java
+++ b/enterprise/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/DefaultTopTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/java/org/neo4j/cypher/internal/javacompat/EnterpriseCypherEngineProvider.java
+++ b/enterprise/cypher/cypher/src/main/java/org/neo4j/cypher/internal/javacompat/EnterpriseCypherEngineProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/java/org/neo4j/cypher/internal/v3_4/codegen/QueryExecutionTracer.java
+++ b/enterprise/cypher/cypher/src/main/java/org/neo4j/cypher/internal/v3_4/codegen/QueryExecutionTracer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/java/org/neo4j/cypher/internal/v3_4/codegen/profiling/ProfilingTracer.java
+++ b/enterprise/cypher/cypher/src/main/java/org/neo4j/cypher/internal/v3_4/codegen/profiling/ProfilingTracer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/java/org/neo4j/cypher/internal/v3_4/executionplan/GeneratedQuery.java
+++ b/enterprise/cypher/cypher/src/main/java/org/neo4j/cypher/internal/v3_4/executionplan/GeneratedQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/java/org/neo4j/cypher/internal/v3_4/executionplan/GeneratedQueryExecution.java
+++ b/enterprise/cypher/cypher/src/main/java/org/neo4j/cypher/internal/v3_4/executionplan/GeneratedQueryExecution.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/BuildSlottedExecutionPlan.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/BuildSlottedExecutionPlan.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/BuildVectorizedExecutionPlan.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/BuildVectorizedExecutionPlan.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/DebugPrettyPrinter.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/DebugPrettyPrinter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/EnterpriseCompatibilityFactory.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/EnterpriseCompatibilityFactory.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/EnterpriseRuntimeBuilder.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/EnterpriseRuntimeBuilder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/BuildCompiledExecutionPlan.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/BuildCompiledExecutionPlan.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/CompiledExecutionResult.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/CompiledExecutionResult.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/CompiledRuntimeBuilder.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/CompiledRuntimeBuilder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/EnterpriseRuntimeContext.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/EnterpriseRuntimeContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/ExecutionPlanBuilder.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/ExecutionPlanBuilder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/CodeGenConfiguration.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/CodeGenConfiguration.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/CodeGenContext.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/CodeGenContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/CodeGenPlan.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/CodeGenPlan.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/CodeGenerator.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/CodeGenerator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/LogicalPlanConverter.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/LogicalPlanConverter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/Namer.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/Namer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/QueryExecutionEvent.java
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/QueryExecutionEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/AcceptVisitor.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/AcceptVisitor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/AggregationInstruction.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/AggregationInstruction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/ApplyInstruction.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/ApplyInstruction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/BuildProbeTable.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/BuildProbeTable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/BuildSortTable.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/BuildSortTable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/CartesianProductInstruction.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/CartesianProductInstruction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/CheckingInstruction.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/CheckingInstruction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/DecreaseAndReturnWhenZero.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/DecreaseAndReturnWhenZero.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/ExpandAllLoopDataGenerator.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/ExpandAllLoopDataGenerator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/ExpandIntoLoopDataGenerator.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/ExpandIntoLoopDataGenerator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/ForEachExpression.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/ForEachExpression.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/GetMatchesFromProbeTable.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/GetMatchesFromProbeTable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/GetSortedResult.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/GetSortedResult.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/If.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/If.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/IndexSeek.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/IndexSeek.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/Instruction.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/Instruction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/LoopDataGenerator.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/LoopDataGenerator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/MethodInvocation.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/MethodInvocation.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/NodeCountFromCountStoreInstruction.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/NodeCountFromCountStoreInstruction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/NullingInstruction.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/NullingInstruction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/Projection.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/Projection.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/RelationshipCountFromCountStoreInstruction.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/RelationshipCountFromCountStoreInstruction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/ScanAllNodes.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/ScanAllNodes.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/ScanForLabel.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/ScanForLabel.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/SeekNodeById.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/SeekNodeById.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/SelectionInstruction.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/SelectionInstruction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/SkipInstruction.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/SkipInstruction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/SortInstruction.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/SortInstruction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/UnwindCollection.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/UnwindCollection.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/UnwindPrimitiveCollection.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/UnwindPrimitiveCollection.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/WhileLoop.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/WhileLoop.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/aggregation/AggregateExpression.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/aggregation/AggregateExpression.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/aggregation/AggregationConverter.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/aggregation/AggregationConverter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/aggregation/Distinct.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/aggregation/Distinct.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/aggregation/DynamicCount.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/aggregation/DynamicCount.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/aggregation/SimpleCount.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/aggregation/SimpleCount.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/expressions/Addition.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/expressions/Addition.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/expressions/AnyProjection.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/expressions/AnyProjection.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/expressions/BinaryOperator.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/expressions/BinaryOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/expressions/BooleanConstant.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/expressions/BooleanConstant.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/expressions/CodeGenExpression.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/expressions/CodeGenExpression.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/expressions/CodeGenType.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/expressions/CodeGenType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/expressions/Division.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/expressions/Division.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/expressions/Equals.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/expressions/Equals.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/expressions/ExpressionConverter.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/expressions/ExpressionConverter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/expressions/HasLabel.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/expressions/HasLabel.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/expressions/IdOf.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/expressions/IdOf.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/expressions/ListLiteral.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/expressions/ListLiteral.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/expressions/Literal.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/expressions/Literal.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/expressions/LoadVariable.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/expressions/LoadVariable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/expressions/MapProperty.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/expressions/MapProperty.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/expressions/Modulo.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/expressions/Modulo.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/expressions/Multiplication.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/expressions/Multiplication.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/expressions/MyMap.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/expressions/MyMap.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/expressions/NodeExpression.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/expressions/NodeExpression.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/expressions/NodeProjection.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/expressions/NodeProjection.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/expressions/NodeProperty.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/expressions/NodeProperty.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/expressions/Not.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/expressions/Not.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/expressions/Or.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/expressions/Or.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/expressions/Parameter.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/expressions/Parameter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/expressions/RelationshipExpression.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/expressions/RelationshipExpression.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/expressions/RelationshipProjection.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/expressions/RelationshipProjection.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/expressions/RepresentationType.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/expressions/RepresentationType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/expressions/Subtraction.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/expressions/Subtraction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/expressions/ToSet.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/expressions/ToSet.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/expressions/TypeOf.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/expressions/TypeOf.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/functions/CodeGenFunction1.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/functions/CodeGenFunction1.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/functions/functionConverter.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/functions/functionConverter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/setStaticField.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/setStaticField.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/spi/CodeStructure.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/spi/CodeStructure.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/spi/CodeStructureResult.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/spi/CodeStructureResult.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/spi/MethodStructure.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/spi/MethodStructure.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/helpers/LiteralTypeSupport.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/helpers/LiteralTypeSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_4/codegen/AuxGenerator.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_4/codegen/AuxGenerator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_4/codegen/Fields.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_4/codegen/Fields.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_4/codegen/GeneratedMethodStructure.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_4/codegen/GeneratedMethodStructure.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_4/codegen/GeneratedQueryStructure.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_4/codegen/GeneratedQueryStructure.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_4/codegen/Methods.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_4/codegen/Methods.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_4/codegen/Templates.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_4/codegen/Templates.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/test/java/org/neo4j/cypher/internal/codegen/CompiledRuntimeEchoIT.java
+++ b/enterprise/cypher/cypher/src/test/java/org/neo4j/cypher/internal/codegen/CompiledRuntimeEchoIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/test/java/org/neo4j/cypher/internal/codegen/DefaultTopTableTest.java
+++ b/enterprise/cypher/cypher/src/test/java/org/neo4j/cypher/internal/codegen/DefaultTopTableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/test/java/org/neo4j/cypher/internal/codegen/SetStaticFieldTest.java
+++ b/enterprise/cypher/cypher/src/test/java/org/neo4j/cypher/internal/codegen/SetStaticFieldTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/test/java/org/neo4j/cypher/internal/javacompat/ExecutionResultTest.java
+++ b/enterprise/cypher/cypher/src/test/java/org/neo4j/cypher/internal/javacompat/ExecutionResultTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/CloseTransactionTest.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/CloseTransactionTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/CypherCompatibilityTest.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/CypherCompatibilityTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/ExecutionEngineIT.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/ExecutionEngineIT.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/RootPlanAcceptanceTest.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/RootPlanAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/spi/v3_4/GeneratedMethodStructureTest.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/spi/v3_4/GeneratedMethodStructureTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_4/BuildCompiledExecutionPlanTest.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_4/BuildCompiledExecutionPlanTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_4/TypeConversionTest.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_4/TypeConversionTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_4/codegen/CompiledExecutionResultTest.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_4/codegen/CompiledExecutionResultTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_4/codegen/CompiledRuntimeContextHelper.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_4/codegen/CompiledRuntimeContextHelper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_4/codegen/SaveGeneratedSource.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_4/codegen/SaveGeneratedSource.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_4/codegen/expressions/CodeGenExpressionTypesTest.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_4/codegen/expressions/CodeGenExpressionTypesTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_4/codegen/ir/BuildProbeTableInstructionsTest.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_4/codegen/ir/BuildProbeTableInstructionsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_4/codegen/ir/CodeGenSugar.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_4/codegen/ir/CodeGenSugar.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_4/codegen/ir/CompiledProfilingTest.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_4/codegen/ir/CompiledProfilingTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/queryReduction/BT.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/queryReduction/BT.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/queryReduction/BTTest.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/queryReduction/BTTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/queryReduction/CypherReductionSupport.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/queryReduction/CypherReductionSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/queryReduction/CypherReductionSupportTest.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/queryReduction/CypherReductionSupportTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/queryReduction/DDmin.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/queryReduction/DDmin.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/queryReduction/DDminTest.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/queryReduction/DDminTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/queryReduction/GTR.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/queryReduction/GTR.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/queryReduction/ReductionTestHelper.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/queryReduction/ReductionTestHelper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/queryReduction/StatementGTRInput.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/queryReduction/StatementGTRInput.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/queryReduction/StatementLevelBTInput.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/queryReduction/StatementLevelBTInput.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/queryReduction/StatementLevelDDInput.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/queryReduction/StatementLevelDDInput.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/queryReduction/ast/ASTNodeHelper.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/queryReduction/ast/ASTNodeHelper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/queryReduction/ast/copyNodeWith.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/queryReduction/ast/copyNodeWith.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/queryReduction/ast/domainsOf.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/queryReduction/ast/domainsOf.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/queryReduction/ast/getChildren.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/queryReduction/ast/getChildren.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/v3_4/codegen/profiling/ProfilingTracerTest.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/v3_4/codegen/profiling/ProfilingTracerTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/morsel-runtime/NOTICE.txt
+++ b/enterprise/cypher/morsel-runtime/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/Message.scala
+++ b/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/Message.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/Morsel.scala
+++ b/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/Morsel.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/MorselExecutionContext.scala
+++ b/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/MorselExecutionContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/Operator.scala
+++ b/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/Operator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/PipelineBuilder.scala
+++ b/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/PipelineBuilder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/dispatcher/Dispatcher.scala
+++ b/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/dispatcher/Dispatcher.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/dispatcher/ParallelDispatcher.scala
+++ b/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/dispatcher/ParallelDispatcher.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/dispatcher/SingleThreadedExecutor.scala
+++ b/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/dispatcher/SingleThreadedExecutor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/expressions/AggregationExpressionOperator.scala
+++ b/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/expressions/AggregationExpressionOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/expressions/AggregationHelper.scala
+++ b/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/expressions/AggregationHelper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/expressions/AvgOperatorExpression.scala
+++ b/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/expressions/AvgOperatorExpression.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/expressions/CollectOperatorExpression.scala
+++ b/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/expressions/CollectOperatorExpression.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/expressions/CountOperatorExpression.scala
+++ b/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/expressions/CountOperatorExpression.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/expressions/CountStarOperatorExpression.scala
+++ b/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/expressions/CountStarOperatorExpression.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/expressions/MinOrMaxOperatorExpression.scala
+++ b/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/expressions/MinOrMaxOperatorExpression.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/expressions/MorselExpressionConverters.scala
+++ b/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/expressions/MorselExpressionConverters.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/operators/AggregationMapperOperator.scala
+++ b/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/operators/AggregationMapperOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/operators/AggregationMapperOperatorNoGrouping.scala
+++ b/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/operators/AggregationMapperOperatorNoGrouping.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/operators/AggregationOffsets.scala
+++ b/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/operators/AggregationOffsets.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/operators/AggregationReduceOperator.scala
+++ b/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/operators/AggregationReduceOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/operators/AggregationReduceOperatorNoGrouping.scala
+++ b/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/operators/AggregationReduceOperatorNoGrouping.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/operators/AllNodeScanOperator.scala
+++ b/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/operators/AllNodeScanOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/operators/ArgumentOperator.scala
+++ b/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/operators/ArgumentOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/operators/ExpandAllOperator.scala
+++ b/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/operators/ExpandAllOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/operators/FilterOperator.scala
+++ b/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/operators/FilterOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/operators/GroupingOffsets.scala
+++ b/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/operators/GroupingOffsets.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/operators/LabelScanOperator.scala
+++ b/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/operators/LabelScanOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/operators/MergeSortOperator.scala
+++ b/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/operators/MergeSortOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/operators/NodeIndexSeekOperator.scala
+++ b/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/operators/NodeIndexSeekOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/operators/PreSortOperator.scala
+++ b/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/operators/PreSortOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/operators/ProduceResultOperator.scala
+++ b/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/operators/ProduceResultOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/operators/ProjectOperator.scala
+++ b/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/operators/ProjectOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/operators/UnwindOperator.scala
+++ b/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/operators/UnwindOperator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/morsel-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/vectorized/expressions/AvgOperatorExpressionTest.scala
+++ b/enterprise/cypher/morsel-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/vectorized/expressions/AvgOperatorExpressionTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/morsel-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/vectorized/operators/AggregationMapperOperatorNoGroupingTest.scala
+++ b/enterprise/cypher/morsel-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/vectorized/operators/AggregationMapperOperatorNoGroupingTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/morsel-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/vectorized/operators/AggregationMapperOperatorTest.scala
+++ b/enterprise/cypher/morsel-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/vectorized/operators/AggregationMapperOperatorTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/morsel-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/vectorized/operators/AggregationReducerOperatorNoGroupingTest.scala
+++ b/enterprise/cypher/morsel-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/vectorized/operators/AggregationReducerOperatorNoGroupingTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/morsel-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/vectorized/operators/AggregationReducerOperatorTest.scala
+++ b/enterprise/cypher/morsel-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/vectorized/operators/AggregationReducerOperatorTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/morsel-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/vectorized/operators/DummyEvenNodeIdAggregation.scala
+++ b/enterprise/cypher/morsel-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/vectorized/operators/DummyEvenNodeIdAggregation.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/morsel-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/vectorized/operators/MergeSortOperatorTest.scala
+++ b/enterprise/cypher/morsel-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/vectorized/operators/MergeSortOperatorTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/morsel-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/vectorized/operators/PreSortOperatorTest.scala
+++ b/enterprise/cypher/morsel-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/vectorized/operators/PreSortOperatorTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/physical-planning/NOTICE.txt
+++ b/enterprise/cypher/physical-planning/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/PhysicalPlanningAttributes.scala
+++ b/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/PhysicalPlanningAttributes.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/Slot.scala
+++ b/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/Slot.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlotAllocation.scala
+++ b/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlotAllocation.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlotConfiguration.scala
+++ b/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlotConfiguration.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlottedRewriter.scala
+++ b/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlottedRewriter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ast/GetDegreePrimitive.scala
+++ b/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ast/GetDegreePrimitive.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ast/IdFromSlot.scala
+++ b/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ast/IdFromSlot.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ast/IsPrimitiveNull.scala
+++ b/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ast/IsPrimitiveNull.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ast/NodeFromSlot.scala
+++ b/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ast/NodeFromSlot.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ast/NodeProperty.scala
+++ b/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ast/NodeProperty.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ast/NullCheck.scala
+++ b/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ast/NullCheck.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ast/PrimitiveEquals.scala
+++ b/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ast/PrimitiveEquals.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ast/ReferenceFromSlot.scala
+++ b/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ast/ReferenceFromSlot.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ast/RelationshipFromSlot.scala
+++ b/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ast/RelationshipFromSlot.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ast/RelationshipProperty.scala
+++ b/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ast/RelationshipProperty.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ast/RuntimeExpression.scala
+++ b/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ast/RuntimeExpression.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ast/RuntimeProperty.scala
+++ b/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ast/RuntimeProperty.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ast/RuntimeVariable.scala
+++ b/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ast/RuntimeVariable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/physical-planning/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlotAllocationArgumentsTest.scala
+++ b/enterprise/cypher/physical-planning/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlotAllocationArgumentsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/physical-planning/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlotAllocationTest.scala
+++ b/enterprise/cypher/physical-planning/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlotAllocationTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/physical-planning/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlotConfigurationTest.scala
+++ b/enterprise/cypher/physical-planning/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlotConfigurationTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/physical-planning/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlottedRewriterTest.scala
+++ b/enterprise/cypher/physical-planning/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlottedRewriterTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/NOTICE.txt
+++ b/enterprise/cypher/slotted-runtime/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/enterprise/cypher/slotted-runtime/src/main/java/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/DefaultComparatorTopTable.java
+++ b/enterprise/cypher/slotted-runtime/src/main/java/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/DefaultComparatorTopTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/ArrayResultExecutionContext.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/ArrayResultExecutionContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/SlottedExecutionContext.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/SlottedExecutionContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/SlottedExecutionResultBuilderFactory.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/SlottedExecutionResultBuilderFactory.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/SlottedPipeBuilder.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/SlottedPipeBuilder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/SlottedQueryState.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/SlottedQueryState.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/expressions/GetDegreePrimitive.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/expressions/GetDegreePrimitive.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/expressions/IdFromSlot.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/expressions/IdFromSlot.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/expressions/IsPrimitiveNull.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/expressions/IsPrimitiveNull.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/expressions/NodeFromSlot.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/expressions/NodeFromSlot.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/expressions/NodeProperty.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/expressions/NodeProperty.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/expressions/NullCheck.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/expressions/NullCheck.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/expressions/PrimitiveEquals.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/expressions/PrimitiveEquals.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/expressions/ReferenceFromSlot.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/expressions/ReferenceFromSlot.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/expressions/RelationshipFromSlot.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/expressions/RelationshipFromSlot.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/expressions/RelationshipProperty.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/expressions/RelationshipProperty.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/expressions/SlottedExpression.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/expressions/SlottedExpression.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/expressions/SlottedExpressionConverters.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/expressions/SlottedExpressionConverters.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/expressions/SlottedProjectedPath.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/expressions/SlottedProjectedPath.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/helpers/NullChecker.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/helpers/NullChecker.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/helpers/SlottedPipeBuilderUtils.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/helpers/SlottedPipeBuilderUtils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/AbstractHashJoinPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/AbstractHashJoinPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/AllNodesScanSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/AllNodesScanSlottedPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/ApplySlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/ApplySlottedPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/ArgumentSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/ArgumentSlottedPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/BaseRelationshipSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/BaseRelationshipSlottedPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/CartesianProductSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/CartesianProductSlottedPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/ConditionalApplySlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/ConditionalApplySlottedPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/CreateNodeSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/CreateNodeSlottedPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/DistinctSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/DistinctSlottedPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/EagerAggregationSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/EagerAggregationSlottedPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/EagerAggregationWithoutGroupingSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/EagerAggregationWithoutGroupingSlottedPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/EagerSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/EagerSlottedPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/ExpandAllSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/ExpandAllSlottedPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/ExpandIntoSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/ExpandIntoSlottedPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/ForeachSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/ForeachSlottedPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/NodeHashJoinSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/NodeHashJoinSlottedPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/NodeIndexScanSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/NodeIndexScanSlottedPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/NodeIndexSeekSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/NodeIndexSeekSlottedPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/NodesByLabelScanSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/NodesByLabelScanSlottedPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/OptionalExpandAllSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/OptionalExpandAllSlottedPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/OptionalExpandIntoSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/OptionalExpandIntoSlottedPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/OptionalSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/OptionalSlottedPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/PrimitiveCachingExpandInto.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/PrimitiveCachingExpandInto.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/ProduceResultSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/ProduceResultSlottedPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/ProjectionSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/ProjectionSlottedPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/RollUpApplySlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/RollUpApplySlottedPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/SortSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/SortSlottedPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/TopSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/TopSlottedPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/UnionSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/UnionSlottedPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/UnwindSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/UnwindSlottedPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/ValueHashJoinSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/ValueHashJoinSlottedPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/VarLengthExpandSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/VarLengthExpandSlottedPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/src/test/java/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/DefaultComparatorTopTableTest.java
+++ b/enterprise/cypher/slotted-runtime/src/test/java/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/DefaultComparatorTopTableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/slotted/PrimitiveExecutionContextTest.scala
+++ b/enterprise/cypher/slotted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/slotted/PrimitiveExecutionContextTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/slotted/SlottedPipeBuilderTest.scala
+++ b/enterprise/cypher/slotted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/slotted/SlottedPipeBuilderTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/slotted/helpers/SlottedPipeBuilderUtilsTest.scala
+++ b/enterprise/cypher/slotted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/slotted/helpers/SlottedPipeBuilderUtilsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/FakeSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/FakeSlottedPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/HashJoinSlottedPipeTestHelper.scala
+++ b/enterprise/cypher/slotted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/HashJoinSlottedPipeTestHelper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/NodeHashJoinSlottedPipeTest.scala
+++ b/enterprise/cypher/slotted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/NodeHashJoinSlottedPipeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/ProduceResultSlottedPipeStressTest.scala
+++ b/enterprise/cypher/slotted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/ProduceResultSlottedPipeStressTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/RollUpApplySlottedPipeTest.scala
+++ b/enterprise/cypher/slotted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/RollUpApplySlottedPipeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/Top1WithTiesSlottedPipeTest.scala
+++ b/enterprise/cypher/slotted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/Top1WithTiesSlottedPipeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/TopSlottedPipeTest.scala
+++ b/enterprise/cypher/slotted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/TopSlottedPipeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/UnionSlottedPipeTest.scala
+++ b/enterprise/cypher/slotted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/UnionSlottedPipeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/UnwindSlottedPipeTest.scala
+++ b/enterprise/cypher/slotted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/UnwindSlottedPipeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/slotted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/ValueHashJoinSlottedPipeTest.scala
+++ b/enterprise/cypher/slotted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/ValueHashJoinSlottedPipeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/spec-suite-tools/NOTICE.txt
+++ b/enterprise/cypher/spec-suite-tools/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/enterprise/cypher/spec-suite-tools/src/test/scala/cypher/features/BaseFeatureTest.scala
+++ b/enterprise/cypher/spec-suite-tools/src/test/scala/cypher/features/BaseFeatureTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/spec-suite-tools/src/test/scala/cypher/features/BlacklistEntry.scala
+++ b/enterprise/cypher/spec-suite-tools/src/test/scala/cypher/features/BlacklistEntry.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/spec-suite-tools/src/test/scala/cypher/features/Neo4jAdapter.scala
+++ b/enterprise/cypher/spec-suite-tools/src/test/scala/cypher/features/Neo4jAdapter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/spec-suite-tools/src/test/scala/cypher/features/Neo4jExceptionToExecutionFailed.scala
+++ b/enterprise/cypher/spec-suite-tools/src/test/scala/cypher/features/Neo4jExceptionToExecutionFailed.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/spec-suite-tools/src/test/scala/cypher/features/Neo4jProcedureAdapter.scala
+++ b/enterprise/cypher/spec-suite-tools/src/test/scala/cypher/features/Neo4jProcedureAdapter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/spec-suite-tools/src/test/scala/cypher/features/Neo4jValueToString.scala
+++ b/enterprise/cypher/spec-suite-tools/src/test/scala/cypher/features/Neo4jValueToString.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/spec-suite-tools/src/test/scala/cypher/features/ProcedureSignature.scala
+++ b/enterprise/cypher/spec-suite-tools/src/test/scala/cypher/features/ProcedureSignature.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/spec-suite-tools/src/test/scala/cypher/features/ProcedureSignatureParser.scala
+++ b/enterprise/cypher/spec-suite-tools/src/test/scala/cypher/features/ProcedureSignatureParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/spec-suite-tools/src/test/scala/cypher/features/ScenarioTestHelper.scala
+++ b/enterprise/cypher/spec-suite-tools/src/test/scala/cypher/features/ScenarioTestHelper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/spec-suite-tools/src/test/scala/cypher/features/TCKValueToNeo4jValue.scala
+++ b/enterprise/cypher/spec-suite-tools/src/test/scala/cypher/features/TCKValueToNeo4jValue.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/cypher/spec-suite-tools/src/test/scala/cypher/features/TestConfig.scala
+++ b/enterprise/cypher/spec-suite-tools/src/test/scala/cypher/features/TestConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/deferred-locks/NOTICE.txt
+++ b/enterprise/deferred-locks/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/enterprise/deferred-locks/src/main/java/org/neo4j/kernel/impl/locking/DeferringLockClient.java
+++ b/enterprise/deferred-locks/src/main/java/org/neo4j/kernel/impl/locking/DeferringLockClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/deferred-locks/src/main/java/org/neo4j/kernel/impl/locking/DeferringStatementLocks.java
+++ b/enterprise/deferred-locks/src/main/java/org/neo4j/kernel/impl/locking/DeferringStatementLocks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/deferred-locks/src/main/java/org/neo4j/kernel/impl/locking/DeferringStatementLocksFactory.java
+++ b/enterprise/deferred-locks/src/main/java/org/neo4j/kernel/impl/locking/DeferringStatementLocksFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/deferred-locks/src/main/java/org/neo4j/kernel/impl/locking/LockUnit.java
+++ b/enterprise/deferred-locks/src/main/java/org/neo4j/kernel/impl/locking/LockUnit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/deferred-locks/src/test/java/org/neo4j/kernel/impl/locking/DeferringLockClientTest.java
+++ b/enterprise/deferred-locks/src/test/java/org/neo4j/kernel/impl/locking/DeferringLockClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/deferred-locks/src/test/java/org/neo4j/kernel/impl/locking/DeferringLocksIT.java
+++ b/enterprise/deferred-locks/src/test/java/org/neo4j/kernel/impl/locking/DeferringLocksIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/deferred-locks/src/test/java/org/neo4j/kernel/impl/locking/DeferringStatementLocksFactoryTest.java
+++ b/enterprise/deferred-locks/src/test/java/org/neo4j/kernel/impl/locking/DeferringStatementLocksFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/deferred-locks/src/test/java/org/neo4j/kernel/impl/locking/DeferringStatementLocksTest.java
+++ b/enterprise/deferred-locks/src/test/java/org/neo4j/kernel/impl/locking/DeferringStatementLocksTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/deferred-locks/src/test/java/org/neo4j/kernel/impl/locking/LockUnitTest.java
+++ b/enterprise/deferred-locks/src/test/java/org/neo4j/kernel/impl/locking/LockUnitTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/fulltext-addon/NOTICE.txt
+++ b/enterprise/fulltext-addon/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/AsyncFulltextIndexOperation.java
+++ b/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/AsyncFulltextIndexOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/FulltextFactory.java
+++ b/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/FulltextFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/FulltextIndexConfiguration.java
+++ b/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/FulltextIndexConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/FulltextIndexType.java
+++ b/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/FulltextIndexType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/FulltextProvider.java
+++ b/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/FulltextProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/FulltextProviderImpl.java
+++ b/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/FulltextProviderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/FulltextTransactionEventUpdater.java
+++ b/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/FulltextTransactionEventUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/FulltextUpdateApplier.java
+++ b/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/FulltextUpdateApplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/LuceneFulltext.java
+++ b/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/LuceneFulltext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/LuceneFulltextDocumentStructure.java
+++ b/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/LuceneFulltextDocumentStructure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/LuceneFulltextFieldEncoding.java
+++ b/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/LuceneFulltextFieldEncoding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/PartitionedFulltextReader.java
+++ b/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/PartitionedFulltextReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/ReadOnlyFulltext.java
+++ b/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/ReadOnlyFulltext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/ScoreEntityIterator.java
+++ b/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/ScoreEntityIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/SimpleFulltextReader.java
+++ b/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/SimpleFulltextReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/WritableFulltext.java
+++ b/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/WritableFulltext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/integrations/bloom/BloomFulltextConfig.java
+++ b/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/integrations/bloom/BloomFulltextConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/integrations/bloom/BloomKernelExtension.java
+++ b/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/integrations/bloom/BloomKernelExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/integrations/bloom/BloomKernelExtensionFactory.java
+++ b/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/integrations/bloom/BloomKernelExtensionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/integrations/bloom/BloomProcedures.java
+++ b/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/integrations/bloom/BloomProcedures.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/fulltext-addon/src/test/java/org/neo4j/kernel/api/impl/fulltext/FulltextAnalyzerTest.java
+++ b/enterprise/fulltext-addon/src/test/java/org/neo4j/kernel/api/impl/fulltext/FulltextAnalyzerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/fulltext-addon/src/test/java/org/neo4j/kernel/api/impl/fulltext/FulltextUpdateApplierTest.java
+++ b/enterprise/fulltext-addon/src/test/java/org/neo4j/kernel/api/impl/fulltext/FulltextUpdateApplierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/fulltext-addon/src/test/java/org/neo4j/kernel/api/impl/fulltext/LuceneFulltextTestSupport.java
+++ b/enterprise/fulltext-addon/src/test/java/org/neo4j/kernel/api/impl/fulltext/LuceneFulltextTestSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/fulltext-addon/src/test/java/org/neo4j/kernel/api/impl/fulltext/LuceneFulltextUpdaterTest.java
+++ b/enterprise/fulltext-addon/src/test/java/org/neo4j/kernel/api/impl/fulltext/LuceneFulltextUpdaterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/fulltext-addon/src/test/java/org/neo4j/kernel/api/impl/fulltext/ScoreEntityIteratorTest.java
+++ b/enterprise/fulltext-addon/src/test/java/org/neo4j/kernel/api/impl/fulltext/ScoreEntityIteratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/fulltext-addon/src/test/java/org/neo4j/kernel/api/impl/fulltext/StubGraphDatabaseService.java
+++ b/enterprise/fulltext-addon/src/test/java/org/neo4j/kernel/api/impl/fulltext/StubGraphDatabaseService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/fulltext-addon/src/test/java/org/neo4j/kernel/api/impl/fulltext/StubLuceneFulltext.java
+++ b/enterprise/fulltext-addon/src/test/java/org/neo4j/kernel/api/impl/fulltext/StubLuceneFulltext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/fulltext-addon/src/test/java/org/neo4j/kernel/api/impl/fulltext/integrations/bloom/BloomBackupIT.java
+++ b/enterprise/fulltext-addon/src/test/java/org/neo4j/kernel/api/impl/fulltext/integrations/bloom/BloomBackupIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/fulltext-addon/src/test/java/org/neo4j/kernel/api/impl/fulltext/integrations/bloom/BloomFulltextIndexBenchmarks.java
+++ b/enterprise/fulltext-addon/src/test/java/org/neo4j/kernel/api/impl/fulltext/integrations/bloom/BloomFulltextIndexBenchmarks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/fulltext-addon/src/test/java/org/neo4j/kernel/api/impl/fulltext/integrations/bloom/BloomIT.java
+++ b/enterprise/fulltext-addon/src/test/java/org/neo4j/kernel/api/impl/fulltext/integrations/bloom/BloomIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/NOTICE.txt
+++ b/enterprise/ha/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/enterprise/ha/src/main/java/org/neo4j/graphdb/factory/HighlyAvailableGraphDatabaseFactory.java
+++ b/enterprise/ha/src/main/java/org/neo4j/graphdb/factory/HighlyAvailableGraphDatabaseFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/AbstractHaRequestTypes.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/AbstractHaRequestTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/AbstractTokenCreator.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/AbstractTokenCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/AquireLockCall.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/AquireLockCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/BranchDetectingTxVerifier.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/BranchDetectingTxVerifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/BranchedDataException.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/BranchedDataException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/BranchedDataMigrator.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/BranchedDataMigrator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/BranchedDataPolicy.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/BranchedDataPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/DelegateInvocationHandler.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/DelegateInvocationHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/EnterpriseConfigurationMigrator.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/EnterpriseConfigurationMigrator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HaRequestType.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HaRequestType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HaRequestType210.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HaRequestType210.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HaRequestTypes.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HaRequestTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HaSettings.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HaSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighAvailabilityDiagnostics.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighAvailabilityDiagnostics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighAvailabilityLogger.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighAvailabilityLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighAvailabilityMemberInfoProvider.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighAvailabilityMemberInfoProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighlyAvailableGraphDatabase.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighlyAvailableGraphDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/LastUpdateTime.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/LastUpdateTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/MasterClient214.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/MasterClient214.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/MasterClient310.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/MasterClient310.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/MasterClient320.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/MasterClient320.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/MasterTransactionCommitProcess.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/MasterTransactionCommitProcess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/MasterUpdatePuller.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/MasterUpdatePuller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/PullerFactory.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/PullerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/SlaveLabelTokenCreator.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/SlaveLabelTokenCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/SlavePropertyTokenCreator.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/SlavePropertyTokenCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/SlaveRelationshipTypeCreator.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/SlaveRelationshipTypeCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/SlaveTransactionCommitProcess.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/SlaveTransactionCommitProcess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/SlaveUpdatePuller.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/SlaveUpdatePuller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/StoreOutOfDateException.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/StoreOutOfDateException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/StoreUnableToParticipateInClusterException.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/StoreUnableToParticipateInClusterException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/TransactionChecksumLookup.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/TransactionChecksumLookup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/UpdatePuller.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/UpdatePuller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/UpdatePullerScheduler.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/UpdatePullerScheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/UpdatePullingTransactionObligationFulfiller.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/UpdatePullingTransactionObligationFulfiller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/ConversationSPI.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/ConversationSPI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/DefaultConversationSPI.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/DefaultConversationSPI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/DefaultElectionCredentials.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/DefaultElectionCredentials.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/DefaultElectionCredentialsProvider.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/DefaultElectionCredentialsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/DefaultMasterImplSPI.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/DefaultMasterImplSPI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/HANewSnapshotFunction.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/HANewSnapshotFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/HighAvailability.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/HighAvailability.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberChangeEvent.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberChangeEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberContext.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberListener.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberState.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberStateMachine.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberStateMachine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/SimpleHighAvailabilityMemberContext.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/SimpleHighAvailabilityMemberContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/SwitchToMaster.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/SwitchToMaster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/SwitchToSlave.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/SwitchToSlave.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/SwitchToSlaveBranchThenCopy.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/SwitchToSlaveBranchThenCopy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/SwitchToSlaveCopyThenBranch.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/SwitchToSlaveCopyThenBranch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/member/ClusterMember.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/member/ClusterMember.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/member/ClusterMembers.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/member/ClusterMembers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/member/HighAvailabilitySlaves.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/member/HighAvailabilitySlaves.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/member/ObservedClusterMembers.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/member/ObservedClusterMembers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/modeswitch/AbstractComponentSwitcher.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/modeswitch/AbstractComponentSwitcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/modeswitch/CommitProcessSwitcher.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/modeswitch/CommitProcessSwitcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/modeswitch/ComponentSwitcher.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/modeswitch/ComponentSwitcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/modeswitch/ComponentSwitcherContainer.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/modeswitch/ComponentSwitcherContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/modeswitch/HighAvailabilityModeSwitcher.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/modeswitch/HighAvailabilityModeSwitcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/modeswitch/LabelTokenCreatorSwitcher.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/modeswitch/LabelTokenCreatorSwitcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/modeswitch/LockManagerSwitcher.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/modeswitch/LockManagerSwitcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/modeswitch/PropertyKeyCreatorSwitcher.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/modeswitch/PropertyKeyCreatorSwitcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/modeswitch/RelationshipTypeCreatorSwitcher.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/modeswitch/RelationshipTypeCreatorSwitcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/modeswitch/StatementLocksFactorySwitcher.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/modeswitch/StatementLocksFactorySwitcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/modeswitch/UpdatePullerSwitcher.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/modeswitch/UpdatePullerSwitcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/RequestContextFactory.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/RequestContextFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/Conversation.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/Conversation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/ConversationManager.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/ConversationManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/DefaultSlaveFactory.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/DefaultSlaveFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/HandshakeResult.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/HandshakeResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/InvalidEpochException.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/InvalidEpochException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/Master.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/Master.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/MasterImpl.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/MasterImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/MasterServer.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/MasterServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/Slave.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/Slave.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/SlaveClient.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/SlaveClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/SlaveFactory.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/SlaveFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/SlavePriorities.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/SlavePriorities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/SlavePriority.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/SlavePriority.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/Slaves.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/Slaves.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/slave/InvalidEpochExceptionHandler.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/slave/InvalidEpochExceptionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/slave/MasterClient.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/slave/MasterClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/slave/MasterClientFactory.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/slave/MasterClientFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/slave/MasterClientResolver.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/slave/MasterClientResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/slave/SlaveImpl.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/slave/SlaveImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/slave/SlaveServer.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/slave/SlaveServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/factory/HighlyAvailableCommitProcessFactory.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/factory/HighlyAvailableCommitProcessFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/factory/HighlyAvailableEditionModule.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/factory/HighlyAvailableEditionModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/id/HaIdGeneratorFactory.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/id/HaIdGeneratorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/id/HaIdReuseEligibility.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/id/HaIdReuseEligibility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/id/IdAllocation.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/id/IdAllocation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/DistributedLockFailureException.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/DistributedLockFailureException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/LocalDeadlockDetectedException.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/LocalDeadlockDetectedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/LockResult.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/LockResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/LockStatus.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/LockStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/SlaveLockManager.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/SlaveLockManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/SlaveLocksClient.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/SlaveLocksClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/SlaveStatementLocks.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/SlaveStatementLocks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/SlaveStatementLocksFactory.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/SlaveStatementLocksFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/management/BranchedStoreBean.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/management/BranchedStoreBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/management/ClusterDatabaseInfoProvider.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/management/ClusterDatabaseInfoProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/management/HighAvailabilityBean.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/management/HighAvailabilityBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/management/HighlyAvailableKernelData.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/management/HighlyAvailableKernelData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/shell/Pullupdates.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/shell/Pullupdates.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/store/ForeignStoreException.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/store/ForeignStoreException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/store/HighAvailabilityStoreFailureException.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/store/HighAvailabilityStoreFailureException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/store/UnableToCopyStoreFromOldMasterException.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/store/UnableToCopyStoreFromOldMasterException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/transaction/CommitPusher.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/transaction/CommitPusher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/transaction/OnDiskLastTxIdGetter.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/transaction/OnDiskLastTxIdGetter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/transaction/TransactionPropagator.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/transaction/TransactionPropagator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/main/resources/clusters.xml
+++ b/enterprise/ha/src/main/resources/clusters.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2018-2020 "Graph Foundation,"
+    Copyright (c) "Graph Foundation,"
     Graph Foundation, Inc. [https://graphfoundation.org]
 
     This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/jmx/HaBeanIT.java
+++ b/enterprise/ha/src/test/java/jmx/HaBeanIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/graphdb/factory/HighlyAvailableGraphDatabaseFactoryTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/graphdb/factory/HighlyAvailableGraphDatabaseFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/graphdb/factory/TestHighlyAvailableGraphDatabaseFactory.java
+++ b/enterprise/ha/src/test/java/org/neo4j/graphdb/factory/TestHighlyAvailableGraphDatabaseFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/ha/BackupHaIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/BackupHaIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/ha/BeginTx.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/BeginTx.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/ha/BranchedDataIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/BranchedDataIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/ha/ClusterClientPaddingIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/ClusterClientPaddingIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/ha/ClusterIndexDeletionIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/ClusterIndexDeletionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/ha/ClusterTransactionIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/ClusterTransactionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/ha/ConstraintsInHAIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/ConstraintsInHAIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/ha/DefaultElectionCredentialsTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/DefaultElectionCredentialsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/ha/FinishTx.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/FinishTx.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/ha/ForeignStoreIdIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/ForeignStoreIdIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/ha/PullUpdatesAppliedIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/PullUpdatesAppliedIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/ha/PullUpdatesIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/PullUpdatesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/ha/SlaveOnlyClusterIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/SlaveOnlyClusterIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/ha/StartInstanceInAnotherJvm.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/StartInstanceInAnotherJvm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/ha/TestBlockLogBuffer.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/TestBlockLogBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/ha/TestRunConditions.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/TestRunConditions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/ha/TransactionConstraintsIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/TransactionConstraintsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/ha/UniquenessConstraintValidationHAIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/UniquenessConstraintValidationHAIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/ha/UpdatePullerSwitchIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/UpdatePullerSwitchIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/ha/correctness/ClusterAction.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/correctness/ClusterAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/ha/correctness/ClusterInstance.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/correctness/ClusterInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/ha/correctness/ClusterState.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/correctness/ClusterState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/ha/correctness/GraphVizExporter.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/correctness/GraphVizExporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/ha/correctness/InstanceCrashedAction.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/correctness/InstanceCrashedAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/ha/correctness/MessageDeliveryAction.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/correctness/MessageDeliveryAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/ha/correctness/ProofDatabase.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/correctness/ProofDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/ha/correctness/Prover.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/correctness/Prover.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/ha/correctness/ProverTimeouts.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/correctness/ProverTimeouts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/ha/correctness/TestProver.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/correctness/TestProver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/ha/correctness/TestProverTimeouts.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/correctness/TestProverTimeouts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/ha/upgrade/LegacyDatabase.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/upgrade/LegacyDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/ha/upgrade/LegacyDatabaseImpl.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/upgrade/LegacyDatabaseImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/ha/upgrade/MasterClientTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/upgrade/MasterClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/ha/upgrade/RollingUpgradeIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/upgrade/RollingUpgradeIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/ha/upgrade/Utils.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/upgrade/Utils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/HACountsPropagationIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/HACountsPropagationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/LabelIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/LabelIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/api/ConstraintHaIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/api/ConstraintHaIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/api/SchemaIndexHaIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/api/SchemaIndexHaIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/api/impl/labelscan/NativeLabelScanStoreHaIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/api/impl/labelscan/NativeLabelScanStoreHaIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/AbstractTokenCreatorTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/AbstractTokenCreatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/BasicHaOperationsIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/BasicHaOperationsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/BiggerThanLogTxIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/BiggerThanLogTxIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/ClusterFailoverIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/ClusterFailoverIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/ClusterPartitionIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/ClusterPartitionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/ClusterTopologyChangesIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/ClusterTopologyChangesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/ConcurrentInstanceStartupIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/ConcurrentInstanceStartupIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/ConflictingServerIdIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/ConflictingServerIdIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/DelegateInvocationHandlerTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/DelegateInvocationHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/DeletionIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/DeletionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/FailoverWithAdditionalSlaveFailuresIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/FailoverWithAdditionalSlaveFailuresIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/HaCountsIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/HaCountsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/HaIPv6ConfigurationIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/HaIPv6ConfigurationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/HardKillIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/HardKillIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/IdBufferingRoleSwitchIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/IdBufferingRoleSwitchIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/MasterEpochTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/MasterEpochTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/MeasureUpdatePullingRecordAndIndexGap.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/MeasureUpdatePullingRecordAndIndexGap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/OnDiskLastTxIdGetterTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/OnDiskLastTxIdGetterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/PropertyConstraintsStressIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/PropertyConstraintsStressIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/SlaveTokenCreatorTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/SlaveTokenCreatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/SlaveTransactionCommitProcessTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/SlaveTransactionCommitProcessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/SlaveUpdatePullerTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/SlaveUpdatePullerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/SlaveUpgradeTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/SlaveUpgradeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/TestMasterCommittingAtSlave.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/TestMasterCommittingAtSlave.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/TransactionChecksumLookupTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/TransactionChecksumLookupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/TwoInstanceClusterIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/TwoInstanceClusterIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/TxPushStrategyConfigIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/TxPushStrategyConfigIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/UpdatePullerSchedulerTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/UpdatePullerSchedulerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/UpdatePullerTriggersPageTransactionTrackingIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/UpdatePullerTriggersPageTransactionTrackingIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/UpdatePullingTransactionObligationFulfillerTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/UpdatePullingTransactionObligationFulfillerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/WhenToInitializeTransactionOnMasterFromSlaveIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/WhenToInitializeTransactionOnMasterFromSlaveIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/DefaultConversationSPITest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/DefaultConversationSPITest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/DefaultMasterImplSPITest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/DefaultMasterImplSPITest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/HANewSnapshotFunctionTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/HANewSnapshotFunctionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/HAStateMachineIllegalTransitionsTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/HAStateMachineIllegalTransitionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberStateMachineTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberStateMachineTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberStateTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/SlaveWritingAfterStoreCopyIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/SlaveWritingAfterStoreCopyIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/SwitchToMasterTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/SwitchToMasterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/SwitchToSlaveBranchThenCopyTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/SwitchToSlaveBranchThenCopyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/SwitchToSlaveCopyThenBranchTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/SwitchToSlaveCopyThenBranchTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/TerminationOfSlavesDuringPullUpdatesIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/TerminationOfSlavesDuringPullUpdatesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/member/ClusterMemberMatcher.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/member/ClusterMemberMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/member/ClusterMembersTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/member/ClusterMembersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/member/HighAvailabilitySlavesTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/member/HighAvailabilitySlavesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/member/ObservedClusterMembersTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/member/ObservedClusterMembersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/modeswitch/AbstractComponentSwitcherTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/modeswitch/AbstractComponentSwitcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/modeswitch/HighAvailabilityModeSwitcherTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/modeswitch/HighAvailabilityModeSwitcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/modeswitch/StatementLocksFactorySwitcherTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/modeswitch/StatementLocksFactorySwitcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/modeswitch/UpdatePullerSwitcherTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/modeswitch/UpdatePullerSwitcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/com/master/ConversationManagerTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/com/master/ConversationManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/com/master/ConversationTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/com/master/ConversationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/com/master/MasterImplConversationStopFuzzIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/com/master/MasterImplConversationStopFuzzIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/com/master/MasterImplTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/com/master/MasterImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/com/master/MasterServerTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/com/master/MasterServerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/com/master/SlavePrioritiesTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/com/master/SlavePrioritiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/com/slave/MasterClientResolverTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/com/slave/MasterClientResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/factory/HighlyAvailableCommitProcessFactoryTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/factory/HighlyAvailableCommitProcessFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/factory/HighlyAvailableEditionModuleIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/factory/HighlyAvailableEditionModuleIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/id/HaIdGeneratorFactoryTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/id/HaIdGeneratorFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/lock/ClusterLocksIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/lock/ClusterLocksIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/lock/SlaveLockManagerTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/lock/SlaveLockManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/lock/SlaveLocksClientConcurrentTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/lock/SlaveLocksClientConcurrentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/lock/SlaveLocksClientTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/lock/SlaveLocksClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/lock/SlaveStatementLocksFactoryIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/lock/SlaveStatementLocksFactoryIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/lock/SlaveStatementLocksFactoryTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/lock/SlaveStatementLocksFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/lock/SlaveStatementLocksTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/lock/SlaveStatementLocksTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/lock/trace/LockRecord.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/lock/trace/LockRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/lock/trace/RecordingLockTracer.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/lock/trace/RecordingLockTracer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/lock/trace/TestLocksTracerFactory.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/lock/trace/TestLocksTracerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/management/HighAvailabilityBeanTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/management/HighAvailabilityBeanTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/transaction/TransactionPropagatorTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/transaction/TransactionPropagatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/transaction/TransactionThroughMasterSwitchStressIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/transaction/TransactionThroughMasterSwitchStressIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/impl/ha/ClusterManager.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/impl/ha/ClusterManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/impl/ha/ParallelLifecycle.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/impl/ha/ParallelLifecycle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/index/AutoIndexConfigIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/index/AutoIndexConfigIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/index/IndexOperationsIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/index/IndexOperationsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/internal/HaKernelDataIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/internal/HaKernelDataIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/test/ConstantRequestContextFactory.java
+++ b/enterprise/ha/src/test/java/org/neo4j/test/ConstantRequestContextFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/test/IntegerResponse.java
+++ b/enterprise/ha/src/test/java/org/neo4j/test/IntegerResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/test/LongResponse.java
+++ b/enterprise/ha/src/test/java/org/neo4j/test/LongResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/test/ManagedResource.java
+++ b/enterprise/ha/src/test/java/org/neo4j/test/ManagedResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/test/ha/ClusterIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/test/ha/ClusterIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/test/ha/ClusterMembersSnapshotTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/test/ha/ClusterMembersSnapshotTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/test/ha/ClusterRule.java
+++ b/enterprise/ha/src/test/java/org/neo4j/test/ha/ClusterRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/org/neo4j/test/ha/ReadOnlySlaveIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/test/ha/ReadOnlySlaveIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/ha/src/test/java/slavetest/InstanceJoinIT.java
+++ b/enterprise/ha/src/test/java/slavetest/InstanceJoinIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/NOTICE.txt
+++ b/enterprise/kernel/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/enterprise/kernel/src/main/java/org/neo4j/graphdb/factory/EnterpriseGraphDatabaseFactory.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/graphdb/factory/EnterpriseGraphDatabaseFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/EnterpriseGraphDatabase.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/EnterpriseGraphDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/api/security/EnterpriseAuthManager.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/api/security/EnterpriseAuthManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/api/security/EnterpriseLoginContext.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/api/security/EnterpriseLoginContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/api/security/EnterpriseSecurityContext.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/api/security/EnterpriseSecurityContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/ActiveLocksResult.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/ActiveLocksResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/EnterpriseBuiltInDbmsProcedures.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/EnterpriseBuiltInDbmsProcedures.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/ProceduresTimeFormatHelper.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/ProceduresTimeFormatHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/QueryId.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/QueryId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/QueryStatusResult.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/QueryStatusResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/TransactionDependenciesResolver.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/TransactionDependenciesResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/TransactionStatusResult.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/TransactionStatusResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/EnterpriseConstraintSemantics.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/EnterpriseConstraintSemantics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/EnterpriseEditionModule.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/EnterpriseEditionModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/PropertyExistenceEnforcer.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/PropertyExistenceEnforcer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/StandardBoltConnectionTracker.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/StandardBoltConnectionTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/configuration/EnterpriseEditionSettings.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/configuration/EnterpriseEditionSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/configuration/OnlineBackupSettings.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/configuration/OnlineBackupSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/id/EnterpriseIdTypeConfigurationProvider.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/id/EnterpriseIdTypeConfigurationProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/lock/forseti/DeadlockStrategies.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/lock/forseti/DeadlockStrategies.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/lock/forseti/ExclusiveLock.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/lock/forseti/ExclusiveLock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/lock/forseti/ForsetiClient.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/lock/forseti/ForsetiClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/lock/forseti/ForsetiLockManager.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/lock/forseti/ForsetiLockManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/lock/forseti/ForsetiLocksFactory.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/lock/forseti/ForsetiLocksFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/lock/forseti/SharedLock.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/lock/forseti/SharedLock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/transaction/log/checkpoint/ConfigurableIOLimiter.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/transaction/log/checkpoint/ConfigurableIOLimiter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/transaction/log/checkpoint/ContinuousCheckPointThreshold.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/transaction/log/checkpoint/ContinuousCheckPointThreshold.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/transaction/log/checkpoint/ContinuousThresholdPolicy.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/transaction/log/checkpoint/ContinuousThresholdPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/transaction/log/checkpoint/VolumetricCheckPointPolicy.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/transaction/log/checkpoint/VolumetricCheckPointPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/transaction/log/checkpoint/VolumetricCheckPointThreshold.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/transaction/log/checkpoint/VolumetricCheckPointThreshold.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/PageCacheWarmer.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/PageCacheWarmer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/PageCacheWarmerKernelExtension.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/PageCacheWarmerKernelExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/PageCacheWarmerKernelExtensionFactory.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/PageCacheWarmerKernelExtensionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/PageCacheWarmerMonitor.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/PageCacheWarmerMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/PageLoader.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/PageLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/PageLoaderFactory.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/PageLoaderFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/ParallelPageLoader.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/ParallelPageLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/Profile.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/Profile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/ProfileRefCounts.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/ProfileRefCounts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/SingleCursorPageLoader.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/SingleCursorPageLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/WarmupAvailabilityListener.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/WarmupAvailabilityListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/BaseHighLimitRecordFormat.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/BaseHighLimitRecordFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/DynamicRecordFormat.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/DynamicRecordFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/HighLimit.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/HighLimit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/HighLimitFactory.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/HighLimitFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/HighLimitFormatFamily.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/HighLimitFormatFamily.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/HighLimitFormatSettings.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/HighLimitFormatSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/NodeRecordFormat.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/NodeRecordFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/PropertyRecordFormat.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/PropertyRecordFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/Reference.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/Reference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/RelationshipGroupRecordFormat.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/RelationshipGroupRecordFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/RelationshipRecordFormat.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/RelationshipRecordFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v300/BaseHighLimitRecordFormatV3_0_0.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v300/BaseHighLimitRecordFormatV3_0_0.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v300/HighLimitFactoryV3_0_0.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v300/HighLimitFactoryV3_0_0.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v300/HighLimitV3_0_0.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v300/HighLimitV3_0_0.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v300/NodeRecordFormatV3_0_0.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v300/NodeRecordFormatV3_0_0.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v300/PropertyRecordFormatV3_0_0.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v300/PropertyRecordFormatV3_0_0.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v300/RelationshipGroupRecordFormatV3_0_0.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v300/RelationshipGroupRecordFormatV3_0_0.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v300/RelationshipRecordFormatV3_0_0.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v300/RelationshipRecordFormatV3_0_0.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v306/BaseHighLimitRecordFormatV3_0_6.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v306/BaseHighLimitRecordFormatV3_0_6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v306/HighLimitFactoryV3_0_6.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v306/HighLimitFactoryV3_0_6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v306/HighLimitV3_0_6.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v306/HighLimitV3_0_6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v306/NodeRecordFormatV3_0_6.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v306/NodeRecordFormatV3_0_6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v306/PropertyRecordFormatV3_0_6.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v306/PropertyRecordFormatV3_0_6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v306/RelationshipGroupRecordFormatV3_0_6.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v306/RelationshipGroupRecordFormatV3_0_6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v306/RelationshipRecordFormatV3_0_6.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v306/RelationshipRecordFormatV3_0_6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v310/BaseHighLimitRecordFormatV3_1_0.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v310/BaseHighLimitRecordFormatV3_1_0.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v310/HighLimitFactoryV3_1_0.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v310/HighLimitFactoryV3_1_0.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v310/HighLimitV3_1_0.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v310/HighLimitV3_1_0.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v310/NodeRecordFormatV3_1_0.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v310/NodeRecordFormatV3_1_0.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v310/PropertyRecordFormatV3_1_0.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v310/PropertyRecordFormatV3_1_0.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v310/RelationshipGroupRecordFormatV3_1_0.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v310/RelationshipGroupRecordFormatV3_1_0.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v310/RelationshipRecordFormatV3_1_0.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v310/RelationshipRecordFormatV3_1_0.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v320/BaseHighLimitRecordFormatV3_2_0.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v320/BaseHighLimitRecordFormatV3_2_0.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v320/HighLimitFactoryV3_2_0.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v320/HighLimitFactoryV3_2_0.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v320/HighLimitFormatSettingsV3_2_0.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v320/HighLimitFormatSettingsV3_2_0.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v320/HighLimitV3_2_0.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v320/HighLimitV3_2_0.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v320/NodeRecordFormatV3_2_0.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v320/NodeRecordFormatV3_2_0.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v320/PropertyRecordFormatV3_2_0.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v320/PropertyRecordFormatV3_2_0.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v320/RelationshipGroupRecordFormatV3_2_0.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v320/RelationshipGroupRecordFormatV3_2_0.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v320/RelationshipRecordFormatV3_2_0.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v320/RelationshipRecordFormatV3_2_0.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/monitoring/tracing/VerbosePageCacheTracer.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/monitoring/tracing/VerbosePageCacheTracer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/monitoring/tracing/VerboseTracerFactory.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/monitoring/tracing/VerboseTracerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/test/java/org/neo4j/SchemaHelper.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/SchemaHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/test/java/org/neo4j/graphdb/SchemaWithPECAcceptanceTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/graphdb/SchemaWithPECAcceptanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/test/java/org/neo4j/graphdb/StartupConstraintSemanticsTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/graphdb/StartupConstraintSemanticsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/test/java/org/neo4j/graphdb/store/id/IdReuseTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/graphdb/store/id/IdReuseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/test/java/org/neo4j/graphdb/store/id/RelationshipIdReuseStressIT.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/graphdb/store/id/RelationshipIdReuseStressIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/enterprise/builtinprocs/ListQueriesProcedureTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/enterprise/builtinprocs/ListQueriesProcedureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/enterprise/builtinprocs/QueryIdTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/enterprise/builtinprocs/QueryIdTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/enterprise/builtinprocs/SetConfigValueProcedureTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/enterprise/builtinprocs/SetConfigValueProcedureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/enterprise/builtinprocs/StubKernelTransaction.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/enterprise/builtinprocs/StubKernelTransaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/enterprise/builtinprocs/TransactionDependenciesResolverTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/enterprise/builtinprocs/TransactionDependenciesResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/enterprise/builtinprocs/TransactionStatusResultTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/enterprise/builtinprocs/TransactionStatusResultTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionTimeoutMonitorWithForsetiIT.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionTimeoutMonitorWithForsetiIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/AbstractConstraintCreationIT.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/AbstractConstraintCreationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/NodeKeyConstraintCreationIT.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/NodeKeyConstraintCreationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/NodePropertyExistenceConstraintCreationIT.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/NodePropertyExistenceConstraintCreationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/PropertyConstraintValidationIT.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/PropertyConstraintValidationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/PropertyExistenceConstraintVerificationIT.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/PropertyExistenceConstraintVerificationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/RelationshipPropertyExistenceConstraintCreationIT.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/RelationshipPropertyExistenceConstraintCreationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/UniquenessConstraintCreationIT.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/UniquenessConstraintCreationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StorageLayerSchemaWithPECTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StorageLayerSchemaWithPECTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/enterprise/EnterpriseEditionModuleTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/enterprise/EnterpriseEditionModuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/enterprise/PropertyExistenceEnforcerTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/enterprise/PropertyExistenceEnforcerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/enterprise/StandardBoltConnectionTrackerTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/enterprise/StandardBoltConnectionTrackerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/enterprise/configuration/EnterpriseEditionSettingsTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/enterprise/configuration/EnterpriseEditionSettingsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/enterprise/id/EnterpriseIdTypeConfigurationProviderTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/enterprise/id/EnterpriseIdTypeConfigurationProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/enterprise/lock/forseti/ForsetiFalseDeadlockTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/enterprise/lock/forseti/ForsetiFalseDeadlockTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/enterprise/lock/forseti/ForsetiLocksTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/enterprise/lock/forseti/ForsetiLocksTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/enterprise/lock/forseti/ForsetiServiceLoadingTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/enterprise/lock/forseti/ForsetiServiceLoadingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/enterprise/lock/forseti/SharedLockTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/enterprise/lock/forseti/SharedLockTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/enterprise/store/id/NodeIdReuseStressIT.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/enterprise/store/id/NodeIdReuseStressIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/enterprise/transaction/log/checkpoint/ConfigurableIOLimiterTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/enterprise/transaction/log/checkpoint/ConfigurableIOLimiterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/enterprise/transaction/log/checkpoint/EnterpriseCheckPointThresholdTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/enterprise/transaction/log/checkpoint/EnterpriseCheckPointThresholdTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/newapi/EnterpriseWriteTestSupport.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/newapi/EnterpriseWriteTestSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/newapi/SchemaReadWriteTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/newapi/SchemaReadWriteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/pagecache/PageCacheWarmerTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/pagecache/PageCacheWarmerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/RecordFormatSelectorTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/RecordFormatSelectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/BaseHighLimitRecordFormatTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/BaseHighLimitRecordFormatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/ConstantIdSequence.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/ConstantIdSequence.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/FixedLinkedStubPageCursor.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/FixedLinkedStubPageCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/HighLimitRecordFormatTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/HighLimitRecordFormatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/HighLimitStoreMigrationTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/HighLimitStoreMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/NodeRecordFormatTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/NodeRecordFormatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/PropertyRecordFormatTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/PropertyRecordFormatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/ReferenceTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/ReferenceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/RelationshipGroupRecordFormatTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/RelationshipGroupRecordFormatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/RelationshipRecordFormatTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/RelationshipRecordFormatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/RelationshipTypeTokenRecordFormatTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/RelationshipTypeTokenRecordFormatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/v30/HighLimitV3_0RecordFormatTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/v30/HighLimitV3_0RecordFormatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/StoreMigrationIT.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/StoreMigrationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/UpgradableDatabaseTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/UpgradableDatabaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/participant/StoreMigratorTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/participant/StoreMigratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/monitoring/tracing/VerbosePageCacheTracerTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/monitoring/tracing/VerbosePageCacheTracerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/monitoring/tracing/VerboseTracerFactoryTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/monitoring/tracing/VerboseTracerFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/test/java/org/neo4j/locking/MergeLockConcurrencyTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/locking/MergeLockConcurrencyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/test/java/org/neo4j/shell/EnterpriseVersionTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/shell/EnterpriseVersionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/test/java/org/neo4j/shell/PECListingIT.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/shell/PECListingIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/test/java/org/neo4j/test/TestEnterpriseGraphDatabaseFactory.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/test/TestEnterpriseGraphDatabaseFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/test/java/org/neo4j/test/rule/EnterpriseDatabaseRule.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/test/rule/EnterpriseDatabaseRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/test/java/org/neo4j/test/rule/ImpermanentEnterpriseDatabaseRule.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/test/rule/ImpermanentEnterpriseDatabaseRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/test/java/org/neo4j/util/TestHelpers.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/util/TestHelpers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/test/scala/org/neo4j/cypher/EnterpriseGraphDatabaseTestSupport.scala
+++ b/enterprise/kernel/src/test/scala/org/neo4j/cypher/EnterpriseGraphDatabaseTestSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/test/scala/org/neo4j/cypher/ExecutionResultStatisticsTest.scala
+++ b/enterprise/kernel/src/test/scala/org/neo4j/cypher/ExecutionResultStatisticsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/kernel/src/test/scala/org/neo4j/internal/cypher/acceptance/PropertyExistenceConstraintAcceptanceTest.scala
+++ b/enterprise/kernel/src/test/scala/org/neo4j/internal/cypher/acceptance/PropertyExistenceConstraintAcceptanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/management/NOTICE.txt
+++ b/enterprise/management/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/enterprise/management/src/main/java/org/neo4j/management/BranchedStore.java
+++ b/enterprise/management/src/main/java/org/neo4j/management/BranchedStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/management/src/main/java/org/neo4j/management/BranchedStoreInfo.java
+++ b/enterprise/management/src/main/java/org/neo4j/management/BranchedStoreInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/management/src/main/java/org/neo4j/management/CausalClustering.java
+++ b/enterprise/management/src/main/java/org/neo4j/management/CausalClustering.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/management/src/main/java/org/neo4j/management/ClusterDatabaseInfo.java
+++ b/enterprise/management/src/main/java/org/neo4j/management/ClusterDatabaseInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/management/src/main/java/org/neo4j/management/ClusterMemberInfo.java
+++ b/enterprise/management/src/main/java/org/neo4j/management/ClusterMemberInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/management/src/main/java/org/neo4j/management/Diagnostics.java
+++ b/enterprise/management/src/main/java/org/neo4j/management/Diagnostics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/management/src/main/java/org/neo4j/management/HighAvailability.java
+++ b/enterprise/management/src/main/java/org/neo4j/management/HighAvailability.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/management/src/main/java/org/neo4j/management/IndexSamplingManager.java
+++ b/enterprise/management/src/main/java/org/neo4j/management/IndexSamplingManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/management/src/main/java/org/neo4j/management/LockManager.java
+++ b/enterprise/management/src/main/java/org/neo4j/management/LockManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/management/src/main/java/org/neo4j/management/MemoryMapping.java
+++ b/enterprise/management/src/main/java/org/neo4j/management/MemoryMapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/management/src/main/java/org/neo4j/management/Neo4jManager.java
+++ b/enterprise/management/src/main/java/org/neo4j/management/Neo4jManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/management/src/main/java/org/neo4j/management/PageCache.java
+++ b/enterprise/management/src/main/java/org/neo4j/management/PageCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/management/src/main/java/org/neo4j/management/RemoteConnection.java
+++ b/enterprise/management/src/main/java/org/neo4j/management/RemoteConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/management/src/main/java/org/neo4j/management/TransactionManager.java
+++ b/enterprise/management/src/main/java/org/neo4j/management/TransactionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/management/src/main/java/org/neo4j/management/WindowPoolInfo.java
+++ b/enterprise/management/src/main/java/org/neo4j/management/WindowPoolInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/management/src/main/java/org/neo4j/management/impl/AdvancedManagementSupport.java
+++ b/enterprise/management/src/main/java/org/neo4j/management/impl/AdvancedManagementSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/management/src/main/java/org/neo4j/management/impl/BeanProxy.java
+++ b/enterprise/management/src/main/java/org/neo4j/management/impl/BeanProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/management/src/main/java/org/neo4j/management/impl/DiagnosticsBean.java
+++ b/enterprise/management/src/main/java/org/neo4j/management/impl/DiagnosticsBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/management/src/main/java/org/neo4j/management/impl/HotspotManagementSupport.java
+++ b/enterprise/management/src/main/java/org/neo4j/management/impl/HotspotManagementSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/management/src/main/java/org/neo4j/management/impl/IndexSamplingManagerBean.java
+++ b/enterprise/management/src/main/java/org/neo4j/management/impl/IndexSamplingManagerBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/management/src/main/java/org/neo4j/management/impl/KernelProxy.java
+++ b/enterprise/management/src/main/java/org/neo4j/management/impl/KernelProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/management/src/main/java/org/neo4j/management/impl/LockManagerBean.java
+++ b/enterprise/management/src/main/java/org/neo4j/management/impl/LockManagerBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/management/src/main/java/org/neo4j/management/impl/MemoryMappingBean.java
+++ b/enterprise/management/src/main/java/org/neo4j/management/impl/MemoryMappingBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/management/src/main/java/org/neo4j/management/impl/PageCacheBean.java
+++ b/enterprise/management/src/main/java/org/neo4j/management/impl/PageCacheBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/management/src/main/java/org/neo4j/management/impl/TransactionManagerBean.java
+++ b/enterprise/management/src/main/java/org/neo4j/management/impl/TransactionManagerBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/management/src/main/java/org/neo4j/management/package-info.java
+++ b/enterprise/management/src/main/java/org/neo4j/management/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/management/src/test/java/org/neo4j/management/ManagementBeansTest.java
+++ b/enterprise/management/src/test/java/org/neo4j/management/ManagementBeansTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/management/src/test/java/org/neo4j/management/TestLockManagerBean.java
+++ b/enterprise/management/src/test/java/org/neo4j/management/TestLockManagerBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/management/src/test/java/org/neo4j/management/impl/CodeDuplicationValidationTest.java
+++ b/enterprise/management/src/test/java/org/neo4j/management/impl/CodeDuplicationValidationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/management/src/test/java/org/neo4j/management/impl/IndexSamplingManagerBeanTest.java
+++ b/enterprise/management/src/test/java/org/neo4j/management/impl/IndexSamplingManagerBeanTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/metrics/NOTICE.txt
+++ b/enterprise/metrics/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/MetricsExtension.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/MetricsExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/MetricsKernelExtensionFactory.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/MetricsKernelExtensionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/MetricsSettings.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/MetricsSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/diagnostics/MetricsDiagnosticsOfflineReportProvider.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/diagnostics/MetricsDiagnosticsOfflineReportProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/output/CompositeEventReporter.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/output/CompositeEventReporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/output/CsvOutput.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/output/CsvOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/output/EventReporter.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/output/EventReporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/output/EventReporterBuilder.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/output/EventReporterBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/output/GraphiteOutput.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/output/GraphiteOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/output/PrometheusOutput.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/output/PrometheusOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/output/RotatableCsvReporter.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/output/RotatableCsvReporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/source/ByteCountsMetric.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/source/ByteCountsMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/source/Neo4jMetricsBuilder.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/source/Neo4jMetricsBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/source/causalclustering/CatchUpMetrics.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/source/causalclustering/CatchUpMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/source/causalclustering/CoreMetrics.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/source/causalclustering/CoreMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/source/causalclustering/InFlightCacheMetric.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/source/causalclustering/InFlightCacheMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/source/causalclustering/LeaderNotFoundMetric.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/source/causalclustering/LeaderNotFoundMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/source/causalclustering/PullRequestMetric.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/source/causalclustering/PullRequestMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/source/causalclustering/RaftLogAppendIndexMetric.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/source/causalclustering/RaftLogAppendIndexMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/source/causalclustering/RaftLogCommitIndexMetric.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/source/causalclustering/RaftLogCommitIndexMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/source/causalclustering/RaftMessageProcessingMetric.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/source/causalclustering/RaftMessageProcessingMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/source/causalclustering/RaftTermMetric.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/source/causalclustering/RaftTermMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/source/causalclustering/ReadReplicaMetrics.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/source/causalclustering/ReadReplicaMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/source/causalclustering/TxPullRequestsMetric.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/source/causalclustering/TxPullRequestsMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/source/causalclustering/TxRetryMetric.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/source/causalclustering/TxRetryMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/source/cluster/ClusterMetrics.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/source/cluster/ClusterMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/source/cluster/NetworkMetrics.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/source/cluster/NetworkMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/source/db/BoltMetrics.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/source/db/BoltMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/source/db/CheckPointingMetrics.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/source/db/CheckPointingMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/source/db/CypherMetrics.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/source/db/CypherMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/source/db/EntityCountMetrics.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/source/db/EntityCountMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/source/db/LogRotationMetrics.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/source/db/LogRotationMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/source/db/PageCacheMetrics.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/source/db/PageCacheMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/source/db/TransactionMetrics.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/source/db/TransactionMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/source/jvm/GCMetrics.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/source/jvm/GCMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/source/jvm/JvmMetrics.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/source/jvm/JvmMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/source/jvm/MemoryBuffersMetrics.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/source/jvm/MemoryBuffersMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/source/jvm/MemoryPoolMetrics.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/source/jvm/MemoryPoolMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/source/jvm/ThreadMetrics.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/source/jvm/ThreadMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/source/server/ServerMetrics.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/source/server/ServerMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/source/server/ServerThreadView.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/source/server/ServerThreadView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/source/server/ServerThreadViewSetter.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/source/server/ServerThreadViewSetter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/metrics/src/test/java/org/neo4j/metrics/BoltMetricsIT.java
+++ b/enterprise/metrics/src/test/java/org/neo4j/metrics/BoltMetricsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/metrics/src/test/java/org/neo4j/metrics/CoreEdgeMetricsIT.java
+++ b/enterprise/metrics/src/test/java/org/neo4j/metrics/CoreEdgeMetricsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/metrics/src/test/java/org/neo4j/metrics/MetricsKernelExtensionFactoryIT.java
+++ b/enterprise/metrics/src/test/java/org/neo4j/metrics/MetricsKernelExtensionFactoryIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/metrics/src/test/java/org/neo4j/metrics/MetricsTestHelper.java
+++ b/enterprise/metrics/src/test/java/org/neo4j/metrics/MetricsTestHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/metrics/src/test/java/org/neo4j/metrics/PageCacheMetricsIT.java
+++ b/enterprise/metrics/src/test/java/org/neo4j/metrics/PageCacheMetricsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/metrics/src/test/java/org/neo4j/metrics/RaftMessageProcessingMetricIT.java
+++ b/enterprise/metrics/src/test/java/org/neo4j/metrics/RaftMessageProcessingMetricIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/metrics/src/test/java/org/neo4j/metrics/output/CsvOutputTest.java
+++ b/enterprise/metrics/src/test/java/org/neo4j/metrics/output/CsvOutputTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/metrics/src/test/java/org/neo4j/metrics/output/PrometheusOutputIT.java
+++ b/enterprise/metrics/src/test/java/org/neo4j/metrics/output/PrometheusOutputIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/metrics/src/test/java/org/neo4j/metrics/output/PrometheusOutputTest.java
+++ b/enterprise/metrics/src/test/java/org/neo4j/metrics/output/PrometheusOutputTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/metrics/src/test/java/org/neo4j/metrics/output/RotatableCsvOutputIT.java
+++ b/enterprise/metrics/src/test/java/org/neo4j/metrics/output/RotatableCsvOutputIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/metrics/src/test/java/org/neo4j/metrics/output/RotatableCsvReporterTest.java
+++ b/enterprise/metrics/src/test/java/org/neo4j/metrics/output/RotatableCsvReporterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/metrics/src/test/java/org/neo4j/metrics/source/ClusterMetricsTest.java
+++ b/enterprise/metrics/src/test/java/org/neo4j/metrics/source/ClusterMetricsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/metrics/src/test/java/org/neo4j/metrics/source/causalclustering/RaftMessageProcessingMetricTest.java
+++ b/enterprise/metrics/src/test/java/org/neo4j/metrics/source/causalclustering/RaftMessageProcessingMetricTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/neo4j-enterprise/NOTICE.txt
+++ b/enterprise/neo4j-enterprise/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/enterprise/neo4j-enterprise/src/test/java/batchimport/HighLimitParallelBatchImporterIT.java
+++ b/enterprise/neo4j-enterprise/src/test/java/batchimport/HighLimitParallelBatchImporterIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/neo4j-enterprise/src/test/java/org/neo4j/CompositeConstraintIT.java
+++ b/enterprise/neo4j-enterprise/src/test/java/org/neo4j/CompositeConstraintIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/neo4j-enterprise/src/test/java/org/neo4j/HalfAppliedConstraintRecoveryIT.java
+++ b/enterprise/neo4j-enterprise/src/test/java/org/neo4j/HalfAppliedConstraintRecoveryIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/neo4j-enterprise/src/test/java/org/neo4j/RecordFormatsGenerationTest.java
+++ b/enterprise/neo4j-enterprise/src/test/java/org/neo4j/RecordFormatsGenerationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/neo4j-enterprise/src/test/java/org/neo4j/commandline/dbms/StoreInfoCommandEnterpriseTest.java
+++ b/enterprise/neo4j-enterprise/src/test/java/org/neo4j/commandline/dbms/StoreInfoCommandEnterpriseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/neo4j-enterprise/src/test/java/org/neo4j/consistency/ConsistencyCheckServiceRecordFormatIT.java
+++ b/enterprise/neo4j-enterprise/src/test/java/org/neo4j/consistency/ConsistencyCheckServiceRecordFormatIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/neo4j-enterprise/src/test/java/org/neo4j/consistency/HighLimitConsistencyCheckServiceIT.java
+++ b/enterprise/neo4j-enterprise/src/test/java/org/neo4j/consistency/HighLimitConsistencyCheckServiceIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/neo4j-enterprise/src/test/java/org/neo4j/consistency/HighLimitDetectAllRelationshipInconsistenciesIT.java
+++ b/enterprise/neo4j-enterprise/src/test/java/org/neo4j/consistency/HighLimitDetectAllRelationshipInconsistenciesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/neo4j-enterprise/src/test/java/org/neo4j/consistency/HighLimitExecutionOrderIT.java
+++ b/enterprise/neo4j-enterprise/src/test/java/org/neo4j/consistency/HighLimitExecutionOrderIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/neo4j-enterprise/src/test/java/org/neo4j/consistency/HighLimitFullCheckIT.java
+++ b/enterprise/neo4j-enterprise/src/test/java/org/neo4j/consistency/HighLimitFullCheckIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/neo4j-enterprise/src/test/java/org/neo4j/consistency/HighLimitRelationshipChainExplorerIT.java
+++ b/enterprise/neo4j-enterprise/src/test/java/org/neo4j/consistency/HighLimitRelationshipChainExplorerIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/neo4j-enterprise/src/test/java/org/neo4j/index/StartOnExistingDbWithIndexIT.java
+++ b/enterprise/neo4j-enterprise/src/test/java/org/neo4j/index/StartOnExistingDbWithIndexIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/neo4j-enterprise/src/test/java/org/neo4j/kernel/builtinprocs/ProcedureResourcesIT.java
+++ b/enterprise/neo4j-enterprise/src/test/java/org/neo4j/kernel/builtinprocs/ProcedureResourcesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/neo4j-enterprise/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/HighLimitWithSmallRecords.java
+++ b/enterprise/neo4j-enterprise/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/HighLimitWithSmallRecords.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/neo4j-enterprise/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/HighLimitWithSmallRecordsFactory.java
+++ b/enterprise/neo4j-enterprise/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/HighLimitWithSmallRecordsFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/neo4j-enterprise/src/test/java/org/neo4j/lock/EnterpriseLockAcquisitionTimeoutIT.java
+++ b/enterprise/neo4j-enterprise/src/test/java/org/neo4j/lock/EnterpriseLockAcquisitionTimeoutIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/neo4j-enterprise/src/test/java/org/neo4j/unsafe/batchinsert/BatchInsertEnterpriseIT.java
+++ b/enterprise/neo4j-enterprise/src/test/java/org/neo4j/unsafe/batchinsert/BatchInsertEnterpriseIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/neo4j-enterprise/src/test/java/org/neo4j/unsafe/impl/batchimport/store/BatchingNeoStoresIT.java
+++ b/enterprise/neo4j-enterprise/src/test/java/org/neo4j/unsafe/impl/batchimport/store/BatchingNeoStoresIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/neo4j-enterprise/src/test/java/org/neo4j/upgrade/EnterpriseStoreUpgraderTest.java
+++ b/enterprise/neo4j-enterprise/src/test/java/org/neo4j/upgrade/EnterpriseStoreUpgraderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/neo4j-enterprise/src/test/java/org/neo4j/upgrade/RecordFormatsMigrationIT.java
+++ b/enterprise/neo4j-enterprise/src/test/java/org/neo4j/upgrade/RecordFormatsMigrationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/neo4j-enterprise/src/test/java/org/neo4j/upgrade/StandardToEnterpriseStoreUpgraderTest.java
+++ b/enterprise/neo4j-enterprise/src/test/java/org/neo4j/upgrade/StandardToEnterpriseStoreUpgraderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/neo4j-harness-enterprise/NOTICE.txt
+++ b/enterprise/neo4j-harness-enterprise/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/enterprise/neo4j-harness-enterprise/src/main/java/org/neo4j/harness/CausalClusterInProcessBuilder.java
+++ b/enterprise/neo4j-harness-enterprise/src/main/java/org/neo4j/harness/CausalClusterInProcessBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/neo4j-harness-enterprise/src/main/java/org/neo4j/harness/CausalClusterInProcessRunner.java
+++ b/enterprise/neo4j-harness-enterprise/src/main/java/org/neo4j/harness/CausalClusterInProcessRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/neo4j-harness-enterprise/src/main/java/org/neo4j/harness/ClusterOfClustersInProcessRunner.java
+++ b/enterprise/neo4j-harness-enterprise/src/main/java/org/neo4j/harness/ClusterOfClustersInProcessRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/neo4j-harness-enterprise/src/main/java/org/neo4j/harness/EnterpriseTestServerBuilders.java
+++ b/enterprise/neo4j-harness-enterprise/src/main/java/org/neo4j/harness/EnterpriseTestServerBuilders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/neo4j-harness-enterprise/src/main/java/org/neo4j/harness/internal/EnterpriseInProcessServerBuilder.java
+++ b/enterprise/neo4j-harness-enterprise/src/main/java/org/neo4j/harness/internal/EnterpriseInProcessServerBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/neo4j-harness-enterprise/src/main/java/org/neo4j/harness/junit/EnterpriseNeo4jRule.java
+++ b/enterprise/neo4j-harness-enterprise/src/main/java/org/neo4j/harness/junit/EnterpriseNeo4jRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/neo4j-harness-enterprise/src/test/java/org/neo4j/harness/CausalClusterInProcessRunnerIT.java
+++ b/enterprise/neo4j-harness-enterprise/src/test/java/org/neo4j/harness/CausalClusterInProcessRunnerIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/neo4j-harness-enterprise/src/test/java/org/neo4j/harness/extensionpackage/MyEnterpriseUnmanagedExtension.java
+++ b/enterprise/neo4j-harness-enterprise/src/test/java/org/neo4j/harness/extensionpackage/MyEnterpriseUnmanagedExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/neo4j-harness-enterprise/src/test/java/org/neo4j/harness/internal/EnterpriseInProcessServerBuilderIT.java
+++ b/enterprise/neo4j-harness-enterprise/src/test/java/org/neo4j/harness/internal/EnterpriseInProcessServerBuilderIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/neo4j-harness-enterprise/src/test/java/org/neo4j/harness/junit/EnterpriseNeo4jRuleTest.java
+++ b/enterprise/neo4j-harness-enterprise/src/test/java/org/neo4j/harness/junit/EnterpriseNeo4jRuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/procedure-compiler-enterprise-tests/NOTICE.txt
+++ b/enterprise/procedure-compiler-enterprise-tests/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/enterprise/procedure-compiler-enterprise-tests/src/test/java/org/neo4j/tooling/procedure/EnterpriseTest.java
+++ b/enterprise/procedure-compiler-enterprise-tests/src/test/java/org/neo4j/tooling/procedure/EnterpriseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/procedure-compiler-enterprise-tests/src/test/java/org/neo4j/tooling/procedure/procedures/context/restricted_types/EnterpriseProcedure.java
+++ b/enterprise/procedure-compiler-enterprise-tests/src/test/java/org/neo4j/tooling/procedure/procedures/context/restricted_types/EnterpriseProcedure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/query-logging/NOTICE.txt
+++ b/enterprise/query-logging/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/enterprise/query-logging/src/main/java/org/neo4j/kernel/impl/query/ConfiguredQueryLogger.java
+++ b/enterprise/query-logging/src/main/java/org/neo4j/kernel/impl/query/ConfiguredQueryLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/query-logging/src/main/java/org/neo4j/kernel/impl/query/DynamicLoggingQueryExecutionMonitor.java
+++ b/enterprise/query-logging/src/main/java/org/neo4j/kernel/impl/query/DynamicLoggingQueryExecutionMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/query-logging/src/main/java/org/neo4j/kernel/impl/query/QueryLogFormatter.java
+++ b/enterprise/query-logging/src/main/java/org/neo4j/kernel/impl/query/QueryLogFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/query-logging/src/main/java/org/neo4j/kernel/impl/query/QueryLogger.java
+++ b/enterprise/query-logging/src/main/java/org/neo4j/kernel/impl/query/QueryLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/query-logging/src/main/java/org/neo4j/kernel/impl/query/QueryLoggerDiagnosticsOfflineReportProvider.java
+++ b/enterprise/query-logging/src/main/java/org/neo4j/kernel/impl/query/QueryLoggerDiagnosticsOfflineReportProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/query-logging/src/main/java/org/neo4j/kernel/impl/query/QueryLoggerKernelExtension.java
+++ b/enterprise/query-logging/src/main/java/org/neo4j/kernel/impl/query/QueryLoggerKernelExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/query-logging/src/test/java/org/neo4j/kernel/impl/query/ConfiguredQueryLoggerTest.java
+++ b/enterprise/query-logging/src/test/java/org/neo4j/kernel/impl/query/ConfiguredQueryLoggerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/query-logging/src/test/java/org/neo4j/kernel/impl/query/QueryLoggerIT.java
+++ b/enterprise/query-logging/src/test/java/org/neo4j/kernel/impl/query/QueryLoggerIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/query-logging/src/test/java/org/neo4j/kernel/impl/query/ShellQueryLoggingIT.java
+++ b/enterprise/query-logging/src/test/java/org/neo4j/kernel/impl/query/ShellQueryLoggingIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/NOTICE.txt
+++ b/enterprise/security/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/AbstractRoleRepository.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/AbstractRoleRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/AuthProceduresBase.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/AuthProceduresBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/EnterpriseAuthAndUserManager.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/EnterpriseAuthAndUserManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/EnterpriseSecurityModule.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/EnterpriseSecurityModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/EnterpriseUserManager.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/EnterpriseUserManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/FileRoleRepository.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/FileRoleRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/InternalFlatFileRealm.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/InternalFlatFileRealm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/LdapRealm.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/LdapRealm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/MultiRealmAuthManager.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/MultiRealmAuthManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/PersonalUserManager.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/PersonalUserManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/PredefinedRolesBuilder.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/PredefinedRolesBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/RealmLifecycle.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/RealmLifecycle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/RoleRecord.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/RoleRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/RoleRepository.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/RoleRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/RoleSerialization.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/RoleSerialization.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/RolesBuilder.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/RolesBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/SecureHasher.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/SecureHasher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/SecurityProcedures.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/SecurityProcedures.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/ShiroAuthToken.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/ShiroAuthToken.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/ShiroAuthenticationInfo.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/ShiroAuthenticationInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/ShiroAuthenticationStrategy.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/ShiroAuthenticationStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/ShiroAuthorizationInfoProvider.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/ShiroAuthorizationInfoProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/ShiroCaffeineCache.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/ShiroCaffeineCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/ShiroSubject.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/ShiroSubject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/ShiroSubjectFactory.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/ShiroSubjectFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/StandardEnterpriseLoginContext.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/StandardEnterpriseLoginContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/UserManagementProcedures.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/UserManagementProcedures.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/CustomCredentialsMatcherSupplier.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/CustomCredentialsMatcherSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/PluginApiAuthToken.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/PluginApiAuthToken.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/PluginAuthInfo.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/PluginAuthInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/PluginAuthenticationInfo.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/PluginAuthenticationInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/PluginAuthorizationInfo.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/PluginAuthorizationInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/PluginRealm.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/PluginRealm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/PluginShiroAuthToken.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/PluginShiroAuthToken.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/configuration/SecuritySettings.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/configuration/SecuritySettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/diagnostics/SecurityLogDiagnosticsOfflineReportProvider.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/diagnostics/SecurityLogDiagnosticsOfflineReportProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/log/SecurityLog.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/log/SecurityLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/test/java/org/neo4j/kernel/impl/proc/ProcedureConfigTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/kernel/impl/proc/ProcedureConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/AuthProceduresInteractionTestBase.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/AuthProceduresInteractionTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/AuthScenariosInteractionTestBase.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/AuthScenariosInteractionTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/AuthTestUtil.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/AuthTestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/BoltAuthScenariosInteractionIT.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/BoltAuthScenariosInteractionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/BoltBuiltInProceduresInteractionIT.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/BoltBuiltInProceduresInteractionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/BoltConfiguredAuthScenariosInteractionIT.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/BoltConfiguredAuthScenariosInteractionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/BoltConfiguredProceduresIT.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/BoltConfiguredProceduresIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/BoltInteraction.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/BoltInteraction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/BoltUserManagementProceduresInteractionIT.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/BoltUserManagementProceduresInteractionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/BuiltInProceduresInteractionTestBase.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/BuiltInProceduresInteractionTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ConfiguredAuthScenariosInteractionTestBase.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ConfiguredAuthScenariosInteractionTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ConfiguredProceduresTestBase.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ConfiguredProceduresTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/EmbeddedAuthScenariosInteractionIT.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/EmbeddedAuthScenariosInteractionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/EmbeddedBuiltInProceduresInteractionIT.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/EmbeddedBuiltInProceduresInteractionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/EmbeddedConfiguredAuthScenariosInteractionIT.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/EmbeddedConfiguredAuthScenariosInteractionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/EmbeddedConfiguredProceduresIT.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/EmbeddedConfiguredProceduresIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/EmbeddedInteraction.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/EmbeddedInteraction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/EmbeddedUserManagementProceduresInteractionIT.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/EmbeddedUserManagementProceduresInteractionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/EnterpriseSecurityContextDescriptionTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/EnterpriseSecurityContextDescriptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/EnterpriseSecurityModuleTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/EnterpriseSecurityModuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/FileRoleRepositoryTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/FileRoleRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/InMemoryRoleRepository.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/InMemoryRoleRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/InternalFlatFileRealmIT.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/InternalFlatFileRealmIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/InternalFlatFileRealmTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/InternalFlatFileRealmTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/LdapCachingTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/LdapCachingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/LdapRealmTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/LdapRealmTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/MultiRealmAuthManagerRule.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/MultiRealmAuthManagerRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/MultiRealmAuthManagerTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/MultiRealmAuthManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/NeoInteractionLevel.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/NeoInteractionLevel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/PersonalUserManagerTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/PersonalUserManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ProcedureInteractionTestBase.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ProcedureInteractionTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/RoleSerializationTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/RoleSerializationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/SecurityProceduresTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/SecurityProceduresTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ShiroAuthTokenTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ShiroAuthTokenTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ShiroAuthenticationInfoTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ShiroAuthenticationInfoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ShiroCaffeineCacheTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ShiroCaffeineCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ThreadedTransaction.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ThreadedTransaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/UserManagementProceduresLoggingTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/UserManagementProceduresLoggingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/integration/bolt/ADAuthIT.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/integration/bolt/ADAuthIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/integration/bolt/ActiveDirectoryAuthenticationIT.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/integration/bolt/ActiveDirectoryAuthenticationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/integration/bolt/BoltConnectionManagementIT.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/integration/bolt/BoltConnectionManagementIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/integration/bolt/BoltInitChangePasswordTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/integration/bolt/BoltInitChangePasswordTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/integration/bolt/EnterpriseAuthenticationIT.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/integration/bolt/EnterpriseAuthenticationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/integration/bolt/EnterpriseAuthenticationTestBase.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/integration/bolt/EnterpriseAuthenticationTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/integration/bolt/LdapAuthIT.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/integration/bolt/LdapAuthIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/integration/bolt/LdapExamplePluginAuthenticationIT.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/integration/bolt/LdapExamplePluginAuthenticationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/integration/bolt/NativeAndCredentialsOnlyIT.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/integration/bolt/NativeAndCredentialsOnlyIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/integration/bolt/PluginAuthenticationIT.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/integration/bolt/PluginAuthenticationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/plugin/LdapGroupHasUsersAuthPlugin.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/plugin/LdapGroupHasUsersAuthPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/plugin/PluginAuthenticationInfoTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/plugin/PluginAuthenticationInfoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/plugin/PluginRealmTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/plugin/PluginRealmTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/plugin/PropertyLevelSecurityIT.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/plugin/PropertyLevelSecurityIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/plugin/TestAuthPlugin.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/plugin/TestAuthPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/plugin/TestAuthenticationPlugin.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/plugin/TestAuthenticationPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/plugin/TestAuthorizationPlugin.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/plugin/TestAuthorizationPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/plugin/TestCacheableAdminAuthPlugin.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/plugin/TestCacheableAdminAuthPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/plugin/TestCacheableAuthPlugin.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/plugin/TestCacheableAuthPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/plugin/TestCacheableAuthenticationPlugin.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/plugin/TestCacheableAuthenticationPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/plugin/TestCombinedAuthPlugin.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/plugin/TestCombinedAuthPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/plugin/TestCredentialsOnlyPlugin.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/plugin/TestCredentialsOnlyPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/plugin/TestCustomCacheableAuthenticationPlugin.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/plugin/TestCustomCacheableAuthenticationPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/plugin/TestCustomParametersAuthenticationPlugin.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/plugin/TestCustomParametersAuthenticationPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/log/SecurityLogTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/log/SecurityLogTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/server-enterprise/NOTICE.txt
+++ b/enterprise/server-enterprise/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/enterprise/server-enterprise/src/main/java/org/neo4j/server/enterprise/ArbiterBootstrapper.java
+++ b/enterprise/server-enterprise/src/main/java/org/neo4j/server/enterprise/ArbiterBootstrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/server-enterprise/src/main/java/org/neo4j/server/enterprise/ArbiterEntryPoint.java
+++ b/enterprise/server-enterprise/src/main/java/org/neo4j/server/enterprise/ArbiterEntryPoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/server-enterprise/src/main/java/org/neo4j/server/enterprise/EnterpriseBootstrapper.java
+++ b/enterprise/server-enterprise/src/main/java/org/neo4j/server/enterprise/EnterpriseBootstrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/server-enterprise/src/main/java/org/neo4j/server/enterprise/EnterpriseEntryPoint.java
+++ b/enterprise/server-enterprise/src/main/java/org/neo4j/server/enterprise/EnterpriseEntryPoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/server-enterprise/src/main/java/org/neo4j/server/enterprise/EnterpriseNeoServer.java
+++ b/enterprise/server-enterprise/src/main/java/org/neo4j/server/enterprise/EnterpriseNeoServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/server-enterprise/src/main/java/org/neo4j/server/enterprise/EnterpriseServerSettings.java
+++ b/enterprise/server-enterprise/src/main/java/org/neo4j/server/enterprise/EnterpriseServerSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/server-enterprise/src/main/java/org/neo4j/server/enterprise/OpenEnterpriseNeoServer.java
+++ b/enterprise/server-enterprise/src/main/java/org/neo4j/server/enterprise/OpenEnterpriseNeoServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/server-enterprise/src/main/java/org/neo4j/server/enterprise/jmx/ServerManagement.java
+++ b/enterprise/server-enterprise/src/main/java/org/neo4j/server/enterprise/jmx/ServerManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/server-enterprise/src/main/java/org/neo4j/server/enterprise/jmx/ServerManagementMBean.java
+++ b/enterprise/server-enterprise/src/main/java/org/neo4j/server/enterprise/jmx/ServerManagementMBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/server-enterprise/src/main/java/org/neo4j/server/enterprise/modules/EnterpriseAuthorizationModule.java
+++ b/enterprise/server-enterprise/src/main/java/org/neo4j/server/enterprise/modules/EnterpriseAuthorizationModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/server-enterprise/src/main/java/org/neo4j/server/enterprise/modules/JMXManagementModule.java
+++ b/enterprise/server-enterprise/src/main/java/org/neo4j/server/enterprise/modules/JMXManagementModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/server-enterprise/src/main/java/org/neo4j/server/rest/CoreDatabaseAvailabilityDiscoveryRepresentation.java
+++ b/enterprise/server-enterprise/src/main/java/org/neo4j/server/rest/CoreDatabaseAvailabilityDiscoveryRepresentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/server-enterprise/src/main/java/org/neo4j/server/rest/CoreDatabaseAvailabilityService.java
+++ b/enterprise/server-enterprise/src/main/java/org/neo4j/server/rest/CoreDatabaseAvailabilityService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/server-enterprise/src/main/java/org/neo4j/server/rest/DatabaseRoleInfoServerModule.java
+++ b/enterprise/server-enterprise/src/main/java/org/neo4j/server/rest/DatabaseRoleInfoServerModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/server-enterprise/src/main/java/org/neo4j/server/rest/HaDiscoveryRepresentation.java
+++ b/enterprise/server-enterprise/src/main/java/org/neo4j/server/rest/HaDiscoveryRepresentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/server-enterprise/src/main/java/org/neo4j/server/rest/MasterInfoService.java
+++ b/enterprise/server-enterprise/src/main/java/org/neo4j/server/rest/MasterInfoService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/server-enterprise/src/main/java/org/neo4j/server/rest/ReadReplicaDatabaseAvailabilityService.java
+++ b/enterprise/server-enterprise/src/main/java/org/neo4j/server/rest/ReadReplicaDatabaseAvailabilityService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/server-enterprise/src/main/java/org/neo4j/server/rest/causalclustering/BaseStatus.java
+++ b/enterprise/server-enterprise/src/main/java/org/neo4j/server/rest/causalclustering/BaseStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/server-enterprise/src/main/java/org/neo4j/server/rest/causalclustering/CausalClusteringDiscovery.java
+++ b/enterprise/server-enterprise/src/main/java/org/neo4j/server/rest/causalclustering/CausalClusteringDiscovery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/server-enterprise/src/main/java/org/neo4j/server/rest/causalclustering/CausalClusteringService.java
+++ b/enterprise/server-enterprise/src/main/java/org/neo4j/server/rest/causalclustering/CausalClusteringService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/server-enterprise/src/main/java/org/neo4j/server/rest/causalclustering/CausalClusteringStatus.java
+++ b/enterprise/server-enterprise/src/main/java/org/neo4j/server/rest/causalclustering/CausalClusteringStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/server-enterprise/src/main/java/org/neo4j/server/rest/causalclustering/CausalClusteringStatusFactory.java
+++ b/enterprise/server-enterprise/src/main/java/org/neo4j/server/rest/causalclustering/CausalClusteringStatusFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/server-enterprise/src/main/java/org/neo4j/server/rest/causalclustering/CoreStatus.java
+++ b/enterprise/server-enterprise/src/main/java/org/neo4j/server/rest/causalclustering/CoreStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/server-enterprise/src/main/java/org/neo4j/server/rest/causalclustering/NotCausalClustering.java
+++ b/enterprise/server-enterprise/src/main/java/org/neo4j/server/rest/causalclustering/NotCausalClustering.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/server-enterprise/src/main/java/org/neo4j/server/rest/causalclustering/ReadReplicaStatus.java
+++ b/enterprise/server-enterprise/src/main/java/org/neo4j/server/rest/causalclustering/ReadReplicaStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/server-enterprise/src/main/java/org/neo4j/server/rest/dbms/EnterpriseAuthorizationDisabledFilter.java
+++ b/enterprise/server-enterprise/src/main/java/org/neo4j/server/rest/dbms/EnterpriseAuthorizationDisabledFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/enterprise/ArbiterEntryPointTest.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/enterprise/ArbiterEntryPointTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/enterprise/NeoServerRestartTestEnterpriseIT.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/enterprise/NeoServerRestartTestEnterpriseIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/enterprise/ServerClassNameTest.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/enterprise/ServerClassNameTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/enterprise/StandaloneHaInfoFunctionalTest.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/enterprise/StandaloneHaInfoFunctionalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/enterprise/functional/EnterpriseServerIT.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/enterprise/functional/EnterpriseServerIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/enterprise/functional/ServerMetricsIT.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/enterprise/functional/ServerMetricsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/enterprise/helpers/EnterpriseServerBuilder.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/enterprise/helpers/EnterpriseServerBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/enterprise/jmx/ServerManagementIT.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/enterprise/jmx/ServerManagementIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/CypherQueriesIT.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/CypherQueriesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/EnterpriseVersionAndEditionServiceIT.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/EnterpriseVersionAndEditionServiceIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/EnterpriseVersionIT.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/EnterpriseVersionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/MasterInfoServiceTest.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/MasterInfoServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/PropertyExistenceConstraintsIT.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/PropertyExistenceConstraintsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/causalclustering/CoreStatusTest.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/causalclustering/CoreStatusTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/causalclustering/ReadReplicaStatusTest.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/causalclustering/ReadReplicaStatusTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/security/AbstractRESTInteraction.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/security/AbstractRESTInteraction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/security/CypherRESTAuthScenariosInteractionIT.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/security/CypherRESTAuthScenariosInteractionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/security/CypherRESTBuiltInProceduresInteractionIT.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/security/CypherRESTBuiltInProceduresInteractionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/security/CypherRESTConfiguredProceduresIT.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/security/CypherRESTConfiguredProceduresIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/security/CypherRESTInteraction.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/security/CypherRESTInteraction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/security/CypherRESTUserManagementProceduresInteractionIT.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/security/CypherRESTUserManagementProceduresInteractionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/security/EnterpriseAuthenticationIT.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/security/EnterpriseAuthenticationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/security/EnterpriseUserServiceTest.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/security/EnterpriseUserServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/security/RESTAuthScenariosInteractionIT.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/security/RESTAuthScenariosInteractionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/security/RESTBuiltInProceduresInteractionIT.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/security/RESTBuiltInProceduresInteractionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/security/RESTConfiguredProceduresIT.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/security/RESTConfiguredProceduresIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/security/RESTInteraction.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/security/RESTInteraction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/security/RESTSubject.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/security/RESTSubject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/security/RESTUserManagementProceduresInteractionIT.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/security/RESTUserManagementProceduresInteractionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/test/server/ha/EnterpriseServerHelper.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/test/server/ha/EnterpriseServerHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/integrationtests/NOTICE.txt
+++ b/integrationtests/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/integrationtests/src/test/java/org/neo4j/TransactionGuardIT.java
+++ b/integrationtests/src/test/java/org/neo4j/TransactionGuardIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/integrationtests/src/test/java/org/neo4j/TransactionTerminationIT.java
+++ b/integrationtests/src/test/java/org/neo4j/TransactionTerminationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/integrationtests/src/test/java/org/neo4j/auth/FlatFileChaoticStressIT.java
+++ b/integrationtests/src/test/java/org/neo4j/auth/FlatFileChaoticStressIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/integrationtests/src/test/java/org/neo4j/auth/FlatFilePredictableStressIT.java
+++ b/integrationtests/src/test/java/org/neo4j/auth/FlatFilePredictableStressIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/integrationtests/src/test/java/org/neo4j/auth/FlatFileStressBase.java
+++ b/integrationtests/src/test/java/org/neo4j/auth/FlatFileStressBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/integrationtests/src/test/java/org/neo4j/bolt/BoltDriverLargePropertiesIT.java
+++ b/integrationtests/src/test/java/org/neo4j/bolt/BoltDriverLargePropertiesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/integrationtests/src/test/java/org/neo4j/bolt/BoltFailuresIT.java
+++ b/integrationtests/src/test/java/org/neo4j/bolt/BoltFailuresIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/integrationtests/src/test/java/org/neo4j/bolt/BoltMessageLoggingIT.java
+++ b/integrationtests/src/test/java/org/neo4j/bolt/BoltMessageLoggingIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/integrationtests/src/test/java/org/neo4j/bolt/BoltProceduresIT.java
+++ b/integrationtests/src/test/java/org/neo4j/bolt/BoltProceduresIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/integrationtests/src/test/java/org/neo4j/bolt/BoltSnapshotQueryExecutionIT.java
+++ b/integrationtests/src/test/java/org/neo4j/bolt/BoltSnapshotQueryExecutionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/integrationtests/src/test/java/org/neo4j/bolt/BoltTlsIT.java
+++ b/integrationtests/src/test/java/org/neo4j/bolt/BoltTlsIT.java
@@ -55,6 +55,7 @@ import org.neo4j.ssl.SslContextFactory;
 import org.neo4j.ssl.SslResource;
 import org.neo4j.test.TestGraphDatabaseFactory;
 import org.neo4j.test.rule.TestDirectory;
+import org.neo4j.ssl.SupportsTls;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.junit.Assert.assertNotNull;
@@ -119,9 +120,9 @@ public class BoltTlsIT
                 new TestSetup( "TLSv1", "TLSv1.1", false ),
                 new TestSetup( "TLSv1.1", "TLSv1.2", false ),
 
-                new TestSetup( "TLSv1", "TLSv1", false ),
-                new TestSetup( "TLSv1.1", "TLSv1.1", false ),
-                new TestSetup( "TLSv1.2", "TLSv1.2", true ),
+                new TestSetup( "TLSv1", "TLSv1", SupportsTls.supportsTls_1_0() ),
+                new TestSetup( "TLSv1.1", "TLSv1.1", SupportsTls.supportsTls_1_1() ),
+                new TestSetup( "TLSv1.2", "TLSv1.2", SupportsTls.supportsTls_1_2() ),
 
                 new TestSetup( "SSLv3,TLSv1", "TLSv1.1,TLSv1.2", false ),
                 new TestSetup( "TLSv1.1,TLSv1.2", "TLSv1.1,TLSv1.2", true ),

--- a/integrationtests/src/test/java/org/neo4j/bolt/BoltTlsIT.java
+++ b/integrationtests/src/test/java/org/neo4j/bolt/BoltTlsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/integrationtests/src/test/java/org/neo4j/bolt/DeleteUserStressIT.java
+++ b/integrationtests/src/test/java/org/neo4j/bolt/DeleteUserStressIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/integrationtests/src/test/java/org/neo4j/bolt/GraphDatabaseFactoryWithCustomBoltKernelExtension.java
+++ b/integrationtests/src/test/java/org/neo4j/bolt/GraphDatabaseFactoryWithCustomBoltKernelExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/integrationtests/src/test/java/org/neo4j/bolt/SessionResetIT.java
+++ b/integrationtests/src/test/java/org/neo4j/bolt/SessionResetIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/integrationtests/src/test/java/org/neo4j/causalclustering/scenarios/BoltCausalClusteringIT.java
+++ b/integrationtests/src/test/java/org/neo4j/causalclustering/scenarios/BoltCausalClusteringIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/integrationtests/src/test/java/org/neo4j/causalclustering/scenarios/ConvertNonCausalClusteringStoreIT.java
+++ b/integrationtests/src/test/java/org/neo4j/causalclustering/scenarios/ConvertNonCausalClusteringStoreIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/integrationtests/src/test/java/org/neo4j/commandline/admin/Neo4jAdminUsageTest.java
+++ b/integrationtests/src/test/java/org/neo4j/commandline/admin/Neo4jAdminUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/integrationtests/src/test/java/org/neo4j/consistency/HalfCreatedConstraintIT.java
+++ b/integrationtests/src/test/java/org/neo4j/consistency/HalfCreatedConstraintIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/integrationtests/src/test/java/org/neo4j/ext/udc/impl/UdcExtensionImplIT.java
+++ b/integrationtests/src/test/java/org/neo4j/ext/udc/impl/UdcExtensionImplIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/integrationtests/src/test/java/org/neo4j/ha/BoltHAIT.java
+++ b/integrationtests/src/test/java/org/neo4j/ha/BoltHAIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/integrationtests/src/test/java/org/neo4j/ha/HAClusterStartupIT.java
+++ b/integrationtests/src/test/java/org/neo4j/ha/HAClusterStartupIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/integrationtests/src/test/java/org/neo4j/kernel/PageCacheFlushTracingTest.java
+++ b/integrationtests/src/test/java/org/neo4j/kernel/PageCacheFlushTracingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/integrationtests/src/test/java/org/neo4j/kernel/PageCacheWarmupCcIT.java
+++ b/integrationtests/src/test/java/org/neo4j/kernel/PageCacheWarmupCcIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/integrationtests/src/test/java/org/neo4j/kernel/PageCacheWarmupEnterpriseEditionIT.java
+++ b/integrationtests/src/test/java/org/neo4j/kernel/PageCacheWarmupEnterpriseEditionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/integrationtests/src/test/java/org/neo4j/kernel/PageCacheWarmupTestSupport.java
+++ b/integrationtests/src/test/java/org/neo4j/kernel/PageCacheWarmupTestSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/integrationtests/src/test/java/org/neo4j/kernel/VersionIT.java
+++ b/integrationtests/src/test/java/org/neo4j/kernel/VersionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/integrationtests/src/test/java/org/neo4j/procedure/ProcedureIT.java
+++ b/integrationtests/src/test/java/org/neo4j/procedure/ProcedureIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/integrationtests/src/test/java/org/neo4j/procedure/StringMatcherIgnoresNewlines.java
+++ b/integrationtests/src/test/java/org/neo4j/procedure/StringMatcherIgnoresNewlines.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/integrationtests/src/test/java/org/neo4j/procedure/UserAggregationFunctionIT.java
+++ b/integrationtests/src/test/java/org/neo4j/procedure/UserAggregationFunctionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/integrationtests/src/test/java/org/neo4j/procedure/UserFunctionIT.java
+++ b/integrationtests/src/test/java/org/neo4j/procedure/UserFunctionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/integrationtests/src/test/java/org/neo4j/server/BatchEndpointIT.java
+++ b/integrationtests/src/test/java/org/neo4j/server/BatchEndpointIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/integrationtests/src/test/java/org/neo4j/server/BoltQueryLoggingIT.java
+++ b/integrationtests/src/test/java/org/neo4j/server/BoltQueryLoggingIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/integrationtests/src/test/java/org/neo4j/server/arbiter/ArbiterBootstrapperIT.java
+++ b/integrationtests/src/test/java/org/neo4j/server/arbiter/ArbiterBootstrapperIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/integrationtests/src/test/java/org/neo4j/server/arbiter/ArbiterBootstrapperTestProxy.java
+++ b/integrationtests/src/test/java/org/neo4j/server/arbiter/ArbiterBootstrapperTestProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/integrationtests/src/test/java/org/neo4j/ssl/SecureClient.java
+++ b/integrationtests/src/test/java/org/neo4j/ssl/SecureClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/integrationtests/src/test/java/org/neo4j/ssl/SecureServer.java
+++ b/integrationtests/src/test/java/org/neo4j/ssl/SecureServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/integrationtests/src/test/java/org/neo4j/ssl/SelfSignedCertificatesIT.java
+++ b/integrationtests/src/test/java/org/neo4j/ssl/SelfSignedCertificatesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/integrationtests/src/test/java/org/neo4j/ssl/SslContextFactory.java
+++ b/integrationtests/src/test/java/org/neo4j/ssl/SslContextFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/integrationtests/src/test/java/org/neo4j/ssl/SslNegotiationTest.java
+++ b/integrationtests/src/test/java/org/neo4j/ssl/SslNegotiationTest.java
@@ -98,7 +98,7 @@ public class SslNegotiationTest
                 new TestSetup(
                         protocols( TLSv10 ).ciphers( NEW_CIPHER_A ),
                         protocols( TLSv10 ).ciphers( NEW_CIPHER_A ),
-                        false, TLSv10, NEW_CIPHER_A ),
+                        SupportsTls.supportsTls_1_0(), TLSv10, NEW_CIPHER_A ),
                 new TestSetup(
                         protocols( TLSv11 ).ciphers( OLD_CIPHER_A ),
                         protocols( TLSv11 ).ciphers( OLD_CIPHER_A ),
@@ -106,7 +106,7 @@ public class SslNegotiationTest
                 new TestSetup(
                         protocols( TLSv11 ).ciphers( NEW_CIPHER_A ),
                         protocols( TLSv11 ).ciphers( NEW_CIPHER_A ),
-                        false, TLSv11, NEW_CIPHER_A ),
+                        SupportsTls.supportsTls_1_1(), TLSv11, NEW_CIPHER_A ),
                 new TestSetup(
                         protocols( TLSv12 ).ciphers( NEW_CIPHER_A ),
                         protocols( TLSv12 ).ciphers( NEW_CIPHER_A ),
@@ -164,7 +164,7 @@ public class SslNegotiationTest
                 new TestSetup(
                         protocols( TLSv11 ).ciphers( NEW_CIPHER_B, NEW_CIPHER_A ),
                         protocols( TLSv11 ).ciphers( NEW_CIPHER_C, NEW_CIPHER_A ),
-                        false, TLSv11, NEW_CIPHER_A ),
+                        SupportsTls.supportsTls_1_1(), TLSv11, NEW_CIPHER_A ),
                 new TestSetup(
                         protocols( TLSv12 ).ciphers( NEW_CIPHER_B, NEW_CIPHER_A ),
                         protocols( TLSv12 ).ciphers( NEW_CIPHER_C, NEW_CIPHER_A ),

--- a/integrationtests/src/test/java/org/neo4j/ssl/SslNegotiationTest.java
+++ b/integrationtests/src/test/java/org/neo4j/ssl/SslNegotiationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/integrationtests/src/test/java/org/neo4j/ssl/SslPlatformTest.java
+++ b/integrationtests/src/test/java/org/neo4j/ssl/SslPlatformTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/integrationtests/src/test/java/org/neo4j/ssl/SslTrustTest.java
+++ b/integrationtests/src/test/java/org/neo4j/ssl/SslTrustTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/integrationtests/src/test/java/org/neo4j/ssl/SupportsTls.java
+++ b/integrationtests/src/test/java/org/neo4j/ssl/SupportsTls.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) "Graph Foundation,"
+ * Graph Foundation, Inc. [https://graphfoundation.org]
+ *
+ * This file is part of ONgDB Enterprise Edition. The included source
+ * code can be redistributed and/or modified under the terms of the
+ * GNU AFFERO GENERAL PUBLIC LICENSE Version 3
+ * (http://www.fsf.org/licensing/licenses/agpl-3.0.html) as found
+ * in the associated LICENSE.txt file.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ */
+package org.neo4j.ssl;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.Security;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import javax.net.ssl.SSLContext;
+
+/**
+ * Reports whether the running JVM can complete a TLS handshake for a given protocol version.
+ * Newer JDKs commonly list legacy protocols in {@code jdk.tls.disabledAlgorithms}; those still appear
+ * in {@link SSLContext#getSupportedSSLParameters()} and can often be passed to
+ * {@code setEnabledProtocols}, but handshakes fail. Version-string checks are intentionally avoided.
+ */
+public class SupportsTls
+{
+    private static final Set<String> PROTOCOL_NAMES = new HashSet<>( Arrays.asList(
+            "SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2", "TLSv1.3" ) );
+
+    private static final Set<String> SUPPORTED_PROTOCOLS = discoverSupportedProtocols();
+    private static final Set<String> DISABLED_PROTOCOLS = discoverDisabledProtocols();
+
+    public static boolean supportsTls_1_0()
+    {
+        return supports( "TLSv1" );
+    }
+
+    public static boolean supportsTls_1_1()
+    {
+        return supports( "TLSv1.1" );
+    }
+
+    public static boolean supportsTls_1_2()
+    {
+        return supports( "TLSv1.2" );
+    }
+
+    public static boolean supportsTls_1_3()
+    {
+        return supports( "TLSv1.3" );
+    }
+
+    private static boolean supports( String protocol )
+    {
+        return SUPPORTED_PROTOCOLS.contains( protocol ) && !DISABLED_PROTOCOLS.contains( protocol );
+    }
+
+    private static Set<String> discoverSupportedProtocols()
+    {
+        try
+        {
+            String[] protocols = SSLContext.getDefault().getSupportedSSLParameters().getProtocols();
+            return Collections.unmodifiableSet( new HashSet<>( Arrays.asList( protocols ) ) );
+        }
+        catch ( NoSuchAlgorithmException e )
+        {
+            return Collections.emptySet();
+        }
+    }
+
+    private static Set<String> discoverDisabledProtocols()
+    {
+        String property = Security.getProperty( "jdk.tls.disabledAlgorithms" );
+        if ( property == null || property.trim().isEmpty() )
+        {
+            return Collections.emptySet();
+        }
+
+        Set<String> disabled = new HashSet<>();
+        for ( String part : property.split( "," ) )
+        {
+            String token = part.trim();
+            if ( PROTOCOL_NAMES.contains( token ) )
+            {
+                disabled.add( token );
+            }
+        }
+        return Collections.unmodifiableSet( disabled );
+    }
+}

--- a/integrationtests/src/test/java/org/neo4j/storeupgrade/ExplicitIndexesUpgradeIT.java
+++ b/integrationtests/src/test/java/org/neo4j/storeupgrade/ExplicitIndexesUpgradeIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/integrationtests/src/test/java/org/neo4j/storeupgrade/StoreUpgradeIT.java
+++ b/integrationtests/src/test/java/org/neo4j/storeupgrade/StoreUpgradeIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/packaging/standalone/NOTICE.txt
+++ b/packaging/standalone/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/ONgDB-Management.psd1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/ONgDB-Management.psd1
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/ONgDB-Management/Confirm-JavaVersion.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/ONgDB-Management/Confirm-JavaVersion.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/ONgDB-Management/Get-Args.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/ONgDB-Management/Get-Args.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/ONgDB-Management/Get-Java.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/ONgDB-Management/Get-Java.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/ONgDB-Management/Get-JavaVersion.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/ONgDB-Management/Get-JavaVersion.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/ONgDB-Management/Get-KeyValuePairsFromConfFile.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/ONgDB-Management/Get-KeyValuePairsFromConfFile.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/ONgDB-Management/Get-ONgDBEnv.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/ONgDB-Management/Get-ONgDBEnv.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/ONgDB-Management/Get-ONgDBPrunsrv.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/ONgDB-Management/Get-ONgDBPrunsrv.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/ONgDB-Management/Get-ONgDBServer.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/ONgDB-Management/Get-ONgDBServer.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/ONgDB-Management/Get-ONgDBSetting.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/ONgDB-Management/Get-ONgDBSetting.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/ONgDB-Management/Get-ONgDBStatus.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/ONgDB-Management/Get-ONgDBStatus.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/ONgDB-Management/Get-ONgDBWindowsServiceName.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/ONgDB-Management/Get-ONgDBWindowsServiceName.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/ONgDB-Management/Install-ONgDBServer.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/ONgDB-Management/Install-ONgDBServer.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/ONgDB-Management/Invoke-ExternalCommand.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/ONgDB-Management/Invoke-ExternalCommand.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/ONgDB-Management/Invoke-ONgDB.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/ONgDB-Management/Invoke-ONgDB.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/ONgDB-Management/Invoke-ONgDBAdmin.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/ONgDB-Management/Invoke-ONgDBAdmin.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/ONgDB-Management/Invoke-ONgDBBackup.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/ONgDB-Management/Invoke-ONgDBBackup.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/ONgDB-Management/Invoke-ONgDBImport.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/ONgDB-Management/Invoke-ONgDBImport.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/ONgDB-Management/Invoke-ONgDBShell.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/ONgDB-Management/Invoke-ONgDBShell.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/ONgDB-Management/Invoke-ONgDBUtility.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/ONgDB-Management/Invoke-ONgDBUtility.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/ONgDB-Management/Merge-ONgDBJavaSettings.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/ONgDB-Management/Merge-ONgDBJavaSettings.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/ONgDB-Management/New-ONgDBTempFile.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/ONgDB-Management/New-ONgDBTempFile.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/ONgDB-Management/ONgDB-Management.psm1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/ONgDB-Management/ONgDB-Management.psm1
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/ONgDB-Management/Set-ONgDBEnv.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/ONgDB-Management/Set-ONgDBEnv.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/ONgDB-Management/Start-ONgDBServer.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/ONgDB-Management/Start-ONgDBServer.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/ONgDB-Management/Stop-ONgDBServer.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/ONgDB-Management/Stop-ONgDBServer.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/ONgDB-Management/Uninstall-ONgDBServer.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/ONgDB-Management/Uninstall-ONgDBServer.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/ONgDB-Management/Update-ONgDBServer.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/ONgDB-Management/Update-ONgDBServer.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/ONgDB-Management/Write-StdErr.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/ONgDB-Management/Write-StdErr.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/ongdb
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/ongdb
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/ongdb-admin
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/ongdb-admin
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/ongdb-admin.bat
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/ongdb-admin.bat
@@ -1,5 +1,5 @@
 @ECHO OFF
-rem Copyright (c) 2018-2020 "Graph Foundation,"
+rem Copyright (c) "Graph Foundation,"
 rem Graph Foundation, Inc. [https://graphfoundation.org]
 rem
 rem This file is part of ONgDB.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/ongdb-admin.m4
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/ongdb-admin.m4
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/ongdb-admin.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/ongdb-admin.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/ongdb-backup
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/ongdb-backup
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/ongdb-backup.bat
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/ongdb-backup.bat
@@ -1,5 +1,5 @@
 @ECHO OFF
-rem Copyright (c) 2018-2020 "Graph Foundation,"
+rem Copyright (c) "Graph Foundation,"
 rem Graph Foundation, Inc. [https://graphfoundation.org]
 rem
 rem This file is part of ONgDB.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/ongdb-backup.m4
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/ongdb-backup.m4
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/ongdb-backup.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/ongdb-backup.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/ongdb-import
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/ongdb-import
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/ongdb-import.bat
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/ongdb-import.bat
@@ -1,5 +1,5 @@
 @ECHO OFF
-rem Copyright (c) 2018-2020 "Graph Foundation,"
+rem Copyright (c) "Graph Foundation,"
 rem Graph Foundation, Inc. [https://graphfoundation.org]
 rem
 rem This file is part of ONgDB.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/ongdb-import.m4
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/ongdb-import.m4
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/ongdb-import.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/ongdb-import.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/ongdb-shared.m4
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/ongdb-shared.m4
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/ongdb-shell
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/ongdb-shell
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/ongdb-shell.bat
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/ongdb-shell.bat
@@ -1,5 +1,5 @@
 @ECHO OFF
-rem Copyright (c) 2018-2020 "Graph Foundation,"
+rem Copyright (c) "Graph Foundation,"
 rem Graph Foundation, Inc. [https://graphfoundation.org]
 rem
 rem This file is part of ONgDB.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/ongdb-shell.m4
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/ongdb-shell.m4
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/ongdb.bat
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/ongdb.bat
@@ -1,5 +1,5 @@
 @ECHO OFF
-rem Copyright (c) 2018-2020 "Graph Foundation,"
+rem Copyright (c) "Graph Foundation,"
 rem Graph Foundation, Inc. [https://graphfoundation.org]
 rem
 rem This file is part of ONgDB.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/ongdb.m4
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/ongdb.m4
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/ongdb.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/ongdb.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB.

--- a/packaging/standalone/src/tests/ONgDB-Management/Common.ps1
+++ b/packaging/standalone/src/tests/ONgDB-Management/Common.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB.

--- a/packaging/standalone/src/tests/ONgDB-Management/Run-Tests.ps1
+++ b/packaging/standalone/src/tests/ONgDB-Management/Run-Tests.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB.

--- a/packaging/standalone/src/tests/ONgDB-Management/unit/Confirm-JavaVersion.Tests.ps1
+++ b/packaging/standalone/src/tests/ONgDB-Management/unit/Confirm-JavaVersion.Tests.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB.

--- a/packaging/standalone/src/tests/ONgDB-Management/unit/Get-Args.Tests.ps1
+++ b/packaging/standalone/src/tests/ONgDB-Management/unit/Get-Args.Tests.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB.

--- a/packaging/standalone/src/tests/ONgDB-Management/unit/Get-Java.Tests.ps1
+++ b/packaging/standalone/src/tests/ONgDB-Management/unit/Get-Java.Tests.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB.

--- a/packaging/standalone/src/tests/ONgDB-Management/unit/Get-JavaVersion.Tests.ps1
+++ b/packaging/standalone/src/tests/ONgDB-Management/unit/Get-JavaVersion.Tests.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB.

--- a/packaging/standalone/src/tests/ONgDB-Management/unit/Get-KeyValuePairsFromConfFile.Tests.ps1
+++ b/packaging/standalone/src/tests/ONgDB-Management/unit/Get-KeyValuePairsFromConfFile.Tests.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB.

--- a/packaging/standalone/src/tests/ONgDB-Management/unit/Get-ONgDBEnv.Tests.ps1
+++ b/packaging/standalone/src/tests/ONgDB-Management/unit/Get-ONgDBEnv.Tests.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB.

--- a/packaging/standalone/src/tests/ONgDB-Management/unit/Get-ONgDBPrunsrv.Tests.ps1
+++ b/packaging/standalone/src/tests/ONgDB-Management/unit/Get-ONgDBPrunsrv.Tests.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB.

--- a/packaging/standalone/src/tests/ONgDB-Management/unit/Get-ONgDBServer.Tests.ps1
+++ b/packaging/standalone/src/tests/ONgDB-Management/unit/Get-ONgDBServer.Tests.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB.

--- a/packaging/standalone/src/tests/ONgDB-Management/unit/Get-ONgDBSetting.Tests.ps1
+++ b/packaging/standalone/src/tests/ONgDB-Management/unit/Get-ONgDBSetting.Tests.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB.

--- a/packaging/standalone/src/tests/ONgDB-Management/unit/Get-ONgDBStatus.Tests.ps1
+++ b/packaging/standalone/src/tests/ONgDB-Management/unit/Get-ONgDBStatus.Tests.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB.

--- a/packaging/standalone/src/tests/ONgDB-Management/unit/Get-ONgDBWindowsServiceName.Tests.ps1
+++ b/packaging/standalone/src/tests/ONgDB-Management/unit/Get-ONgDBWindowsServiceName.Tests.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB.

--- a/packaging/standalone/src/tests/ONgDB-Management/unit/Install-ONgDBServer.Tests.ps1
+++ b/packaging/standalone/src/tests/ONgDB-Management/unit/Install-ONgDBServer.Tests.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB.

--- a/packaging/standalone/src/tests/ONgDB-Management/unit/Invoke-ONgDB.Tests.ps1
+++ b/packaging/standalone/src/tests/ONgDB-Management/unit/Invoke-ONgDB.Tests.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB.

--- a/packaging/standalone/src/tests/ONgDB-Management/unit/Invoke-ONgDBAdmin.Tests.ps1
+++ b/packaging/standalone/src/tests/ONgDB-Management/unit/Invoke-ONgDBAdmin.Tests.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB.

--- a/packaging/standalone/src/tests/ONgDB-Management/unit/Invoke-ONgDBImport.Tests.ps1
+++ b/packaging/standalone/src/tests/ONgDB-Management/unit/Invoke-ONgDBImport.Tests.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB.

--- a/packaging/standalone/src/tests/ONgDB-Management/unit/Merge-ONgDBJavaSettings.Tests.ps1
+++ b/packaging/standalone/src/tests/ONgDB-Management/unit/Merge-ONgDBJavaSettings.Tests.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB.

--- a/packaging/standalone/src/tests/ONgDB-Management/unit/Start-ONgDBServer.Tests.ps1
+++ b/packaging/standalone/src/tests/ONgDB-Management/unit/Start-ONgDBServer.Tests.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB.

--- a/packaging/standalone/src/tests/ONgDB-Management/unit/Stop-ONgDBServer.Tests.ps1
+++ b/packaging/standalone/src/tests/ONgDB-Management/unit/Stop-ONgDBServer.Tests.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB.

--- a/packaging/standalone/src/tests/ONgDB-Management/unit/Uninstall-ONgDBServer.Tests.ps1
+++ b/packaging/standalone/src/tests/ONgDB-Management/unit/Uninstall-ONgDBServer.Tests.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB.

--- a/packaging/standalone/src/tests/ONgDB-Management/unit/Update-ONgDBServer.Tests.ps1
+++ b/packaging/standalone/src/tests/ONgDB-Management/unit/Update-ONgDBServer.Tests.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 "Graph Foundation,"
+# Copyright (c) "Graph Foundation,"
 # Graph Foundation, Inc. [https://graphfoundation.org]
 #
 # This file is part of ONgDB.

--- a/packaging/standalone/standalone-community/src/main/assemblies/community-unix-dist.xml
+++ b/packaging/standalone/standalone-community/src/main/assemblies/community-unix-dist.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018-2020 "Graph Foundation,"
+    Copyright (c) "Graph Foundation,"
     Graph Foundation, Inc. [https://graphfoundation.org]
 
     This file is part of ONgDB Enterprise Edition. The included source

--- a/packaging/standalone/standalone-community/src/main/assemblies/community-windows-dist.xml
+++ b/packaging/standalone/standalone-community/src/main/assemblies/community-windows-dist.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018-2020 "Graph Foundation,"
+    Copyright (c) "Graph Foundation,"
     Graph Foundation, Inc. [https://graphfoundation.org]
 
     This file is part of ONgDB Enterprise Edition. The included source

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/NOTICE.txt
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/packaging/standalone/standalone-enterprise/NOTICE.txt
+++ b/packaging/standalone/standalone-enterprise/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/packaging/standalone/standalone-enterprise/src/main/assemblies/enterprise-unix-dist.xml
+++ b/packaging/standalone/standalone-enterprise/src/main/assemblies/enterprise-unix-dist.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018-2020 "Graph Foundation,"
+    Copyright (c) "Graph Foundation,"
     Graph Foundation, Inc. [https://graphfoundation.org]
 
     This file is part of ONgDB Enterprise Edition. The included source

--- a/packaging/standalone/standalone-enterprise/src/main/assemblies/enterprise-windows-dist.xml
+++ b/packaging/standalone/standalone-enterprise/src/main/assemblies/enterprise-windows-dist.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018-2020 "Graph Foundation,"
+    Copyright (c) "Graph Foundation,"
     Graph Foundation, Inc. [https://graphfoundation.org]
 
     This file is part of ONgDB Enterprise Edition. The included source

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/NOTICE.txt
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,6 @@
         <maven.build.timestamp.format>yyMMddHHmmssSSS</maven.build.timestamp.format>
 
         <license-text.header>headers/AGPL-3-header.txt</license-text.header>
-        <currentYear>2020</currentYear>
 
         <scala-maven-plugin.version>3.3.2</scala-maven-plugin.version>
         <scala.version>2.11.12</scala.version>
@@ -815,9 +814,6 @@
                         <feature>SCRIPT_STYLE</feature>
                         <g4>SLASHSTAR_STYLE</g4>
                     </mapping>
-                    <properties>
-                        <currentYear>${currentYear}</currentYear>
-                    </properties>
                 </configuration>
             </plugin>
 

--- a/stresstests/NOTICE.txt
+++ b/stresstests/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/stresstests/src/test/java/org/neo4j/backup/BackupHelper.java
+++ b/stresstests/src/test/java/org/neo4j/backup/BackupHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/stresstests/src/test/java/org/neo4j/backup/BackupResult.java
+++ b/stresstests/src/test/java/org/neo4j/backup/BackupResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/stresstests/src/test/java/org/neo4j/backup/stresstests/BackupLoad.java
+++ b/stresstests/src/test/java/org/neo4j/backup/stresstests/BackupLoad.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/stresstests/src/test/java/org/neo4j/backup/stresstests/BackupServiceStressTesting.java
+++ b/stresstests/src/test/java/org/neo4j/backup/stresstests/BackupServiceStressTesting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/stresstests/src/test/java/org/neo4j/backup/stresstests/StartStop.java
+++ b/stresstests/src/test/java/org/neo4j/backup/stresstests/StartStop.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/stresstests/src/test/java/org/neo4j/backup/stresstests/TransactionalWorkload.java
+++ b/stresstests/src/test/java/org/neo4j/backup/stresstests/TransactionalWorkload.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/stresstests/src/test/java/org/neo4j/causalclustering/stresstests/BackupRandomMember.java
+++ b/stresstests/src/test/java/org/neo4j/causalclustering/stresstests/BackupRandomMember.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/stresstests/src/test/java/org/neo4j/causalclustering/stresstests/CatchupNewReadReplica.java
+++ b/stresstests/src/test/java/org/neo4j/causalclustering/stresstests/CatchupNewReadReplica.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/stresstests/src/test/java/org/neo4j/causalclustering/stresstests/ClusterConfiguration.java
+++ b/stresstests/src/test/java/org/neo4j/causalclustering/stresstests/ClusterConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/stresstests/src/test/java/org/neo4j/causalclustering/stresstests/ClusterStressScenarioSmoke.java
+++ b/stresstests/src/test/java/org/neo4j/causalclustering/stresstests/ClusterStressScenarioSmoke.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/stresstests/src/test/java/org/neo4j/causalclustering/stresstests/ClusterStressTesting.java
+++ b/stresstests/src/test/java/org/neo4j/causalclustering/stresstests/ClusterStressTesting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/stresstests/src/test/java/org/neo4j/causalclustering/stresstests/Config.java
+++ b/stresstests/src/test/java/org/neo4j/causalclustering/stresstests/Config.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/stresstests/src/test/java/org/neo4j/causalclustering/stresstests/ConsistencyCheck.java
+++ b/stresstests/src/test/java/org/neo4j/causalclustering/stresstests/ConsistencyCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/stresstests/src/test/java/org/neo4j/causalclustering/stresstests/Control.java
+++ b/stresstests/src/test/java/org/neo4j/causalclustering/stresstests/Control.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/stresstests/src/test/java/org/neo4j/causalclustering/stresstests/CreateNodesWithProperties.java
+++ b/stresstests/src/test/java/org/neo4j/causalclustering/stresstests/CreateNodesWithProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/stresstests/src/test/java/org/neo4j/causalclustering/stresstests/IdReuse.java
+++ b/stresstests/src/test/java/org/neo4j/causalclustering/stresstests/IdReuse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/stresstests/src/test/java/org/neo4j/causalclustering/stresstests/Preparation.java
+++ b/stresstests/src/test/java/org/neo4j/causalclustering/stresstests/Preparation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/stresstests/src/test/java/org/neo4j/causalclustering/stresstests/Preparations.java
+++ b/stresstests/src/test/java/org/neo4j/causalclustering/stresstests/Preparations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/stresstests/src/test/java/org/neo4j/causalclustering/stresstests/RepeatOnRandomCore.java
+++ b/stresstests/src/test/java/org/neo4j/causalclustering/stresstests/RepeatOnRandomCore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/stresstests/src/test/java/org/neo4j/causalclustering/stresstests/RepeatOnRandomMember.java
+++ b/stresstests/src/test/java/org/neo4j/causalclustering/stresstests/RepeatOnRandomMember.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/stresstests/src/test/java/org/neo4j/causalclustering/stresstests/ReplaceRandomMember.java
+++ b/stresstests/src/test/java/org/neo4j/causalclustering/stresstests/ReplaceRandomMember.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/stresstests/src/test/java/org/neo4j/causalclustering/stresstests/Resources.java
+++ b/stresstests/src/test/java/org/neo4j/causalclustering/stresstests/Resources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/stresstests/src/test/java/org/neo4j/causalclustering/stresstests/StartStopRandomCore.java
+++ b/stresstests/src/test/java/org/neo4j/causalclustering/stresstests/StartStopRandomCore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/stresstests/src/test/java/org/neo4j/causalclustering/stresstests/StartStopRandomMember.java
+++ b/stresstests/src/test/java/org/neo4j/causalclustering/stresstests/StartStopRandomMember.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/stresstests/src/test/java/org/neo4j/causalclustering/stresstests/TxHelp.java
+++ b/stresstests/src/test/java/org/neo4j/causalclustering/stresstests/TxHelp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/stresstests/src/test/java/org/neo4j/causalclustering/stresstests/Validation.java
+++ b/stresstests/src/test/java/org/neo4j/causalclustering/stresstests/Validation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/stresstests/src/test/java/org/neo4j/causalclustering/stresstests/Validations.java
+++ b/stresstests/src/test/java/org/neo4j/causalclustering/stresstests/Validations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/stresstests/src/test/java/org/neo4j/causalclustering/stresstests/Workloads.java
+++ b/stresstests/src/test/java/org/neo4j/causalclustering/stresstests/Workloads.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/stresstests/src/test/java/org/neo4j/helper/DatabaseConfiguration.java
+++ b/stresstests/src/test/java/org/neo4j/helper/DatabaseConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/stresstests/src/test/java/org/neo4j/helper/IsChannelClosedException.java
+++ b/stresstests/src/test/java/org/neo4j/helper/IsChannelClosedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/stresstests/src/test/java/org/neo4j/helper/IsConnectionException.java
+++ b/stresstests/src/test/java/org/neo4j/helper/IsConnectionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/stresstests/src/test/java/org/neo4j/helper/IsConnectionResetByPeer.java
+++ b/stresstests/src/test/java/org/neo4j/helper/IsConnectionResetByPeer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/stresstests/src/test/java/org/neo4j/helper/IsStoreClosed.java
+++ b/stresstests/src/test/java/org/neo4j/helper/IsStoreClosed.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/stresstests/src/test/java/org/neo4j/helper/StressTestingHelper.java
+++ b/stresstests/src/test/java/org/neo4j/helper/StressTestingHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/stresstests/src/test/java/org/neo4j/helper/Workload.java
+++ b/stresstests/src/test/java/org/neo4j/helper/Workload.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/stresstests/src/test/java/org/neo4j/index/population/LucenePartitionedIndexStressTesting.java
+++ b/stresstests/src/test/java/org/neo4j/index/population/LucenePartitionedIndexStressTesting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/stresstests/src/test/java/org/neo4j/io/pagecache/stresstests/PageCacheStressTesting.java
+++ b/stresstests/src/test/java/org/neo4j/io/pagecache/stresstests/PageCacheStressTesting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/stresstests/src/test/java/org/neo4j/kernel/stresstests/transaction/checkpoint/CheckPointingLogRotationStressTesting.java
+++ b/stresstests/src/test/java/org/neo4j/kernel/stresstests/transaction/checkpoint/CheckPointingLogRotationStressTesting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/stresstests/src/test/java/org/neo4j/kernel/stresstests/transaction/checkpoint/NodeCountInputs.java
+++ b/stresstests/src/test/java/org/neo4j/kernel/stresstests/transaction/checkpoint/NodeCountInputs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/stresstests/src/test/java/org/neo4j/kernel/stresstests/transaction/checkpoint/TransactionThroughputChecker.java
+++ b/stresstests/src/test/java/org/neo4j/kernel/stresstests/transaction/checkpoint/TransactionThroughputChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/stresstests/src/test/java/org/neo4j/kernel/stresstests/transaction/checkpoint/mutation/LabelMutation.java
+++ b/stresstests/src/test/java/org/neo4j/kernel/stresstests/transaction/checkpoint/mutation/LabelMutation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/stresstests/src/test/java/org/neo4j/kernel/stresstests/transaction/checkpoint/mutation/Mutation.java
+++ b/stresstests/src/test/java/org/neo4j/kernel/stresstests/transaction/checkpoint/mutation/Mutation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/stresstests/src/test/java/org/neo4j/kernel/stresstests/transaction/checkpoint/mutation/PropertyMutation.java
+++ b/stresstests/src/test/java/org/neo4j/kernel/stresstests/transaction/checkpoint/mutation/PropertyMutation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/stresstests/src/test/java/org/neo4j/kernel/stresstests/transaction/checkpoint/mutation/RandomMutation.java
+++ b/stresstests/src/test/java/org/neo4j/kernel/stresstests/transaction/checkpoint/mutation/RandomMutation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/stresstests/src/test/java/org/neo4j/kernel/stresstests/transaction/checkpoint/mutation/RandomMutationFactory.java
+++ b/stresstests/src/test/java/org/neo4j/kernel/stresstests/transaction/checkpoint/mutation/RandomMutationFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/stresstests/src/test/java/org/neo4j/kernel/stresstests/transaction/checkpoint/mutation/SimpleRandomMutation.java
+++ b/stresstests/src/test/java/org/neo4j/kernel/stresstests/transaction/checkpoint/mutation/SimpleRandomMutation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/stresstests/src/test/java/org/neo4j/kernel/stresstests/transaction/checkpoint/tracers/TimerTracerFactory.java
+++ b/stresstests/src/test/java/org/neo4j/kernel/stresstests/transaction/checkpoint/tracers/TimerTracerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/stresstests/src/test/java/org/neo4j/kernel/stresstests/transaction/checkpoint/tracers/TimerTransactionTracer.java
+++ b/stresstests/src/test/java/org/neo4j/kernel/stresstests/transaction/checkpoint/tracers/TimerTransactionTracer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/stresstests/src/test/java/org/neo4j/kernel/stresstests/transaction/checkpoint/workload/SyncMonitor.java
+++ b/stresstests/src/test/java/org/neo4j/kernel/stresstests/transaction/checkpoint/workload/SyncMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/stresstests/src/test/java/org/neo4j/kernel/stresstests/transaction/checkpoint/workload/Worker.java
+++ b/stresstests/src/test/java/org/neo4j/kernel/stresstests/transaction/checkpoint/workload/Worker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/stresstests/src/test/java/org/neo4j/kernel/stresstests/transaction/checkpoint/workload/Workload.java
+++ b/stresstests/src/test/java/org/neo4j/kernel/stresstests/transaction/checkpoint/workload/Workload.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/stresstests/src/test/java/org/neo4j/kernel/stresstests/transaction/log/TransactionAppenderStressTesting.java
+++ b/stresstests/src/test/java/org/neo4j/kernel/stresstests/transaction/log/TransactionAppenderStressTesting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/tools/NOTICE.txt
+++ b/tools/NOTICE.txt
@@ -1,5 +1,5 @@
 ONgDB
-Copyright © 2018-2020 Graph Foundation, Inc.
+Copyright © Graph Foundation, Inc.
 (referred to in this notice as "Graph Foundation")
 [https://graphfoundation.org]
 

--- a/tools/src/main/java/org/neo4j/tools/applytx/ApplyTransactionsCommand.java
+++ b/tools/src/main/java/org/neo4j/tools/applytx/ApplyTransactionsCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/tools/src/main/java/org/neo4j/tools/applytx/DatabaseRebuildTool.java
+++ b/tools/src/main/java/org/neo4j/tools/applytx/DatabaseRebuildTool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/tools/src/main/java/org/neo4j/tools/applytx/DumpRecordsCommand.java
+++ b/tools/src/main/java/org/neo4j/tools/applytx/DumpRecordsCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/tools/src/main/java/org/neo4j/tools/console/input/ArgsCommand.java
+++ b/tools/src/main/java/org/neo4j/tools/console/input/ArgsCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/tools/src/main/java/org/neo4j/tools/console/input/Command.java
+++ b/tools/src/main/java/org/neo4j/tools/console/input/Command.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/tools/src/main/java/org/neo4j/tools/console/input/ConsoleInput.java
+++ b/tools/src/main/java/org/neo4j/tools/console/input/ConsoleInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/tools/src/main/java/org/neo4j/tools/console/input/ConsoleUtil.java
+++ b/tools/src/main/java/org/neo4j/tools/console/input/ConsoleUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/tools/src/main/java/org/neo4j/tools/dump/DumpCountsStore.java
+++ b/tools/src/main/java/org/neo4j/tools/dump/DumpCountsStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/tools/src/main/java/org/neo4j/tools/dump/DumpGBPTree.java
+++ b/tools/src/main/java/org/neo4j/tools/dump/DumpGBPTree.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/tools/src/main/java/org/neo4j/tools/dump/DumpLogicalLog.java
+++ b/tools/src/main/java/org/neo4j/tools/dump/DumpLogicalLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/tools/src/main/java/org/neo4j/tools/dump/DumpStore.java
+++ b/tools/src/main/java/org/neo4j/tools/dump/DumpStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/tools/src/main/java/org/neo4j/tools/dump/DumpStoreChain.java
+++ b/tools/src/main/java/org/neo4j/tools/dump/DumpStoreChain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/tools/src/main/java/org/neo4j/tools/dump/InconsistencyReportReader.java
+++ b/tools/src/main/java/org/neo4j/tools/dump/InconsistencyReportReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/tools/src/main/java/org/neo4j/tools/dump/LenientInvalidLogEntryHandler.java
+++ b/tools/src/main/java/org/neo4j/tools/dump/LenientInvalidLogEntryHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/tools/src/main/java/org/neo4j/tools/dump/TransactionLogAnalyzer.java
+++ b/tools/src/main/java/org/neo4j/tools/dump/TransactionLogAnalyzer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/tools/src/main/java/org/neo4j/tools/dump/inconsistency/Inconsistencies.java
+++ b/tools/src/main/java/org/neo4j/tools/dump/inconsistency/Inconsistencies.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/tools/src/main/java/org/neo4j/tools/dump/inconsistency/ReportInconsistencies.java
+++ b/tools/src/main/java/org/neo4j/tools/dump/inconsistency/ReportInconsistencies.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/tools/src/main/java/org/neo4j/tools/dump/log/TransactionLogEntryCursor.java
+++ b/tools/src/main/java/org/neo4j/tools/dump/log/TransactionLogEntryCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/tools/src/main/java/org/neo4j/tools/migration/StoreMigration.java
+++ b/tools/src/main/java/org/neo4j/tools/migration/StoreMigration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/tools/src/main/java/org/neo4j/tools/rawstorereader/RsdrMain.java
+++ b/tools/src/main/java/org/neo4j/tools/rawstorereader/RsdrMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/tools/src/main/java/org/neo4j/tools/rebuild/RebuildFromLogs.java
+++ b/tools/src/main/java/org/neo4j/tools/rebuild/RebuildFromLogs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/tools/src/main/java/org/neo4j/tools/txlog/CheckTxLogs.java
+++ b/tools/src/main/java/org/neo4j/tools/txlog/CheckTxLogs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/tools/src/main/java/org/neo4j/tools/txlog/CommittedRecords.java
+++ b/tools/src/main/java/org/neo4j/tools/txlog/CommittedRecords.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/tools/src/main/java/org/neo4j/tools/txlog/InconsistenciesHandler.java
+++ b/tools/src/main/java/org/neo4j/tools/txlog/InconsistenciesHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/tools/src/main/java/org/neo4j/tools/txlog/PrintingInconsistenciesHandler.java
+++ b/tools/src/main/java/org/neo4j/tools/txlog/PrintingInconsistenciesHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/tools/src/main/java/org/neo4j/tools/txlog/RecordInfo.java
+++ b/tools/src/main/java/org/neo4j/tools/txlog/RecordInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/tools/src/main/java/org/neo4j/tools/txlog/checktypes/CheckType.java
+++ b/tools/src/main/java/org/neo4j/tools/txlog/checktypes/CheckType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/tools/src/main/java/org/neo4j/tools/txlog/checktypes/CheckTypes.java
+++ b/tools/src/main/java/org/neo4j/tools/txlog/checktypes/CheckTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/tools/src/main/java/org/neo4j/tools/txlog/checktypes/NeoStoreCheckType.java
+++ b/tools/src/main/java/org/neo4j/tools/txlog/checktypes/NeoStoreCheckType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/tools/src/main/java/org/neo4j/tools/txlog/checktypes/NodeCheckType.java
+++ b/tools/src/main/java/org/neo4j/tools/txlog/checktypes/NodeCheckType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/tools/src/main/java/org/neo4j/tools/txlog/checktypes/PropertyCheckType.java
+++ b/tools/src/main/java/org/neo4j/tools/txlog/checktypes/PropertyCheckType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/tools/src/main/java/org/neo4j/tools/txlog/checktypes/RelationshipCheckType.java
+++ b/tools/src/main/java/org/neo4j/tools/txlog/checktypes/RelationshipCheckType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/tools/src/main/java/org/neo4j/tools/txlog/checktypes/RelationshipGroupCheckType.java
+++ b/tools/src/main/java/org/neo4j/tools/txlog/checktypes/RelationshipGroupCheckType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/tools/src/main/java/org/neo4j/tools/util/TransactionLogUtils.java
+++ b/tools/src/main/java/org/neo4j/tools/util/TransactionLogUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/tools/src/test/java/org/neo4j/tools/applytx/DatabaseRebuildToolTest.java
+++ b/tools/src/test/java/org/neo4j/tools/applytx/DatabaseRebuildToolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/tools/src/test/java/org/neo4j/tools/dump/DumpCountsStoreTest.java
+++ b/tools/src/test/java/org/neo4j/tools/dump/DumpCountsStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/tools/src/test/java/org/neo4j/tools/dump/DumpStoreTest.java
+++ b/tools/src/test/java/org/neo4j/tools/dump/DumpStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/tools/src/test/java/org/neo4j/tools/dump/InconsistencyReportReaderTest.java
+++ b/tools/src/test/java/org/neo4j/tools/dump/InconsistencyReportReaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/tools/src/test/java/org/neo4j/tools/dump/TransactionLogAnalyzerTest.java
+++ b/tools/src/test/java/org/neo4j/tools/dump/TransactionLogAnalyzerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/tools/src/test/java/org/neo4j/tools/dump/log/TransactionLogEntryCursorTest.java
+++ b/tools/src/test/java/org/neo4j/tools/dump/log/TransactionLogEntryCursorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/tools/src/test/java/org/neo4j/tools/migration/StoreMigrationTest.java
+++ b/tools/src/test/java/org/neo4j/tools/migration/StoreMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/tools/src/test/java/org/neo4j/tools/rebuild/RebuildFromLogsTest.java
+++ b/tools/src/test/java/org/neo4j/tools/rebuild/RebuildFromLogsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/tools/src/test/java/org/neo4j/tools/txlog/CheckTxLogsTest.java
+++ b/tools/src/test/java/org/neo4j/tools/txlog/CheckTxLogsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/tools/src/test/java/org/neo4j/tools/txlog/checktypes/NeoStoreCheckTypeTest.java
+++ b/tools/src/test/java/org/neo4j/tools/txlog/checktypes/NeoStoreCheckTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/tools/src/test/java/org/neo4j/tools/txlog/checktypes/NodeCheckTypeTest.java
+++ b/tools/src/test/java/org/neo4j/tools/txlog/checktypes/NodeCheckTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/tools/src/test/java/org/neo4j/tools/txlog/checktypes/PropertyCheckTypeTest.java
+++ b/tools/src/test/java/org/neo4j/tools/txlog/checktypes/PropertyCheckTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/tools/src/test/java/org/neo4j/tools/txlog/checktypes/RelationshipCheckTypeTest.java
+++ b/tools/src/test/java/org/neo4j/tools/txlog/checktypes/RelationshipCheckTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source

--- a/tools/src/test/java/org/neo4j/tools/txlog/checktypes/RelationshipGroupCheckTypeTest.java
+++ b/tools/src/test/java/org/neo4j/tools/txlog/checktypes/RelationshipGroupCheckTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 "Graph Foundation,"
+ * Copyright (c) "Graph Foundation,"
  * Graph Foundation, Inc. [https://graphfoundation.org]
  *
  * This file is part of ONgDB Enterprise Edition. The included source


### PR DESCRIPTION
## Summary
- Merge `1.0-dev` into `1.0` after green CI on the rewritten tip.
- Include TLS IT expectations gated on JVM protocol capability (`SupportsTls`).
- Drop Graph Foundation copyright year ranges from CMI/headers/checkstyle so annual year bumps are not required.

## Test plan
- [x] `Java CI with Maven` / `build` succeeded on `1.0-dev` tip (`0344a60e289`)
- [ ] `full-reactor` required check green on this PR
- [ ] Merge to `1.0` once full-reactor passes